### PR TITLE
use better `go test` command in cicd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,13 +21,17 @@ jobs:
       with:
         egress-policy: block
         allowed-endpoints: >
+          *.codecov.io:443
           *.docker.com:443
           *.docker.io:443
+          *.ingest.us.sentry.io:443
           api.github.com:443
           cdn.datatables.net:443
           cdn.jsdelivr.net:443
           code.jquery.com:443
+          codecov.io:443
           github.com:443
+          keybase.io:443
           objects.githubusercontent.com:443
           proxy.golang.org:443
           storage.googleapis.com:443
@@ -50,8 +54,5 @@ jobs:
     #  do these on the developer's computer, and this can be
     #  enforced by pre-commit.
 
-    - name: Build
-      run: go build -v ./...
-
-    - name: Test
-      run: go test -v ./...
+    - name: Compile, test, and generate coverage
+      run: go test -race -covermode=atomic -coverprofile=coverage.out --coverpkg ./... ./...

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ docker build --tag ranger-ims-go .
 docker run --env-file .env -it -p 80:8080 ranger-ims-go:latest
 ```
 
+## Upgrade Go dependencies
+
+Upgrade the Go toolchain by setting the value in `go.mod`.
+
+Upgrade all Go dependencies by running:
+
+```shell
+# Upgrade all normal and test dependencies
+go get -t -u ./...
+
+# Tidy up go.mod and go.sum
+go mod tidy
+```
+
 ## Differences between the Go and Python IMS servers
 
 1. We didn't bring over support for a SQLite IMS database, so MariaDB is the only option currently.


### PR DESCRIPTION
the `go build` was pointless, because `go test` also compiles named targets, even those without test files