### PR TITLE
add air temp dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ node_modules
 
 # the default dir for storing attachments
 ims-attachments
+
+# the temp dir for `go tool air`
+air_tmp

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ run/live:
 		--build.include_ext "go,tpl,tmpl,templ,html,css,scss,js,ts,sql,jpeg,jpg,gif,png,bmp,svg,webp,ico,env" \
 		--build.exclude_file "web/template/*_templ.go,web/static/*.js,store/imsdb/*.go,directory/clubhousedb/*.go" \
 		--build.exclude_dir "playwright" \
-		--misc.clean_on_exit "true"
+		--misc.clean_on_exit "true" --tmp_dir=air_tmp
 
 ## update: update all deps
 .PHONY: update


### PR DESCRIPTION
air makes a temp dir when you're running `make run/live`, and we don't want that checked in