### PR TITLE
set a global limit on request sizes

### DIFF
--- a/api/attachment.go
+++ b/api/attachment.go
@@ -220,7 +220,7 @@ func (action AttachToIncident) ServeHTTP(w http.ResponseWriter, req *http.Reques
 		return
 	}
 	slog.Info("Saved Incident attachment")
-	w.Header().Set("IMS-Report-Entry-Number", conv.FormatInt32(reID))
+	w.Header().Set("IMS-Report-Entry-Number", conv.FormatInt(reID))
 	http.Error(w, "Saved Incident attachment", http.StatusNoContent)
 }
 
@@ -242,6 +242,10 @@ func (action AttachToIncident) attachToIncident(req *http.Request) (int32, *herr
 	// this must match the key sent by the client
 	fi, fiHead, err := req.FormFile(IMSAttachmentFormKey)
 	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			return 0, herr.RequestEntityTooLarge(fmt.Sprintf("The supplied file is above the server limit of %v", format.HumanByteSize(mbe.Limit)), err)
+		}
 		return 0, herr.BadRequest("Failed to parse file", err)
 	}
 	defer shut(fi)
@@ -311,7 +315,7 @@ func (action AttachToFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Req
 		return
 	}
 	slog.Info("Saved Field Report attachment")
-	w.Header().Set("IMS-Report-Entry-Number", conv.FormatInt32(reID))
+	w.Header().Set("IMS-Report-Entry-Number", conv.FormatInt(reID))
 	http.Error(w, "Saved Field Report attachment", http.StatusNoContent)
 }
 func (action AttachToFieldReport) attachToFieldReport(req *http.Request) (int32, *herr.HTTPError) {
@@ -344,6 +348,10 @@ func (action AttachToFieldReport) attachToFieldReport(req *http.Request) (int32,
 	// this must match the key sent by the client
 	fi, fiHead, err := req.FormFile(IMSAttachmentFormKey)
 	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			return 0, herr.RequestEntityTooLarge(fmt.Sprintf("The supplied file is above the server limit of %v", format.HumanByteSize(mbe.Limit)), err)
+		}
 		return 0, herr.BadRequest("Failed to parse file", err)
 	}
 	defer shut(fi)

--- a/api/integration/fieldreport_test.go
+++ b/api/integration/fieldreport_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/burningmantech/ranger-ims-go/lib/rand"
 	"github.com/stretchr/testify/require"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -257,6 +258,12 @@ func TestCreateAndAttachFileToFieldReport(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, fileBytes, returnedAttachment)
+
+	// Try to send something too large
+	fileBytes = []byte(strings.Repeat("a", int(shared.cfg.Core.MaxRequestBytes+1)))
+	_, resp = apisNonAdmin.attachFileToFieldReport(ctx, eventName, num, fileBytes)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
 }
 
 // requireEqualIncident is a hacky way of checking two incident responses are the same.

--- a/api/integration/helpers_test.go
+++ b/api/integration/helpers_test.go
@@ -158,16 +158,16 @@ func (a ApiHelper) getFieldReports(ctx context.Context, eventName string) (imsjs
 
 func (a ApiHelper) updateFieldReport(ctx context.Context, eventName string, fieldReport int32, req imsjson.FieldReport) *http.Response {
 	a.t.Helper()
-	return a.imsPost(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/field_reports/", conv.FormatInt32(fieldReport)).String())
+	return a.imsPost(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/field_reports/", conv.FormatInt(fieldReport)).String())
 }
 
 func (a ApiHelper) attachFieldReportToIncident(ctx context.Context, eventName string, fieldReport int32, incident int32) *http.Response {
 	a.t.Helper()
 	req := imsjson.FieldReport{}
-	params := "?action=attach&incident=" + conv.FormatInt32(incident)
+	params := "?action=attach&incident=" + conv.FormatInt(incident)
 	return a.imsPost(ctx, req,
 		a.serverURL.JoinPath("/ims/api/events/", eventName, "/field_reports/",
-			conv.FormatInt32(fieldReport)).String()+params)
+			conv.FormatInt(fieldReport)).String()+params)
 }
 
 func (a ApiHelper) detachFieldReportFromIncident(ctx context.Context, eventName string, fieldReport int32) *http.Response {
@@ -176,7 +176,7 @@ func (a ApiHelper) detachFieldReportFromIncident(ctx context.Context, eventName 
 	params := "?action=detach"
 	return a.imsPost(ctx, req,
 		a.serverURL.JoinPath("/ims/api/events/", eventName, "/field_reports/",
-			conv.FormatInt32(fieldReport)).String()+params)
+			conv.FormatInt(fieldReport)).String()+params)
 }
 
 func (a ApiHelper) newIncident(ctx context.Context, req imsjson.Incident) *http.Response {
@@ -265,7 +265,7 @@ func (a ApiHelper) getAccess(ctx context.Context) (imsjson.EventsAccess, *http.R
 func (a ApiHelper) attachFileToIncident(ctx context.Context, eventName string, incident int32, fileBytes []byte) (int32, *http.Response) {
 	a.t.Helper()
 
-	path := a.serverURL.JoinPath("/ims/api/events", eventName, "incidents", conv.FormatInt32(incident), "attachments")
+	path := a.serverURL.JoinPath("/ims/api/events", eventName, "incidents", conv.FormatInt(incident), "attachments")
 
 	// Create a `multipart/form-data`-encoded request, with a single form file inside
 	var requestBody bytes.Buffer
@@ -288,22 +288,21 @@ func (a ApiHelper) attachFileToIncident(ctx context.Context, eventName string, i
 	resp, err := client.Do(httpPost)
 	require.NoError(a.t, err)
 
-	reID, err := conv.ParseInt32(resp.Header.Get("IMS-Report-Entry-Number"))
-	require.NoError(a.t, err)
+	reID, _ := conv.ParseInt32(resp.Header.Get("IMS-Report-Entry-Number"))
 
 	return reID, resp
 }
 
 func (a ApiHelper) getIncidentAttachment(ctx context.Context, eventName string, incident, reID int32) ([]byte, *http.Response) {
 	a.t.Helper()
-	path := a.serverURL.JoinPath("/ims/api/events", eventName, "incidents", conv.FormatInt32(incident), "attachments", conv.FormatInt32(reID)).String()
+	path := a.serverURL.JoinPath("/ims/api/events", eventName, "incidents", conv.FormatInt(incident), "attachments", conv.FormatInt(reID)).String()
 	return a.imsGetBodyBytes(ctx, path)
 }
 
 func (a ApiHelper) attachFileToFieldReport(ctx context.Context, eventName string, fieldReport int32, fileBytes []byte) (int32, *http.Response) {
 	a.t.Helper()
 
-	path := a.serverURL.JoinPath("/ims/api/events", eventName, "field_reports", conv.FormatInt32(fieldReport), "attachments")
+	path := a.serverURL.JoinPath("/ims/api/events", eventName, "field_reports", conv.FormatInt(fieldReport), "attachments")
 
 	// Create a `multipart/form-data`-encoded request, with a single form file inside
 	var requestBody bytes.Buffer
@@ -326,15 +325,14 @@ func (a ApiHelper) attachFileToFieldReport(ctx context.Context, eventName string
 	resp, err := client.Do(httpPost)
 	require.NoError(a.t, err)
 
-	reID, err := conv.ParseInt32(resp.Header.Get("IMS-Report-Entry-Number"))
-	require.NoError(a.t, err)
+	reID, _ := conv.ParseInt32(resp.Header.Get("IMS-Report-Entry-Number"))
 
 	return reID, resp
 }
 
 func (a ApiHelper) getFieldReportAttachment(ctx context.Context, eventName string, fieldReport, reID int32) ([]byte, *http.Response) {
 	a.t.Helper()
-	path := a.serverURL.JoinPath("/ims/api/events", eventName, "field_reports", conv.FormatInt32(fieldReport), "attachments", conv.FormatInt32(reID)).String()
+	path := a.serverURL.JoinPath("/ims/api/events", eventName, "field_reports", conv.FormatInt(fieldReport), "attachments", conv.FormatInt(reID)).String()
 	return a.imsGetBodyBytes(ctx, path)
 }
 

--- a/api/integration/incident_test.go
+++ b/api/integration/incident_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/burningmantech/ranger-ims-go/lib/rand"
 	"github.com/stretchr/testify/require"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 )
@@ -303,6 +304,12 @@ func TestCreateAndAttachFileToIncident(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, fileBytes, returnedAttachment)
+
+	// Try to send something too large
+	fileBytes = []byte(strings.Repeat("a", int(shared.cfg.Core.MaxRequestBytes+1)))
+	_, resp = apisNonAdmin.attachFileToIncident(ctx, eventName, num, fileBytes)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
 }
 
 // requireEqualIncident is a hacky way of checking two incident responses are the same.

--- a/api/integration/main_test.go
+++ b/api/integration/main_test.go
@@ -88,6 +88,9 @@ func setup(ctx context.Context, tempDir string) {
 	shared.cfg = conf.DefaultIMS()
 	shared.cfg.Core.JWTSecret = "jwtsecret-" + rand.NonCryptoText()
 	shared.cfg.Core.Admins = []string{userAdminHandle}
+	// 100 KiB, much lower than we'd use outside tests, since we want to test error cases
+	// when requests are too large.
+	shared.cfg.Core.MaxRequestBytes = 100 << 10
 	shared.cfg.AttachmentsStore.Type = conf.AttachmentsStoreLocal
 	shared.cfg.AttachmentsStore.Local = conf.LocalAttachments{
 		Dir: tempRoot,

--- a/api/mux.go
+++ b/api/mux.go
@@ -51,18 +51,20 @@ func AddToMux(
 	mux.Handle("GET /ims/api/access",
 		Adapt(
 			GetEventAccesses{db, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/access",
 		Adapt(
 			PostEventAccess{db, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
@@ -75,8 +77,9 @@ func AddToMux(
 				cfg.Core.AccessTokenLifetime,
 				cfg.Core.RefreshTokenLifetime,
 			},
-			RecoverOnPanic(),
-			LogBeforeAfter(),
+			RecoverFromPanic(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 			// This endpoint does not require authentication, nor
 			// does it even consider the request's Authorization header,
 			// because the point of this is to make a new JWT.
@@ -91,10 +94,11 @@ func AddToMux(
 				cfg.Core.Admins,
 				attachmentsEnabled,
 			},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			// This endpoint does not require authentication or authorization, by design
 			OptionalAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
@@ -106,8 +110,9 @@ func AddToMux(
 				cfg.Core.JWTSecret,
 				cfg.Core.AccessTokenLifetime,
 			},
-			RecoverOnPanic(),
-			LogBeforeAfter(),
+			RecoverFromPanic(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 			// This endpoint does not require authentication, nor
 			// does it even consider the request's Authorization header,
 			// because the point of this is to make a new access token.
@@ -117,197 +122,219 @@ func AddToMux(
 	mux.Handle("GET /ims/api/events/{eventName}/incidents",
 		Adapt(
 			GetIncidents{db, cfg.Core.Admins, attachmentsEnabled},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/incidents",
 		Adapt(
 			NewIncident{db, es, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/events/{eventName}/incidents/{incidentNumber}",
 		Adapt(
 			GetIncident{db, cfg.Core.Admins, attachmentsEnabled},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/incidents/{incidentNumber}",
 		Adapt(
 			EditIncident{db, es, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/events/{eventName}/incidents/{incidentNumber}/attachments/{attachmentNumber}",
 		Adapt(
 			GetIncidentAttachment{db, cfg.AttachmentsStore, s3Client, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/incidents/{incidentNumber}/attachments",
 		Adapt(
 			AttachToIncident{db, es, cfg.AttachmentsStore, s3Client, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/incidents/{incidentNumber}/report_entries/{reportEntryId}",
 		Adapt(
 			EditIncidentReportEntry{db, es, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/events/{eventName}/field_reports",
 		Adapt(
 			GetFieldReports{db, cfg.Core.Admins, attachmentsEnabled},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/field_reports",
 		Adapt(
 			NewFieldReport{db, es, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/events/{eventName}/field_reports/{fieldReportNumber}",
 		Adapt(
 			GetFieldReport{db, cfg.Core.Admins, attachmentsEnabled},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/field_reports/{fieldReportNumber}",
 		Adapt(
 			EditFieldReport{db, es, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/events/{eventName}/field_reports/{fieldReportNumber}/attachments/{attachmentNumber}",
 		Adapt(
 			GetFieldReportAttachment{db, cfg.AttachmentsStore, s3Client, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/field_reports/{fieldReportNumber}/attachments",
 		Adapt(
 			AttachToFieldReport{db, es, cfg.AttachmentsStore, s3Client, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events/{eventName}/field_reports/{fieldReportNumber}/report_entries/{reportEntryId}",
 		Adapt(
 			EditFieldReportReportEntry{db, es, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/events",
 		Adapt(
 			GetEvents{db, cfg.Core.Admins, cfg.Core.CacheControlShort},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/events",
 		Adapt(
 			EditEvents{db, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/streets",
 		Adapt(
 			GetStreets{db, cfg.Core.Admins, cfg.Core.CacheControlShort},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/streets",
 		Adapt(
 			EditStreets{db, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/incident_types",
 		Adapt(
 			GetIncidentTypes{db, cfg.Core.Admins, cfg.Core.CacheControlShort},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("POST /ims/api/incident_types",
 		Adapt(
 			EditIncidentTypes{db, cfg.Core.Admins},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/personnel",
 		Adapt(
 			GetPersonnel{db, userStore, cfg.Core.Admins, cfg.Core.CacheControlShort},
-			RecoverOnPanic(),
+			RecoverFromPanic(),
 			RequireAuthN(jwter),
-			LogBeforeAfter(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
 	mux.Handle("GET /ims/api/eventsource",
 		Adapt(
 			es.Server.Handler(EventSourceChannel),
-			RecoverOnPanic(),
-			LogBeforeAfter(),
+			RecoverFromPanic(),
+			LogRequest(),
+			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)
 
@@ -360,7 +387,13 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func LogBeforeAfter() Adapter {
+func LimitRequestBytes(maxRequestBytes int64) Adapter {
+	return func(next http.Handler) http.Handler {
+		return http.MaxBytesHandler(next, maxRequestBytes)
+	}
+}
+
+func LogRequest() Adapter {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
@@ -404,7 +437,7 @@ func LogBeforeAfter() Adapter {
 	}
 }
 
-func RecoverOnPanic() Adapter {
+func RecoverFromPanic() Adapter {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			defer func() {

--- a/conf/imsconfig.go
+++ b/conf/imsconfig.go
@@ -42,6 +42,7 @@ func DefaultIMS() *IMSConfig {
 			RefreshTokenLifetime: 8 * time.Hour,
 			CacheControlShort:    20 * time.Minute,
 			CacheControlLong:     2 * time.Hour,
+			MaxRequestBytes:      100 << 20,
 		},
 		Store: DBStore{
 			Type: DBStoreTypeMaria,
@@ -199,6 +200,10 @@ type ConfigCore struct {
 
 	// LogLevel should be one of DEBUG, INFO, WARN, or ERROR
 	LogLevel string
+
+	// MaxRequestBytes is a hard limit on request sizes that will be permitted by the API server.
+	// This serve as a backstop against accidentally or maliciously large requests.
+	MaxRequestBytes int64
 }
 
 type DBStore struct {

--- a/directory/testusersquerier.go
+++ b/directory/testusersquerier.go
@@ -81,10 +81,10 @@ func (t TestUsersStore) RangersById(ctx context.Context, db clubhousequeries.DBT
 		rows = append(rows, clubhousequeries.RangersByIdRow{
 			ID:       person.DirectoryID,
 			Callsign: person.Handle,
-			Email:    conv.ParseSqlNullString(&person.Email),
+			Email:    conv.StringToSql(&person.Email),
 			Status:   clubhousequeries.PersonStatus(person.Status),
 			OnSite:   person.Onsite,
-			Password: conv.ParseSqlNullString(&person.Password),
+			Password: conv.StringToSql(&person.Password),
 		})
 	}
 	return rows, nil

--- a/lib/conv/convert_test.go
+++ b/lib/conv/convert_test.go
@@ -17,11 +17,13 @@
 package conv
 
 import (
+	"database/sql"
 	"github.com/stretchr/testify/assert"
+	"math"
 	"testing"
 )
 
-func TestFloat64UnixSeconds(t *testing.T) {
+func TestFloatTimeConversions(t *testing.T) {
 	t.Parallel()
 	// epochSec is when I wrote this test
 	const (
@@ -30,7 +32,7 @@ func TestFloat64UnixSeconds(t *testing.T) {
 	)
 	nanoPreciseTime := float64(epochSec) + float64(nanoseconds)/1e9
 	// convert to a time.Time
-	tim := Float64UnixSeconds(nanoPreciseTime)
+	tim := FloatToTime(nanoPreciseTime)
 	// that time can't actually hold the full precision. It's 21 ns off, not that
 	// the value itself actually matters
 	epsilon := int(nanoseconds) - tim.Nanosecond()
@@ -40,6 +42,36 @@ func TestFloat64UnixSeconds(t *testing.T) {
 	// but, this is good enough for microsecond precision!
 	assert.Equal(t, epochSec*1e6+nanoseconds/1e3, tim.UnixMicro())
 
-	backToFloat := TimeFloat64(tim)
+	// convert back to float
+	backToFloat := TimeToFloat(tim)
 	assert.Less(t, nanoPreciseTime-backToFloat, 1e-7)
+}
+
+func TestFormatInt(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "123", FormatInt(123))
+}
+
+func TestFormatSqlInt16(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "42", *FormatSqlInt16(sql.NullInt16{Valid: true, Int16: 42}))
+	assert.Nil(t, FormatSqlInt16(sql.NullInt16{}))
+}
+
+func TestParseSqlInt16(t *testing.T) {
+	t.Parallel()
+
+	s123 := "123"
+	assert.Equal(t, sql.NullInt16{Valid: true, Int16: 123}, ParseSqlInt16(&s123))
+	assert.Equal(t, sql.NullInt16{}, ParseSqlInt16(nil))
+}
+
+func TestMustInt(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, int32(math.MaxInt32), MustInt32(math.MaxInt32))
+	assert.Panics(t, func() {
+		MustInt32(math.MaxInt32 + 1)
+	})
 }

--- a/lib/herr/httperror.go
+++ b/lib/herr/httperror.go
@@ -57,6 +57,10 @@ func BadRequest(userMessage string, err error) *HTTPError {
 	return New(http.StatusBadRequest, userMessage, err)
 }
 
+func RequestEntityTooLarge(userMessage string, err error) *HTTPError {
+	return New(http.StatusRequestEntityTooLarge, userMessage, err)
+}
+
 // Unauthorized returns an http.StatusUnauthorized HTTPError.
 func Unauthorized(userMessage string, err error) *HTTPError {
 	return New(http.StatusUnauthorized, userMessage, err)


### PR DESCRIPTION
I first just planned to do this for the file attachment endpoints, but then I figured we might as well impose that same large limit on all the other endpoints as well. This helps prevent accidental or malicious DoSing of the server that could arise from enormous payloads.

This PR also does a bunch of assorted renamings.