### PR TITLE
do health check as a subcommand, removing need for "curl"

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - funlen  # meh
     - gochecknoglobals  # there are a bunch of globals that could be cleaned up
     - gocognit  # many functions are too complex currently
+    - goconst  # not very helpful
     - gocyclo  # many functions are too complex currently
     - maintidx  # many functions are too complex currently
     - mnd  # magic numbers can often be obvious enough. Maybe...

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,6 @@ RUN CGO_ENABLED=0 GOOS=linux go build -o /app/ranger-ims-go
 
 # Start a new stage and only copy over the IMS binary.
 FROM alpine:latest
-# Include curl for the health check's sake
-RUN apk add curl
 COPY --from=build /app/ranger-ims-go /
 
 # Use a non-root user to run the server

--- a/bin/test_docker
+++ b/bin/test_docker
@@ -12,8 +12,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 exit_code=0
 echo "Building and starting Docker containers"
-docker compose build
-docker compose up --wait-timeout 30 --wait || exit_code=$?
+docker compose up --build --wait-timeout 30 --wait || exit_code=$?
 
 echo "Stopping and deleting those Docker containers"
 docker compose rm -fsv

--- a/cmd/healthcheck.go
+++ b/cmd/healthcheck.go
@@ -1,0 +1,78 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+)
+
+var healthCheckCmd = &cobra.Command{
+	Use:   "healthcheck",
+	Short: "Perform a health check against an IMS server",
+	Long:  "Perform a health check against an IMS server",
+	Run:   runHealthCheck,
+}
+
+var serverURL string
+
+// exit is overridable for tests.
+var exit = os.Exit
+
+func init() {
+	rootCmd.AddCommand(healthCheckCmd)
+
+	healthCheckCmd.Flags().StringVar(&serverURL, "server_url", "", "The server URL and port of an IMS server")
+	_ = healthCheckCmd.MarkFlagRequired("server_url")
+}
+
+func runHealthCheck(cmd *cobra.Command, args []string) {
+	client := http.Client{Timeout: time.Second * 5}
+
+	pingURL, err := url.JoinPath(serverURL, "ims/api/ping")
+	must(err)
+
+	req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, pingURL, nil)
+	must(err)
+
+	resp, err := client.Do(req)
+	must(err)
+
+	body, err := io.ReadAll(resp.Body)
+	must(err)
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		fmt.Println("wanted status code 200, got", resp.StatusCode) //nolint:forbidigo
+		exit(5)
+		return
+	}
+	if strings.TrimSpace(string(body)) != "ack" {
+		fmt.Printf("wanted response of 'ack', got '%v'\n", string(body)) //nolint:forbidigo
+		exit(6)
+		return
+	}
+	fmt.Println("OK") //nolint:forbidigo
+	exit(0)
+	return
+}

--- a/cmd/healthcheck_test.go
+++ b/cmd/healthcheck_test.go
@@ -1,0 +1,102 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthCheckSuccess(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	exitVal := make(chan int, 1)
+	exit = func(code int) {
+		exitVal <- code
+	}
+
+	ser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ims/api/ping" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ack"))
+		}
+	}))
+	serverURL = ser.URL
+
+	runHealthCheck(cmd, nil)
+	got := <-exitVal
+	if got != 0 {
+		t.Errorf("wanted exit code 0, got %v", got)
+	}
+}
+
+func TestHealthCheckBadStatus(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	exitVal := make(chan int, 1)
+	exit = func(code int) {
+		exitVal <- code
+	}
+
+	ser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ims/api/ping" {
+			w.WriteHeader(http.StatusTeapot)
+			_, _ = w.Write([]byte("ack"))
+		}
+	}))
+	serverURL = ser.URL
+
+	runHealthCheck(cmd, nil)
+	got := <-exitVal
+	if got != 5 {
+		t.Errorf("wanted exit code 5, got %v", got)
+	}
+}
+
+func TestHealthCheckBadResponse(t *testing.T) {
+	t.Parallel()
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(t.Context())
+
+	exitVal := make(chan int, 1)
+	exit = func(code int) {
+		exitVal <- code
+	}
+
+	ser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ims/api/ping" {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("nack"))
+		}
+	}))
+	serverURL = ser.URL
+
+	runHealthCheck(cmd, nil)
+	got := <-exitVal
+	if got != 6 {
+		t.Errorf("wanted exit code 6, got %v", got)
+	}
+}

--- a/cmd/healthcheck_test.go
+++ b/cmd/healthcheck_test.go
@@ -17,7 +17,6 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -26,39 +25,21 @@ import (
 func TestHealthCheckSuccess(t *testing.T) {
 	t.Parallel()
 
-	cmd := &cobra.Command{}
-	cmd.SetContext(t.Context())
-
-	exitVal := make(chan int, 1)
-	exit = func(code int) {
-		exitVal <- code
-	}
-
 	ser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/ims/api/ping" {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("ack"))
 		}
 	}))
-	serverURL = ser.URL
 
-	runHealthCheck(cmd, nil)
-	got := <-exitVal
-	if got != 0 {
-		t.Errorf("wanted exit code 0, got %v", got)
+	exitCode := runHealthCheckInternal(t.Context(), ser.URL)
+	if exitCode != 0 {
+		t.Errorf("wanted exit code 0, got %v", exitCode)
 	}
 }
 
 func TestHealthCheckBadStatus(t *testing.T) {
 	t.Parallel()
-
-	cmd := &cobra.Command{}
-	cmd.SetContext(t.Context())
-
-	exitVal := make(chan int, 1)
-	exit = func(code int) {
-		exitVal <- code
-	}
 
 	ser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/ims/api/ping" {
@@ -66,25 +47,15 @@ func TestHealthCheckBadStatus(t *testing.T) {
 			_, _ = w.Write([]byte("ack"))
 		}
 	}))
-	serverURL = ser.URL
 
-	runHealthCheck(cmd, nil)
-	got := <-exitVal
-	if got != 5 {
-		t.Errorf("wanted exit code 5, got %v", got)
+	exitCode := runHealthCheckInternal(t.Context(), ser.URL)
+	if exitCode != 5 {
+		t.Errorf("wanted exit code 5, got %v", exitCode)
 	}
 }
 
 func TestHealthCheckBadResponse(t *testing.T) {
 	t.Parallel()
-
-	cmd := &cobra.Command{}
-	cmd.SetContext(t.Context())
-
-	exitVal := make(chan int, 1)
-	exit = func(code int) {
-		exitVal <- code
-	}
 
 	ser := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/ims/api/ping" {
@@ -92,11 +63,9 @@ func TestHealthCheckBadResponse(t *testing.T) {
 			_, _ = w.Write([]byte("nack"))
 		}
 	}))
-	serverURL = ser.URL
 
-	runHealthCheck(cmd, nil)
-	got := <-exitVal
-	if got != 6 {
-		t.Errorf("wanted exit code 6, got %v", got)
+	exitCode := runHealthCheckInternal(t.Context(), ser.URL)
+	if exitCode != 6 {
+		t.Errorf("wanted exit code 6, got %v", exitCode)
 	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,10 @@ services:
 
   app:
     build: .
-    container_name: "rangers-ims-go"
+    container_name: "ranger-ims-go"
     environment:
       IMS_DIRECTORY: "TestUsers"
-      IMS_DB_HOST_NAME: "rangers-ims-database"
+      IMS_DB_HOST_NAME: "ranger-ims-database"
       IMS_DB_PORT: "${IMS_DB_PORT:-3306}"
       IMS_DB_USER_NAME: "${IMS_DB_USER_NAME:-ims}"
       IMS_DB_PASSWORD: "${IMS_DB_PASSWORD:-ims}"
@@ -15,14 +15,14 @@ services:
       database:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://app:80/ims/api/ping" ]
+      test: [ "CMD", "/ranger-ims-go", "healthcheck", "--server_url", "http://app:80" ]
       interval: 1s
       timeout: 3s
       retries: 30
 
   database:
     image: "mariadb:10.5.27"
-    container_name: "rangers-ims-database"
+    container_name: "ranger-ims-database"
     environment:
       MARIADB_DATABASE: "${IMS_DB_DATABASE:-ims}"
       MARIADB_USER: "${IMS_DB_USER_NAME:-ims}"


### PR DESCRIPTION
it seemed unfortunate to have to bring the curl package into the final image just for the sake of the health check.

this reduces the final image's size from 51.1MB to 38.7MB

fyi @wsanchez 