### PR TITLE
update some code to correct coverage a bit

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -57,12 +57,12 @@ func runServer(cmd *cobra.Command, args []string) {
 	must(logLevel.UnmarshalText([]byte(imsCfg.Core.LogLevel)))
 	slog.SetLogLoggerLevel(logLevel)
 
-	cfgStr, err := imsCfg.PrintRedacted()
-	must(err)
+	cfgStr := imsCfg.PrintRedacted()
 	log.Printf("Here's the final redacted IMSConfig:\n\n%v\n\n", cfgStr)
 
 	log.Printf("With JWTSecret: %v...%v", imsCfg.Core.JWTSecret[:1], imsCfg.Core.JWTSecret[len(imsCfg.Core.JWTSecret)-1:])
 
+	var err error
 	var userStore *directory.UserStore
 	switch imsCfg.Directory.Directory {
 	case conf.DirectoryTypeClubhouseDB:

--- a/codecov.yml
+++ b/codecov.yml
@@ -13,3 +13,13 @@ coverage:
       default:
         informational: false
         target: 100%
+
+ignore:
+  # These are glorified shell scripts in the form of Go programs (for cross-platform use),
+  # and they are separate from the server program.
+  - "bin/build"
+  # This is generated code from templ.
+  - "web/template/*.go"
+  # These are generated code from sqlc.
+  - "store/imsdb/*.go"
+  - "directory/clubhousedb/*.go"

--- a/conf/.gitignore
+++ b/conf/.gitignore
@@ -1,1 +1,0 @@
-testusers.go

--- a/conf/README.md
+++ b/conf/README.md
@@ -21,9 +21,8 @@ cp .env-example .env
 ## TestUsers
 
 When working locally, you might want to configure a simple set of IMS users,
-so you don't need a full Clubhouse DB. To do this, copy `conf/testusers.example.go`
-to `conf/testusers.go` (that'll make it actually load as the server starts).
-In that file, you'll configure the dummy users you want for your Directory.
+so you don't need a full Clubhouse DB. To do this, configure those users
+in `conf/testusers.go`.
 
 After that, you just need to toggle on the TestUsers feature in your `.env`:
 

--- a/conf/imsconfig_test.go
+++ b/conf/imsconfig_test.go
@@ -2,7 +2,7 @@ package conf_test
 
 import (
 	"github.com/burningmantech/ranger-ims-go/conf"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
@@ -31,12 +31,11 @@ func TestPrintRedacted(t *testing.T) {
 		},
 	}
 
-	s, err := cfg.PrintRedacted()
-	require.NoError(t, err)
-	require.Contains(t, s, "admin user")
-	require.Contains(t, s, "db username")
-	require.NotContains(t, s, "db password")
-	require.NotContains(t, s, "user password")
-	require.Contains(t, s, "clubhouse username")
-	require.NotContains(t, s, "clubhouse password")
+	redacted := cfg.PrintRedacted()
+	assert.Contains(t, redacted, "admin user")
+	assert.Contains(t, redacted, "db username")
+	assert.NotContains(t, redacted, "db password")
+	assert.NotContains(t, redacted, "user password")
+	assert.Contains(t, redacted, "clubhouse username")
+	assert.NotContains(t, redacted, "clubhouse password")
 }

--- a/conf/testusers.go
+++ b/conf/testusers.go
@@ -18,17 +18,11 @@ package conf
 
 import (
 	"github.com/burningmantech/ranger-ims-go/lib/authn"
-	"runtime"
-	"strings"
 )
 
-func init() {
-	_, filename, _, _ := runtime.Caller(0)
-	if strings.Contains(filename, ".example") {
-		return
-	}
-	defaultTestUsers = append(defaultTestUsers,
-		TestUser{
+func testusers() []TestUser {
+	return []TestUser{
+		{
 			Handle:      "Hardware",
 			Email:       "hardware@rangers.brc",
 			Status:      "active",
@@ -38,7 +32,7 @@ func init() {
 			Positions:   []string{"Driver", "Dancer"},
 			Teams:       []string{"Driving Team"},
 		},
-		TestUser{
+		{
 			Handle:      "Parenthetical",
 			Email:       "parenthetical@rangers.brc",
 			Status:      "active",
@@ -48,7 +42,7 @@ func init() {
 			Positions:   nil,
 			Teams:       nil,
 		},
-		TestUser{
+		{
 			Handle:      "Defect",
 			Email:       "defect@rangers.brc",
 			Status:      "active",
@@ -58,7 +52,7 @@ func init() {
 			Positions:   []string{},
 			Teams:       []string{},
 		},
-		TestUser{
+		{
 			Handle:      "Irate",
 			Email:       "irate@rangers.brc",
 			Status:      "active",
@@ -68,7 +62,7 @@ func init() {
 			Positions:   []string{},
 			Teams:       []string{},
 		},
-		TestUser{
+		{
 			Handle:      "Loosy",
 			Email:       "loosy@rangers.brc",
 			Status:      "active",
@@ -78,5 +72,5 @@ func init() {
 			Positions:   []string{},
 			Teams:       []string{},
 		},
-	)
+	}
 }

--- a/lib/redact/redact_test.go
+++ b/lib/redact/redact_test.go
@@ -2,7 +2,7 @@ package redact_test
 
 import (
 	"github.com/burningmantech/ranger-ims-go/lib/redact"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
 )
@@ -45,21 +45,28 @@ Secret
 Secrets[0]
     🤐🤐
 Secrets[1]
-    🤐🤐`
-	b, err := redact.ToBytes(&e)
-	require.NoError(t, err)
-	require.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(b)))
+    🤐🤐
+`
+	b := redact.ToBytes(&e)
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(b)))
 }
 
 type ExampleType2 struct {
+	SSN   string `redact:"true"`
 	MyMap map[string]string
 }
 
 func TestToBytes_noMapSupport(t *testing.T) {
 	t.Parallel()
 	// we haven't bothered adding support for various Kinds yet, but feel free to do so if the need arises!
-	e := ExampleType2{}
-	_, err := redact.ToBytes(&e)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "unsupported field kind: map")
+	e := ExampleType2{
+		SSN:   "someKey",
+		MyMap: map[string]string{"dog": "pony"},
+	}
+	expected := `
+SSN = 🤐🤐🤐
+MyMap [Unsupported field kind (map)]
+`
+	b := redact.ToBytes(&e)
+	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(b)))
 }


### PR DESCRIPTION
* exclude some generated and scripting code from coverage
* clean up redact.go to get rid of a lot of impossible error cases (bytes.Buffer.Write cannot actually error...it just has error returns to fit the Writer interface)