### PR TITLE
use .dockerignore to not copy particular files into the image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# This file should pretty much include everything .gitignore'd throughout the repo
+
+# Note that the ".git" directory does not appear in this file.
+# We want that included so that Go can generate BuildInfo for the binary.
+
+# local dev configuration
+conf/testusers.go
+.env
+
+# the compiled binary
+ranger-ims-go
+
+# the default dir for storing attachments
+ims-attachments
+
+# the temp dir for `go tool air`
+air_tmp
+
+# playwright generated stuff, including any node_modules anywhere
+**/node_modules
+playwright/test-results
+playwright/playwright-report
+playwright/blob-report
+playwright/playwright/.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN go run ./bin/fetchbuilddeps/fetchbuilddeps.go
 # Copy everything in the repo, including the .git directory,
 # because we want Go to bake the repo's state into the build.
 # See https://pkg.go.dev/debug/buildinfo#BuildInfo
-COPY --exclude=playwright ./ ./
+COPY ./ ./
 
 # Build the server
 RUN CGO_ENABLED=0 GOOS=linux go build -tags noinprocessdb -o /app/ranger-ims-go


### PR DESCRIPTION
I was using COPY --exclude before, but .dockerignore is the better approach for this.