### PR TITLE
use MariaDB testcontainers module, bring back t.Parallel()

### DIFF
--- a/api/integration/auth_test.go
+++ b/api/integration/auth_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestPostAuthAPIAuthorization(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisNotAuthenticated := ApiHelper{t: t, serverURL: shared.serverURL, jwt: ""}
@@ -71,7 +71,7 @@ func TestPostAuthAPIAuthorization(t *testing.T) {
 }
 
 func TestGetAuthAPIAuthorization(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -111,7 +111,7 @@ func TestGetAuthAPIAuthorization(t *testing.T) {
 }
 
 func TestGetAuthWithEvent(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -153,7 +153,7 @@ func TestGetAuthWithEvent(t *testing.T) {
 }
 
 func TestPostAuthMakesRefreshCookie(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisNotAuthenticated := ApiHelper{t: t, serverURL: shared.serverURL, jwt: ""}

--- a/api/integration/event_test.go
+++ b/api/integration/event_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestEventAPIAuthorization(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -60,7 +60,7 @@ func TestEventAPIAuthorization(t *testing.T) {
 }
 
 func TestGetAndEditEvent(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -116,7 +116,7 @@ func TestGetAndEditEvent(t *testing.T) {
 }
 
 func TestEditEvent_errors(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}

--- a/api/integration/eventaccess_test.go
+++ b/api/integration/eventaccess_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestEventAccessAPIAuthorization(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}

--- a/api/integration/fieldreport_test.go
+++ b/api/integration/fieldreport_test.go
@@ -20,7 +20,7 @@ func sampleFieldReport1(eventName string) imsjson.FieldReport {
 }
 
 func TestCreateAndGetFieldReport(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -81,7 +81,7 @@ func TestCreateAndGetFieldReport(t *testing.T) {
 }
 
 func TestCreateAndUpdateFieldReport(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}

--- a/api/integration/incident_test.go
+++ b/api/integration/incident_test.go
@@ -48,7 +48,7 @@ func sampleIncident1(eventName string) imsjson.Incident {
 }
 
 func TestIncidentAPIAuthorization(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	adminUser := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -127,7 +127,7 @@ func TestIncidentAPIAuthorization(t *testing.T) {
 }
 
 func TestCreateAndGetIncident(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -188,7 +188,7 @@ func TestCreateAndGetIncident(t *testing.T) {
 }
 
 func TestCreateAndUpdateIncident(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}

--- a/api/integration/itype_test.go
+++ b/api/integration/itype_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestIncidentTypesAPIAuthorization(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
@@ -59,7 +59,7 @@ func TestIncidentTypesAPIAuthorization(t *testing.T) {
 }
 
 func TestCreateIncident(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 
 	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}

--- a/api/mux_test.go
+++ b/api/mux_test.go
@@ -65,7 +65,7 @@ func thirdAdapter(output *bytes.Buffer) api.Adapter {
 
 // TestAdapt demonstrates how the Adapter pattern works.
 func TestAdapt(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	b := bytes.Buffer{}
 	api.Adapt(
 		exampleAction{output: &b},

--- a/auth/jwt_test.go
+++ b/auth/jwt_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestCreateAndGetValidJWT(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	jwter := auth.JWTer{SecretKey: "some-secret"}
 	j, err := jwter.CreateAccessToken(
 		"Hardware",
@@ -47,7 +47,7 @@ func TestCreateAndGetValidJWT(t *testing.T) {
 }
 
 func TestCreateAndGetInvalidJWTs(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	jwter := auth.JWTer{SecretKey: "some-secret"}
 	expiredJWT, err := jwter.CreateAccessToken(
 		"Hardware",

--- a/auth/password/password_test.go
+++ b/auth/password/password_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestVerifyPassword_success(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	pw, s := "Hardware", "my_little_salty"
 	hashed := "ee9a23000af19a22acd0d9a22dfe9558580771dc"
 	assert.Equal(t, hashed, password.Hash(pw, s))
@@ -40,7 +40,7 @@ func TestVerifyPassword_success(t *testing.T) {
 }
 
 func TestVerifyPassword_badStoredValue(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	noColonInThisString := "abcdefg"
 	_, err := password.Verify("some_password", noColonInThisString)
 	require.Error(t, err)
@@ -48,7 +48,7 @@ func TestVerifyPassword_badStoredValue(t *testing.T) {
 }
 
 func TestNewSalted(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	pw := "this is my password"
 	saltedPw := password.NewSalted(pw)
 	isValid, err := password.Verify(pw, saltedPw)

--- a/auth/permission_test.go
+++ b/auth/permission_test.go
@@ -43,7 +43,7 @@ func addPerm(m map[int32][]imsdb.EventAccess, eventID int32, expr, mode, validit
 }
 
 func TestManyEventPermissions_personRules(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	accessByEvent := make(map[int32][]imsdb.EventAccess)
 	addPerm(accessByEvent, 999, "person:SomeoneElse", "read", "always")
 	addPerm(accessByEvent, 123, "person:EventReaderGuy", "read", "always")
@@ -99,7 +99,7 @@ func TestManyEventPermissions_personRules(t *testing.T) {
 }
 
 func TestManyEventPermissions_positionRules(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	accessByEvent := make(map[int32][]imsdb.EventAccess)
 	addPerm(accessByEvent, 123, "person:Running Ranger", "report", "always")
 	addPerm(accessByEvent, 123, "position:Runner", "read", "always")
@@ -120,7 +120,7 @@ func TestManyEventPermissions_positionRules(t *testing.T) {
 }
 
 func TestManyEventPermissions_teamRules(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	accessByEvent := make(map[int32][]imsdb.EventAccess)
 	addPerm(accessByEvent, 123, "position:Runner", "report", "always")
 	addPerm(accessByEvent, 123, "team:Running Squad", "read", "always")
@@ -141,7 +141,7 @@ func TestManyEventPermissions_teamRules(t *testing.T) {
 }
 
 func TestManyEventPermissions_wildcardValidity(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	accessByEvent := make(map[int32][]imsdb.EventAccess)
 	addPerm(accessByEvent, 123, "*", "report", "onsite")
 

--- a/conf/imsconfig_test.go
+++ b/conf/imsconfig_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestPrintRedacted(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	cfg := conf.IMSConfig{
 		Core: conf.ConfigCore{
 			Admins: []string{"admin user"},

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/a-h/templ v0.3.865
 	github.com/go-sql-driver/mysql v1.9.2
 	github.com/golang-jwt/jwt/v5 v5.2.2
+	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
 	github.com/launchdarkly/eventsource v1.9.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
+	github.com/testcontainers/testcontainers-go/modules/mariadb v0.37.0
 )
 
 require (
@@ -44,7 +46,6 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/cel-go v0.25.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/testcontainers/testcontainers-go v0.37.0 h1:L2Qc0vkTw2EHWQ08djon0D2uw7Z/PtHS/QzZZ5Ra/hg=
 github.com/testcontainers/testcontainers-go v0.37.0/go.mod h1:QPzbxZhQ6Bclip9igjLFj6z0hs01bU8lrl2dHQmgFGM=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.37.0 h1:iNWRJsWL8N5fksLvaxtP5pM1BHMxhoUnBHtlVe9K9JY=
+github.com/testcontainers/testcontainers-go/modules/mariadb v0.37.0/go.mod h1:jizTV2XERWcvtLW4xk0HCrCQxsBWqupyDjZ9ttXM4lk=
 github.com/tetratelabs/wazero v1.9.0 h1:IcZ56OuxrtaEz8UYNRHBrUa9bYeX9oVY93KspZZBf/I=
 github.com/tetratelabs/wazero v1.9.0/go.mod h1:TSbcXCfFP0L2FGkRPxHphadXPjo1T6W+CseNNY7EkjM=
 github.com/tklauser/go-sysconf v0.3.15 h1:VE89k0criAymJ/Os65CSn1IXaol+1wrsFHEB8Ol49K4=

--- a/web/mux_test.go
+++ b/web/mux_test.go
@@ -45,7 +45,7 @@ var templEndpoints = []string{
 // TestTemplEndpoints tests that the IMS server can render all the
 // HTML pages and serve them at the correct paths.
 func TestTemplEndpoints(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 	cfg := conf.DefaultIMS()
 	s := httptest.NewServer(web.AddToMux(nil, cfg))
@@ -70,7 +70,7 @@ func TestTemplEndpoints(t *testing.T) {
 }
 
 func TestCatchall(t *testing.T) {
-	// t.Parallel()
+	t.Parallel()
 	ctx := t.Context()
 	cfg := conf.DefaultIMS()
 	s := httptest.NewServer(web.AddToMux(nil, cfg))


### PR DESCRIPTION
I now suspect the reason I was getting CI errors was that my container startup code wasn't waiting for the right condition. The MariaDB testcontainers module waits for a better condition, so I think this might do the trick.