### PR TITLE
refactor DB code to log proper SQL execution duration

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -252,9 +252,6 @@ func (action RefreshAccessToken) refreshAccessToken(req *http.Request) (RefreshA
 	if err != nil {
 		return empty, herr.Unauthorized("Failed to authenticate refresh token", err).From("[AuthenticateRefreshToken]")
 	}
-	if jwt.RangerHandle() == "" {
-		return empty, herr.InternalServerError("No Ranger handle associated with refresh token", nil)
-	}
 
 	slog.Info("Refreshing access token", "ranger", jwt.RangerHandle())
 	rangers, err := action.userStore.GetRangers(req.Context())

--- a/api/integration/main_test.go
+++ b/api/integration/main_test.go
@@ -123,7 +123,7 @@ func setup(ctx context.Context, tempDir string) {
 	}
 	must(shared.cfg.Validate())
 	shared.es = api.NewEventSourcerer()
-	clubhouseDBQ := directory.NewFakeTestUsersDBQ(
+	clubhouseDBQ := directory.NewTestUsersDBQ(
 		shared.cfg.Directory.TestUsers,
 		shared.cfg.Directory.InMemoryCacheTTL,
 	)

--- a/api/mux.go
+++ b/api/mux.go
@@ -18,7 +18,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/burningmantech/ranger-ims-go/conf"
 	"github.com/burningmantech/ranger-ims-go/directory"
@@ -482,10 +481,6 @@ func RequireAuthN(j authz.JWTer) Adapter {
 			claims, err := j.AuthenticateJWT(strings.TrimPrefix(header, "Bearer "))
 			if err != nil || claims == nil {
 				handleErr(w, r, http.StatusUnauthorized, "Invalid Authorization token", err)
-				return
-			}
-			if claims.RangerHandle() == "" {
-				handleErr(w, r, http.StatusUnauthorized, "Invalid Authorization token", errors.New("no Ranger handle in JWT"))
 				return
 			}
 			jwtCtx := context.WithValue(r.Context(), JWTContextKey, JWTContext{

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -88,10 +88,10 @@ func runServerInternal(ctx context.Context, unvalidatedCfg *conf.IMSConfig, prin
 	case conf.DirectoryTypeClubhouseDB:
 		db, err := directory.MariaDB(ctx, imsCfg.Directory.ClubhouseDB)
 		must(err)
-		clubhouseDBQ = directory.NewRealMariaDBQ(db, imsCfg.Directory.InMemoryCacheTTL)
+		clubhouseDBQ = directory.NewMariaDBQ(db, imsCfg.Directory.InMemoryCacheTTL)
 	case conf.DirectoryTypeTestUsers:
 		must(err)
-		clubhouseDBQ = directory.NewFakeTestUsersDBQ(imsCfg.Directory.TestUsers, imsCfg.Directory.InMemoryCacheTTL)
+		clubhouseDBQ = directory.NewTestUsersDBQ(imsCfg.Directory.TestUsers, imsCfg.Directory.InMemoryCacheTTL)
 	default:
 		must(fmt.Errorf("unknown directory %v", imsCfg.Directory.Directory))
 	}

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -18,6 +18,7 @@ package directory
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	imsjson "github.com/burningmantech/ranger-ims-go/json"
 	"slices"
@@ -52,21 +53,19 @@ func (store *UserStore) GetRangers(ctx context.Context) ([]imsjson.Person, error
 }
 
 func (store *UserStore) GetUserPositionsTeams(ctx context.Context, userID int64) (positions, teams []string, err error) {
+	var errs []error
+
 	teamRows, err := store.DBQ.Teams(ctx, store.DBQ)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[Teams]: %w", err)
-	}
+	errs = append(errs, err)
 	positionRows, err := store.DBQ.Positions(ctx, store.DBQ)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[Positions]: %w", err)
-	}
+	errs = append(errs, err)
 	personTeams, err := store.DBQ.PersonTeams(ctx, store.DBQ)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[PersonTeams]: %w", err)
-	}
+	errs = append(errs, err)
 	personPositions, err := store.DBQ.PersonPositions(ctx, store.DBQ)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[PersonPositions]: %w", err)
+	errs = append(errs, err)
+
+	if err := errors.Join(errs...); err != nil {
+		return nil, nil, fmt.Errorf("[Teams,Positions,PersonTeams,PersonPositions] %w", err)
 	}
 
 	var foundPositions []int64

--- a/store/dbquerier.go
+++ b/store/dbquerier.go
@@ -22,66 +22,26 @@ import (
 	"fmt"
 	"github.com/burningmantech/ranger-ims-go/store/imsdb"
 	"log/slog"
-	"strings"
 	"time"
 )
 
-// DBQ combines the SQL database and the Querier for the IMS datastore. It's convenient having those
-// two types embedded in one struct, because it allows great flexibility in custom method overrides.
+// DBQ combines the SQL database and the Querier for the IMS datastore.
 type DBQ struct {
 	*sql.DB
-	imsdb.Querier
+	q imsdb.Querier
 }
 
 func New(sqlDB *sql.DB, querier imsdb.Querier) *DBQ {
-	db := &DBQ{
-		DB:      sqlDB,
-		Querier: querier,
+	return &DBQ{
+		DB: sqlDB,
+		q:  querier,
 	}
-	return db
 }
 
-func (l DBQ) ExecContext(ctx context.Context, s string, i ...interface{}) (sql.Result, error) {
-	start := time.Now()
-	result, err := l.DB.ExecContext(ctx, s, i...)
-	logQuery(s, start, err)
-	return result, err
-}
-
-func (l DBQ) PrepareContext(ctx context.Context, s string) (*sql.Stmt, error) {
-	start := time.Now()
-	stmt, err := l.DB.PrepareContext(ctx, s)
-	logQuery(s, start, err)
-	return stmt, err
-}
-
-func (l DBQ) QueryContext(ctx context.Context, s string, i ...interface{}) (*sql.Rows, error) {
-	start := time.Now()
-	rows, err := l.DB.QueryContext(ctx, s, i...)
-	logQuery(s, start, err)
-	return rows, err
-}
-
-func (l DBQ) QueryRowContext(ctx context.Context, s string, i ...interface{}) *sql.Row {
-	start := time.Now()
-	row := l.DB.QueryRowContext(ctx, s, i...)
-	logQuery(s, start, nil)
-	return row
-}
-
-func logQuery(s string, start time.Time, err error) {
-	queryName, _, _ := strings.Cut(s, "\n")
-	queryName = strings.TrimPrefix(queryName, "-- name: ")
-	queryName = strings.Fields(queryName)[0]
+func logQuery(queryName string, start time.Time, err error) {
 	durationMS := float64(time.Since(start).Microseconds()) / 1000.0
-
-	// Note that the duration(ish) is very misleading. It'll always be less than
-	// the actual query time, often significantly. That's because most of the IO
-	// takes place after we're able to log in this file, e.g. in the "for rows.Next()"
-	// part of reading the results, and unfortunately that code is in the generated
-	// sqlc package. It's a TODO for later to log actual query times.
 	slog.Debug("Ran IMS SQL: "+queryName,
-		"durationish", fmt.Sprintf("%.3fms", durationMS),
+		"duration", fmt.Sprintf("%.3fms", durationMS),
 		"err", err,
 	)
 }
@@ -99,3 +59,272 @@ func logQuery(s string, start time.Time, err error) {
 //	}
 //	return *sl
 //}
+
+// Force DBQ to implement the imsdb.Querier interface.
+var _ imsdb.Querier = (*DBQ)(nil)
+
+func (l DBQ) AddEventAccess(ctx context.Context, db imsdb.DBTX, arg imsdb.AddEventAccessParams) (int64, error) {
+	start := time.Now()
+	id, err := l.q.AddEventAccess(ctx, db, arg)
+	logQuery("AddEventAccess", start, err)
+	return id, err
+}
+
+func (l DBQ) AttachFieldReportToIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.AttachFieldReportToIncidentParams) error {
+	start := time.Now()
+	err := l.q.AttachFieldReportToIncident(ctx, db, arg)
+	logQuery("AttachFieldReportToIncident", start, err)
+	return err
+}
+
+func (l DBQ) AttachIncidentTypeToIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.AttachIncidentTypeToIncidentParams) error {
+	start := time.Now()
+	err := l.q.AttachIncidentTypeToIncident(ctx, db, arg)
+	logQuery("AttachIncidentTypeToIncident", start, err)
+	return err
+}
+
+func (l DBQ) AttachRangerHandleToIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.AttachRangerHandleToIncidentParams) error {
+	start := time.Now()
+	err := l.q.AttachRangerHandleToIncident(ctx, db, arg)
+	logQuery("AttachRangerHandleToIncident", start, err)
+	return err
+}
+
+func (l DBQ) AttachReportEntryToFieldReport(ctx context.Context, db imsdb.DBTX, arg imsdb.AttachReportEntryToFieldReportParams) error {
+	start := time.Now()
+	err := l.q.AttachReportEntryToFieldReport(ctx, db, arg)
+	logQuery("AttachReportEntryToFieldReport", start, err)
+	return err
+}
+
+func (l DBQ) AttachReportEntryToIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.AttachReportEntryToIncidentParams) error {
+	start := time.Now()
+	err := l.q.AttachReportEntryToIncident(ctx, db, arg)
+	logQuery("AttachReportEntryToIncident", start, err)
+	return err
+}
+
+func (l DBQ) ClearEventAccessForExpression(ctx context.Context, db imsdb.DBTX, arg imsdb.ClearEventAccessForExpressionParams) error {
+	start := time.Now()
+	err := l.q.ClearEventAccessForExpression(ctx, db, arg)
+	logQuery("ClearEventAccessForExpression", start, err)
+	return err
+}
+
+func (l DBQ) ClearEventAccessForMode(ctx context.Context, db imsdb.DBTX, arg imsdb.ClearEventAccessForModeParams) error {
+	start := time.Now()
+	err := l.q.ClearEventAccessForMode(ctx, db, arg)
+	logQuery("ClearEventAccessForMode", start, err)
+	return err
+}
+
+func (l DBQ) ConcentricStreets(ctx context.Context, db imsdb.DBTX, event int32) ([]imsdb.ConcentricStreetsRow, error) {
+	start := time.Now()
+	streets, err := l.q.ConcentricStreets(ctx, db, event)
+	logQuery("ConcentricStreets", start, err)
+	return streets, err
+}
+
+func (l DBQ) CreateConcentricStreet(ctx context.Context, db imsdb.DBTX, arg imsdb.CreateConcentricStreetParams) error {
+	start := time.Now()
+	err := l.q.CreateConcentricStreet(ctx, db, arg)
+	logQuery("CreateConcentricStreet", start, err)
+	return err
+}
+
+func (l DBQ) CreateEvent(ctx context.Context, db imsdb.DBTX, name string) (int64, error) {
+	start := time.Now()
+	event, err := l.q.CreateEvent(ctx, db, name)
+	logQuery("CreateEvent", start, err)
+	return event, err
+}
+
+func (l DBQ) CreateFieldReport(ctx context.Context, db imsdb.DBTX, arg imsdb.CreateFieldReportParams) error {
+	start := time.Now()
+	err := l.q.CreateFieldReport(ctx, db, arg)
+	logQuery("CreateFieldReport", start, err)
+	return err
+}
+
+func (l DBQ) CreateIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.CreateIncidentParams) (int64, error) {
+	start := time.Now()
+	incident, err := l.q.CreateIncident(ctx, db, arg)
+	logQuery("CreateIncident", start, err)
+	return incident, err
+}
+
+func (l DBQ) CreateIncidentTypeOrIgnore(ctx context.Context, db imsdb.DBTX, arg imsdb.CreateIncidentTypeOrIgnoreParams) error {
+	start := time.Now()
+	err := l.q.CreateIncidentTypeOrIgnore(ctx, db, arg)
+	logQuery("CreateIncidentTypeOrIgnore", start, err)
+	return err
+}
+
+func (l DBQ) CreateReportEntry(ctx context.Context, db imsdb.DBTX, arg imsdb.CreateReportEntryParams) (int64, error) {
+	start := time.Now()
+	entry, err := l.q.CreateReportEntry(ctx, db, arg)
+	logQuery("CreateReportEntry", start, err)
+	return entry, err
+}
+
+func (l DBQ) DetachIncidentTypeFromIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.DetachIncidentTypeFromIncidentParams) error {
+	start := time.Now()
+	err := l.q.DetachIncidentTypeFromIncident(ctx, db, arg)
+	logQuery("DetachIncidentTypeFromIncident", start, err)
+	return err
+}
+
+func (l DBQ) DetachRangerHandleFromIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.DetachRangerHandleFromIncidentParams) error {
+	start := time.Now()
+	err := l.q.DetachRangerHandleFromIncident(ctx, db, arg)
+	logQuery("DetachRangerHandleFromIncident", start, err)
+	return err
+}
+
+func (l DBQ) EventAccess(ctx context.Context, db imsdb.DBTX, event int32) ([]imsdb.EventAccessRow, error) {
+	start := time.Now()
+	items, err := l.q.EventAccess(ctx, db, event)
+	logQuery("EventAccess", start, err)
+	return items, err
+}
+
+func (l DBQ) EventAccessAll(ctx context.Context, db imsdb.DBTX) ([]imsdb.EventAccessAllRow, error) {
+	start := time.Now()
+	all, err := l.q.EventAccessAll(ctx, db)
+	logQuery("EventAccessAll", start, err)
+	return all, err
+}
+
+func (l DBQ) Events(ctx context.Context, db imsdb.DBTX) ([]imsdb.EventsRow, error) {
+	start := time.Now()
+	events, err := l.q.Events(ctx, db)
+	logQuery("Events", start, err)
+	return events, err
+}
+
+func (l DBQ) FieldReport(ctx context.Context, db imsdb.DBTX, arg imsdb.FieldReportParams) (imsdb.FieldReportRow, error) {
+	start := time.Now()
+	report, err := l.q.FieldReport(ctx, db, arg)
+	logQuery("FieldReport", start, err)
+	return report, err
+}
+
+func (l DBQ) FieldReport_ReportEntries(ctx context.Context, db imsdb.DBTX, arg imsdb.FieldReport_ReportEntriesParams) ([]imsdb.FieldReport_ReportEntriesRow, error) {
+	start := time.Now()
+	entries, err := l.q.FieldReport_ReportEntries(ctx, db, arg)
+	logQuery("FieldReport_ReportEntries", start, err)
+	return entries, err
+}
+
+func (l DBQ) FieldReports(ctx context.Context, db imsdb.DBTX, event int32) ([]imsdb.FieldReportsRow, error) {
+	start := time.Now()
+	reports, err := l.q.FieldReports(ctx, db, event)
+	logQuery("FieldReports", start, err)
+	return reports, err
+}
+
+func (l DBQ) FieldReports_ReportEntries(ctx context.Context, db imsdb.DBTX, arg imsdb.FieldReports_ReportEntriesParams) ([]imsdb.FieldReports_ReportEntriesRow, error) {
+	start := time.Now()
+	entries, err := l.q.FieldReports_ReportEntries(ctx, db, arg)
+	logQuery("FieldReports_ReportEntries", start, err)
+	return entries, err
+}
+
+func (l DBQ) HideShowIncidentType(ctx context.Context, db imsdb.DBTX, arg imsdb.HideShowIncidentTypeParams) error {
+	start := time.Now()
+	err := l.q.HideShowIncidentType(ctx, db, arg)
+	logQuery("HideShowIncidentType", start, err)
+	return err
+}
+
+func (l DBQ) Incident(ctx context.Context, db imsdb.DBTX, arg imsdb.IncidentParams) (imsdb.IncidentRow, error) {
+	start := time.Now()
+	incident, err := l.q.Incident(ctx, db, arg)
+	logQuery("Incident", start, err)
+	return incident, err
+}
+
+func (l DBQ) IncidentTypes(ctx context.Context, db imsdb.DBTX) ([]imsdb.IncidentTypesRow, error) {
+	start := time.Now()
+	types, err := l.q.IncidentTypes(ctx, db)
+	logQuery("IncidentTypes", start, err)
+	return types, err
+}
+
+func (l DBQ) Incident_ReportEntries(ctx context.Context, db imsdb.DBTX, arg imsdb.Incident_ReportEntriesParams) ([]imsdb.Incident_ReportEntriesRow, error) {
+	start := time.Now()
+	entries, err := l.q.Incident_ReportEntries(ctx, db, arg)
+	logQuery("Incident_ReportEntries", start, err)
+	return entries, err
+}
+
+func (l DBQ) Incidents(ctx context.Context, db imsdb.DBTX, event int32) ([]imsdb.IncidentsRow, error) {
+	start := time.Now()
+	incidents, err := l.q.Incidents(ctx, db, event)
+	logQuery("Incidents", start, err)
+	return incidents, err
+}
+
+func (l DBQ) Incidents_ReportEntries(ctx context.Context, db imsdb.DBTX, arg imsdb.Incidents_ReportEntriesParams) ([]imsdb.Incidents_ReportEntriesRow, error) {
+	start := time.Now()
+	entries, err := l.q.Incidents_ReportEntries(ctx, db, arg)
+	logQuery("Incidents_ReportEntries", start, err)
+	return entries, err
+}
+
+func (l DBQ) NextFieldReportNumber(ctx context.Context, db imsdb.DBTX, event int32) (int32, error) {
+	start := time.Now()
+	number, err := l.q.NextFieldReportNumber(ctx, db, event)
+	logQuery("NextFieldReportNumber", start, err)
+	return number, err
+}
+
+func (l DBQ) NextIncidentNumber(ctx context.Context, db imsdb.DBTX, event int32) (int32, error) {
+	start := time.Now()
+	number, err := l.q.NextIncidentNumber(ctx, db, event)
+	logQuery("NextIncidentNumber", start, err)
+	return number, err
+}
+
+func (l DBQ) QueryEventID(ctx context.Context, db imsdb.DBTX, name string) (imsdb.QueryEventIDRow, error) {
+	start := time.Now()
+	id, err := l.q.QueryEventID(ctx, db, name)
+	logQuery("QueryEventID", start, err)
+	return id, err
+}
+
+func (l DBQ) SchemaVersion(ctx context.Context, db imsdb.DBTX) (int16, error) {
+	start := time.Now()
+	version, err := l.q.SchemaVersion(ctx, db)
+	logQuery("SchemaVersion", start, err)
+	return version, err
+}
+
+func (l DBQ) SetFieldReportReportEntryStricken(ctx context.Context, db imsdb.DBTX, arg imsdb.SetFieldReportReportEntryStrickenParams) error {
+	start := time.Now()
+	err := l.q.SetFieldReportReportEntryStricken(ctx, db, arg)
+	logQuery("SetFieldReportReportEntryStricken", start, err)
+	return err
+}
+
+func (l DBQ) SetIncidentReportEntryStricken(ctx context.Context, db imsdb.DBTX, arg imsdb.SetIncidentReportEntryStrickenParams) error {
+	start := time.Now()
+	err := l.q.SetIncidentReportEntryStricken(ctx, db, arg)
+	logQuery("SetIncidentReportEntryStricken", start, err)
+	return err
+}
+
+func (l DBQ) UpdateFieldReport(ctx context.Context, db imsdb.DBTX, arg imsdb.UpdateFieldReportParams) error {
+	start := time.Now()
+	err := l.q.UpdateFieldReport(ctx, db, arg)
+	logQuery("UpdateFieldReport", start, err)
+	return err
+}
+
+func (l DBQ) UpdateIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.UpdateIncidentParams) error {
+	start := time.Now()
+	err := l.q.UpdateIncident(ctx, db, arg)
+	logQuery("UpdateIncident", start, err)
+	return err
+}

--- a/store/imsdb/querier.go
+++ b/store/imsdb/querier.go
@@ -15,7 +15,6 @@ type Querier interface {
 	AttachRangerHandleToIncident(ctx context.Context, db DBTX, arg AttachRangerHandleToIncidentParams) error
 	AttachReportEntryToFieldReport(ctx context.Context, db DBTX, arg AttachReportEntryToFieldReportParams) error
 	AttachReportEntryToIncident(ctx context.Context, db DBTX, arg AttachReportEntryToIncidentParams) error
-	AttachedFieldReportNumbers(ctx context.Context, db DBTX, arg AttachedFieldReportNumbersParams) ([]int32, error)
 	ClearEventAccessForExpression(ctx context.Context, db DBTX, arg ClearEventAccessForExpressionParams) error
 	ClearEventAccessForMode(ctx context.Context, db DBTX, arg ClearEventAccessForModeParams) error
 	ConcentricStreets(ctx context.Context, db DBTX, event int32) ([]ConcentricStreetsRow, error)
@@ -27,7 +26,6 @@ type Querier interface {
 	CreateReportEntry(ctx context.Context, db DBTX, arg CreateReportEntryParams) (int64, error)
 	DetachIncidentTypeFromIncident(ctx context.Context, db DBTX, arg DetachIncidentTypeFromIncidentParams) error
 	DetachRangerHandleFromIncident(ctx context.Context, db DBTX, arg DetachRangerHandleFromIncidentParams) error
-	DetachedFieldReportNumbers(ctx context.Context, db DBTX, event int32) ([]int32, error)
 	EventAccess(ctx context.Context, db DBTX, event int32) ([]EventAccessRow, error)
 	EventAccessAll(ctx context.Context, db DBTX) ([]EventAccessAllRow, error)
 	Events(ctx context.Context, db DBTX) ([]EventsRow, error)

--- a/store/imsdb/queries.sql.go
+++ b/store/imsdb/queries.sql.go
@@ -125,41 +125,6 @@ func (q *Queries) AttachReportEntryToIncident(ctx context.Context, db DBTX, arg 
 	return err
 }
 
-const attachedFieldReportNumbers = `-- name: AttachedFieldReportNumbers :many
-select NUMBER from FIELD_REPORT
-where
-    EVENT = ? and
-    INCIDENT_NUMBER = ?
-`
-
-type AttachedFieldReportNumbersParams struct {
-	Event          int32
-	IncidentNumber sql.NullInt32
-}
-
-func (q *Queries) AttachedFieldReportNumbers(ctx context.Context, db DBTX, arg AttachedFieldReportNumbersParams) ([]int32, error) {
-	rows, err := db.QueryContext(ctx, attachedFieldReportNumbers, arg.Event, arg.IncidentNumber)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []int32
-	for rows.Next() {
-		var number int32
-		if err := rows.Scan(&number); err != nil {
-			return nil, err
-		}
-		items = append(items, number)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const clearEventAccessForExpression = `-- name: ClearEventAccessForExpression :exec
 delete from EVENT_ACCESS
 where EVENT = ? and EXPRESSION = ?
@@ -399,34 +364,6 @@ type DetachRangerHandleFromIncidentParams struct {
 func (q *Queries) DetachRangerHandleFromIncident(ctx context.Context, db DBTX, arg DetachRangerHandleFromIncidentParams) error {
 	_, err := db.ExecContext(ctx, detachRangerHandleFromIncident, arg.Event, arg.IncidentNumber, arg.RangerHandle)
 	return err
-}
-
-const detachedFieldReportNumbers = `-- name: DetachedFieldReportNumbers :many
-select NUMBER from FIELD_REPORT
-where EVENT = ? and INCIDENT_NUMBER is null
-`
-
-func (q *Queries) DetachedFieldReportNumbers(ctx context.Context, db DBTX, event int32) ([]int32, error) {
-	rows, err := db.QueryContext(ctx, detachedFieldReportNumbers, event)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []int32
-	for rows.Next() {
-		var number int32
-		if err := rows.Scan(&number); err != nil {
-			return nil, err
-		}
-		items = append(items, number)
-	}
-	if err := rows.Close(); err != nil {
-		return nil, err
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
 }
 
 const eventAccess = `-- name: EventAccess :many

--- a/store/integration/migrate_test.go
+++ b/store/integration/migrate_test.go
@@ -86,6 +86,9 @@ func TestMigrateSameAsCurrentSchema(t *testing.T) {
 	// DB2: migrate straight up to current schema version
 	err = store.MigrateDB(ctx, db2)
 	require.NoError(t, err)
+	// Run MigrateDB again, which is a no-op
+	err = store.MigrateDB(ctx, db2)
+	require.NoError(t, err)
 
 	// The two databases should have the same set of tables
 	var dbTables [2][]string

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -52,7 +52,8 @@ func repoSchemaVersion() (schemaVersion, error) {
 }
 
 func dbSchemaVersion(ctx context.Context, db *sql.DB) (schemaVersion, error) {
-	result, err := imsdb.New().SchemaVersion(ctx, db)
+	dbq := New(db, imsdb.New())
+	result, err := dbq.SchemaVersion(ctx, db)
 	if err == nil {
 		return schemaVersion(result), nil
 	}

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -222,16 +222,6 @@ insert into FIELD_REPORT (
 )
 values (?, ?, ?, ?, ?);
 
--- name: DetachedFieldReportNumbers :many
-select NUMBER from FIELD_REPORT
-where EVENT = ? and INCIDENT_NUMBER is null;
-
--- name: AttachedFieldReportNumbers :many
-select NUMBER from FIELD_REPORT
-where
-    EVENT = ? and
-    INCIDENT_NUMBER = ?;
-
 -- name: UpdateFieldReport :exec
 update FIELD_REPORT
 set SUMMARY = ?, INCIDENT_NUMBER = ?


### PR DESCRIPTION
We unfortunately need a method per query to log the actual SQL execution times, but this does the trick.

This change also removes a couple of unused queries and cleans up various bits of code in minor ways to improve testability.