### PR TITLE
get new Incident number as part of INSERT statement

### DIFF
--- a/api/incident.go
+++ b/api/incident.go
@@ -320,23 +320,18 @@ func (action NewIncident) newIncident(req *http.Request) (incidentNumber int32, 
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	// First create the incident, to lock in the incident number reservation
-	newIncidentNumber, err := action.imsDBQ.NextIncidentNumber(ctx, action.imsDBQ, event.ID)
-	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to find next Incident number", err).From("[NextIncidentNumber]")
-	}
 	newIncident.EventID = event.ID
 	newIncident.Event = event.Name
-	newIncident.Number = newIncidentNumber
 
-	createTheIncident := imsdb.CreateIncidentParams{
+	// Create the incident to lock in a number for it
+	createTheIncident := store.CreateIncidentParams{
 		Event:    newIncident.EventID,
-		Number:   newIncident.Number,
 		Created:  float64(time.Now().Unix()),
 		Priority: imsjson.IncidentPriorityNormal,
 		State:    imsdb.IncidentStateNew,
 	}
-	_, err = action.imsDBQ.CreateIncident(ctx, action.imsDBQ, createTheIncident)
+	var err error
+	newIncident.Number, err = action.imsDBQ.CreateIncident(ctx, action.imsDBQ, createTheIncident)
 	if err != nil {
 		return 0, "", herr.InternalServerError("Failed to create incident", err).From("[CreateIncident]")
 	}

--- a/store/extraqueries.go
+++ b/store/extraqueries.go
@@ -1,0 +1,83 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package store
+
+import (
+	"context"
+	"database/sql"
+	"github.com/burningmantech/ranger-ims-go/store/imsdb"
+)
+
+const createIncident = `-- name: CreateIncident :one
+insert into INCIDENT(EVENT, NUMBER, STATE, CREATED, PRIORITY)
+values (?, (select ifnull(max(inc.NUMBER),0) + 1 as NEXT_ID
+            from INCIDENT inc
+            where inc.EVENT = ?),
+        ?, ?, ?)
+returning (NUMBER)
+`
+
+type CreateIncidentParams struct {
+	Event    int32
+	State    imsdb.IncidentState
+	Created  float64
+	Priority int8
+}
+
+func (l DBQ) CreateIncident(ctx context.Context, db imsdb.DBTX, arg CreateIncidentParams) (int32, error) {
+	row := db.QueryRowContext(ctx, createIncident,
+		arg.Event,
+		arg.Event,
+		arg.State,
+		arg.Created,
+		arg.Priority,
+	)
+	var incidentNumber int32
+	err := row.Scan(&incidentNumber)
+	return incidentNumber, err
+}
+
+const createFieldReport = `-- name: CreateFieldReport :one
+insert into FIELD_REPORT (
+    EVENT, NUMBER, CREATED, SUMMARY, INCIDENT_NUMBER
+)
+values (?, (select ifnull(max(fr.NUMBER),0) + 1 as NEXT_ID
+            from FIELD_REPORT fr
+            where fr.EVENT = ?),
+        ?, ?, ?)
+returning (NUMBER)
+`
+
+type CreateFieldReportParams struct {
+	Event          int32
+	Created        float64
+	Summary        sql.NullString
+	IncidentNumber sql.NullInt32
+}
+
+func (l DBQ) CreateFieldReport(ctx context.Context, db imsdb.DBTX, arg CreateFieldReportParams) (int32, error) {
+	row := db.QueryRowContext(ctx, createFieldReport,
+		arg.Event,
+		arg.Event,
+		arg.Created,
+		arg.Summary,
+		arg.IncidentNumber,
+	)
+	var fieldReportNumber int32
+	err := row.Scan(&fieldReportNumber)
+	return fieldReportNumber, err
+}

--- a/store/imsdb/querier.go
+++ b/store/imsdb/querier.go
@@ -21,8 +21,6 @@ type Querier interface {
 	ConcentricStreets(ctx context.Context, db DBTX, event int32) ([]ConcentricStreetsRow, error)
 	CreateConcentricStreet(ctx context.Context, db DBTX, arg CreateConcentricStreetParams) error
 	CreateEvent(ctx context.Context, db DBTX, name string) (int64, error)
-	CreateFieldReport(ctx context.Context, db DBTX, arg CreateFieldReportParams) error
-	CreateIncident(ctx context.Context, db DBTX, arg CreateIncidentParams) (int64, error)
 	CreateIncidentTypeOrIgnore(ctx context.Context, db DBTX, arg CreateIncidentTypeOrIgnoreParams) error
 	CreateReportEntry(ctx context.Context, db DBTX, arg CreateReportEntryParams) (int64, error)
 	DetachIncidentTypeFromIncident(ctx context.Context, db DBTX, arg DetachIncidentTypeFromIncidentParams) error
@@ -41,10 +39,6 @@ type Querier interface {
 	Incident_ReportEntries(ctx context.Context, db DBTX, arg Incident_ReportEntriesParams) ([]Incident_ReportEntriesRow, error)
 	Incidents(ctx context.Context, db DBTX, event int32) ([]IncidentsRow, error)
 	Incidents_ReportEntries(ctx context.Context, db DBTX, arg Incidents_ReportEntriesParams) ([]Incidents_ReportEntriesRow, error)
-	// This doesn't use "MAX" because sqlc can't figure out the type for aggregations :(.
-	NextFieldReportNumber(ctx context.Context, db DBTX, event int32) (int32, error)
-	// This doesn't use "MAX" because sqlc can't figure out the type for aggregations :(.
-	NextIncidentNumber(ctx context.Context, db DBTX, event int32) (int32, error)
 	QueryEventID(ctx context.Context, db DBTX, name string) (QueryEventIDRow, error)
 	SchemaVersion(ctx context.Context, db DBTX) (int16, error)
 	SetFieldReportReportEntryStricken(ctx context.Context, db DBTX, arg SetFieldReportReportEntryStrickenParams) error

--- a/store/imsdb/queries.sql.go
+++ b/store/imsdb/queries.sql.go
@@ -251,67 +251,6 @@ func (q *Queries) CreateEvent(ctx context.Context, db DBTX, name string) (int64,
 	return result.LastInsertId()
 }
 
-const createFieldReport = `-- name: CreateFieldReport :exec
-insert into FIELD_REPORT (
-    EVENT, NUMBER, CREATED, SUMMARY, INCIDENT_NUMBER
-)
-values (?, ?, ?, ?, ?)
-`
-
-type CreateFieldReportParams struct {
-	Event          int32
-	Number         int32
-	Created        float64
-	Summary        sql.NullString
-	IncidentNumber sql.NullInt32
-}
-
-func (q *Queries) CreateFieldReport(ctx context.Context, db DBTX, arg CreateFieldReportParams) error {
-	_, err := db.ExecContext(ctx, createFieldReport,
-		arg.Event,
-		arg.Number,
-		arg.Created,
-		arg.Summary,
-		arg.IncidentNumber,
-	)
-	return err
-}
-
-const createIncident = `-- name: CreateIncident :execlastid
-insert into INCIDENT (
-    EVENT,
-    NUMBER,
-    CREATED,
-    PRIORITY,
-    STATE
-)
-values (
-   ?,?,?,?,?
-)
-`
-
-type CreateIncidentParams struct {
-	Event    int32
-	Number   int32
-	Created  float64
-	Priority int8
-	State    IncidentState
-}
-
-func (q *Queries) CreateIncident(ctx context.Context, db DBTX, arg CreateIncidentParams) (int64, error) {
-	result, err := db.ExecContext(ctx, createIncident,
-		arg.Event,
-		arg.Number,
-		arg.Created,
-		arg.Priority,
-		arg.State,
-	)
-	if err != nil {
-		return 0, err
-	}
-	return result.LastInsertId()
-}
-
 const createIncidentTypeOrIgnore = `-- name: CreateIncidentTypeOrIgnore :exec
 insert into INCIDENT_TYPE (NAME, HIDDEN)
 values (?, ?)
@@ -1002,42 +941,6 @@ func (q *Queries) Incidents_ReportEntries(ctx context.Context, db DBTX, arg Inci
 		return nil, err
 	}
 	return items, nil
-}
-
-const nextFieldReportNumber = `-- name: NextFieldReportNumber :one
-select NUMBER + 1 as NEXT_ID
-from FIELD_REPORT
-where EVENT = ?
-union
-select 1
-order by 1 desc
-limit 1
-`
-
-// This doesn't use "MAX" because sqlc can't figure out the type for aggregations :(.
-func (q *Queries) NextFieldReportNumber(ctx context.Context, db DBTX, event int32) (int32, error) {
-	row := db.QueryRowContext(ctx, nextFieldReportNumber, event)
-	var next_id int32
-	err := row.Scan(&next_id)
-	return next_id, err
-}
-
-const nextIncidentNumber = `-- name: NextIncidentNumber :one
-select NUMBER + 1 as NEXT_ID
-from INCIDENT
-where EVENT = ?
-union
-select 1
-order by 1 desc
-limit 1
-`
-
-// This doesn't use "MAX" because sqlc can't figure out the type for aggregations :(.
-func (q *Queries) NextIncidentNumber(ctx context.Context, db DBTX, event int32) (int32, error) {
-	row := db.QueryRowContext(ctx, nextIncidentNumber, event)
-	var next_id int32
-	err := row.Scan(&next_id)
-	return next_id, err
 }
 
 const queryEventID = `-- name: QueryEventID :one

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -32,18 +32,6 @@ where EVENT = ? and EXPRESSION = ?;
 insert into EVENT_ACCESS (EVENT, EXPRESSION, MODE, VALIDITY)
 values (?, ?, ?, ?);
 
--- name: CreateIncident :execlastid
-insert into INCIDENT (
-    EVENT,
-    NUMBER,
-    CREATED,
-    PRIORITY,
-    STATE
-)
-values (
-   ?,?,?,?,?
-);
-
 -- name: UpdateIncident :exec
 update INCIDENT set
     CREATED = ?,
@@ -193,32 +181,6 @@ update FIELD_REPORT
 set INCIDENT_NUMBER = ?
 where EVENT = ? and NUMBER = ?
 ;
-
--- This doesn't use "MAX" because sqlc can't figure out the type for aggregations :(.
--- name: NextFieldReportNumber :one
-select NUMBER + 1 as NEXT_ID
-from FIELD_REPORT
-where EVENT = ?
-union
-select 1
-order by 1 desc
-limit 1;
-
--- This doesn't use "MAX" because sqlc can't figure out the type for aggregations :(.
--- name: NextIncidentNumber :one
-select NUMBER + 1 as NEXT_ID
-from INCIDENT
-where EVENT = ?
-union
-select 1
-order by 1 desc
-limit 1;
-
--- name: CreateFieldReport :exec
-insert into FIELD_REPORT (
-    EVENT, NUMBER, CREATED, SUMMARY, INCIDENT_NUMBER
-)
-values (?, ?, ?, ?, ?);
 
 -- name: DetachedFieldReportNumbers :many
 select NUMBER from FIELD_REPORT


### PR DESCRIPTION
...same for Field Report number

previously we were doing a two-step thing, in which we first queried to find the max number for a given event, then we second did an insert using that max number + 1. Now I'm doing it all in one insert statement. The only caveat is that I had to go outside sqlc to make this work, but it's good to see how simple it can be to do that.