### PR TITLE
update the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,27 +6,21 @@ COPY go.mod go.sum ./
 
 RUN go mod download
 
+COPY *.go ./
 COPY api/ ./api/
 COPY auth/ ./auth/
-COPY web/ ./web/
-COPY store/ ./store/
-COPY cmd/ ./cmd/
-COPY json/ ./json/
-COPY directory/ ./directory/
 COPY bin/ ./bin/
-COPY *.go ./
-
-# Copy go files, but not toml files in this dir,
-# which may contain real credentials
-COPY conf/*.go ./conf/
+COPY cmd/ ./cmd/
+COPY conf/ ./conf/
+COPY directory/ ./directory/
+COPY json/ ./json/
+COPY store/ ./store/
+COPY web/ ./web/
 
 RUN bin/fetch_client_deps.sh
-
 RUN CGO_ENABLED=0 GOOS=linux go build -o /app/ranger-ims-go
 
-FROM gcr.io/distroless/static-debian12
-COPY --from=build /app /
-
+FROM alpine:3.21
+COPY --from=build /app/ranger-ims-go /
 EXPOSE 80
-
 CMD ["/ranger-ims-go", "serve"]


### PR DESCRIPTION
We can now safely copy all of the conf dir, since I dropped the toml file.

This also changes the second stage Docker base image from distroless to alpine. This takes our image size up from ~25MB to ~30MB, but we get things like a shell for that little increase, and that will be useful.