### PR TITLE
use correct image version for test_docker, upgrade harden-runner step

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -189,6 +189,8 @@ jobs:
 
       - name: Test Docker image
         run: ./bin/test_docker
+        env:
+          TAG: ${{ github.sha }}
 
 
   deploy-staging:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -166,7 +166,7 @@ jobs:
     steps:
 
       - name: Harden CI
-        uses: step-security/harden-runner@v2.10.4
+        uses: step-security/harden-runner@v2.12.0
         with:
           disable-sudo: true
           egress-policy: block
@@ -206,7 +206,7 @@ jobs:
     steps:
 
       - name: Harden CI
-        uses: step-security/harden-runner@v2.10.4
+        uses: step-security/harden-runner@v2.12.0
         with:
           disable-sudo: true
           egress-policy: block

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
 services:
 
   app:
-    build: .
     image: "ranger-ims-go"
     container_name: "ranger-ims-go"
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
 
   app:
-    image: "ranger-ims-go"
+    image: "ranger-ims-go:${TAG}"
     container_name: "ranger-ims-go"
     environment:
       IMS_DIRECTORY: "TestUsers"


### PR DESCRIPTION
Dependabot complains about versions before 2.12.0
https://github.com/burningmantech/ranger-ims-go/security/dependabot/2