### PR TITLE
clean up the JWT

### DIFF
--- a/lib/authz/accesstoken.go
+++ b/lib/authz/accesstoken.go
@@ -36,10 +36,10 @@ func (j JWTer) CreateAccessToken(
 	expiration time.Time,
 ) (string, error) {
 	return j.createJWT(
-		NewIMSClaims().
+		IMSClaims{}.
 			WithIssuedAt(time.Now()).
 			WithExpiration(expiration).
-			WithIssuer("ranger-ims-go").
+			WithIssuer("ims").
 			WithRangerHandle(rangerName).
 			WithRangerOnSite(onsite).
 			WithRangerPositions(positions...).

--- a/lib/authz/claim.go
+++ b/lib/authz/claim.go
@@ -19,83 +19,71 @@ package authz
 import (
 	"github.com/burningmantech/ranger-ims-go/lib/conv"
 	"github.com/golang-jwt/jwt/v5"
-	"strings"
 	"time"
 )
 
-const (
-	handleKey    = "handle"
-	onsiteKey    = "onsite"
-	positionsKey = "positions"
-	teamsKey     = "teams"
-)
-
 type IMSClaims struct {
-	jwt.MapClaims
-}
-
-func NewIMSClaims() IMSClaims {
-	return IMSClaims{MapClaims: make(jwt.MapClaims)}
+	jwt.RegisteredClaims
+	Handle    string   `json:"han"`
+	Onsite    bool     `json:"ons"`
+	Positions []string `json:"pos"`
+	Teams     []string `json:"tea"`
 }
 
 func (c IMSClaims) WithExpiration(t time.Time) IMSClaims {
-	c.MapClaims["exp"] = t.Unix()
+	c.ExpiresAt = jwt.NewNumericDate(t)
 	return c
 }
 
 func (c IMSClaims) WithIssuedAt(t time.Time) IMSClaims {
-	c.MapClaims["iat"] = t.Unix()
+	c.IssuedAt = jwt.NewNumericDate(t)
 	return c
 }
 
 func (c IMSClaims) WithIssuer(s string) IMSClaims {
-	c.MapClaims["iss"] = s
+	c.Issuer = s
 	return c
 }
 
 func (c IMSClaims) WithSubject(s string) IMSClaims {
-	c.MapClaims["sub"] = s
+	c.Subject = s
 	return c
 }
 
 func (c IMSClaims) WithRangerHandle(s string) IMSClaims {
-	c.MapClaims[handleKey] = s
+	c.Handle = s
 	return c
 }
 
 func (c IMSClaims) WithRangerOnSite(onsite bool) IMSClaims {
-	c.MapClaims[onsiteKey] = onsite
+	c.Onsite = onsite
 	return c
 }
 
 func (c IMSClaims) WithRangerPositions(pos ...string) IMSClaims {
-	c.MapClaims[positionsKey] = strings.Join(pos, ",")
+	c.Positions = pos
 	return c
 }
 
 func (c IMSClaims) WithRangerTeams(teams ...string) IMSClaims {
-	c.MapClaims[teamsKey] = strings.Join(teams, ",")
+	c.Teams = teams
 	return c
 }
 
 func (c IMSClaims) RangerHandle() string {
-	rh, _ := c.MapClaims[handleKey].(string)
-	return rh
+	return c.Handle
 }
 
 func (c IMSClaims) RangerOnSite() bool {
-	onsite, _ := c.MapClaims[onsiteKey].(bool)
-	return onsite
+	return c.Onsite
 }
 
 func (c IMSClaims) RangerPositions() []string {
-	positions, _ := c.MapClaims[positionsKey].(string)
-	return strings.Split(positions, ",")
+	return c.Positions
 }
 
 func (c IMSClaims) RangerTeams() []string {
-	teams, _ := c.MapClaims[teamsKey].(string)
-	return strings.Split(teams, ",")
+	return c.Teams
 }
 
 // DirectoryID returns the Clubhouse ID for a Ranger.

--- a/lib/authz/jwt_test.go
+++ b/lib/authz/jwt_test.go
@@ -58,7 +58,7 @@ func TestCreateAndGetInvalidJWTs(t *testing.T) {
 		time.Now().Add(-1*time.Hour),
 	)
 	require.NoError(t, err)
-	differentKeyJWT, err := authz.JWTer{"some-other-secret"}.CreateAccessToken(
+	differentKeyJWT, err := authz.JWTer{SecretKey: "some-other-secret"}.CreateAccessToken(
 		"Hardware",
 		1,
 		nil,

--- a/lib/authz/refreshtoken.go
+++ b/lib/authz/refreshtoken.go
@@ -36,10 +36,10 @@ const RefreshTokenCookieName = "refresh_token"
 // we instead rely on the security of JWT signing.
 func (j JWTer) CreateRefreshToken(rangerName string, clubhouseID int64, expiration time.Time) (string, error) {
 	return j.createJWT(
-		NewIMSClaims().
+		IMSClaims{}.
 			WithIssuedAt(time.Now()).
 			WithExpiration(expiration).
-			WithIssuer("ranger-ims-go").
+			WithIssuer("ims").
 			WithRangerHandle(rangerName).
 			WithSubject(strconv.FormatInt(clubhouseID, 10)),
 	)


### PR DESCRIPTION
previously the JSON getting signed had a top-level "MapClaims". That was ugly, even though it worked fine.

```json
{
  "MapClaims": {
    "exp": 1747527746,
    "handle": "Hardware",
    "iat": 1747526846,
    "iss": "ranger-ims-go",
    "onsite": true,
    "positions": "Driver,Dancer",
    "sub": "10101",
    "teams": "Driving Team"
  }
}
```

Here's what this PR does instead, and the resulting code is cleaner too. I shortened a few strings in here, because JWTs are supposed to be as compact as possible. As a next step, I'd like to switch over to having position and team ID numbers rather than names. https://github.com/burningmantech/ranger-ims-go/issues/119

```json
{
  "iss": "ims",
  "sub": "10101",
  "exp": 1747527367,
  "iat": 1747526467,
  "han": "Hardware",
  "ons": true,
  "pos": [
    "Driver",
    "Dancer"
  ],
  "tea": [
    "Driving Team"
  ]
}
```