### PR TITLE
remove GIT_COMMIT_MESSAGE from amazon-ecs-render-task-definition

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -268,7 +268,6 @@ jobs:
             GIT_AUTHOR_EMAIL=${{ github.event.head_commit.author.email }}
             GIT_AUTHOR_NAME=${{ github.event.head_commit.author.name }}
             GIT_AUTHOR_USER=${{ github.event.head_commit.author.username }}
-            GIT_COMMIT_MESSAGE=${{ github.event.head_commit.message }}
             GIT_REPOSITORY=${{ github.github.repositoryUrl }}
             GIT_SHA=${{ github.sha }}
             TASK_UPDATED=${{ steps.date.outputs.date }}


### PR DESCRIPTION
this was previously failing when commit messages had multiple lines (like this commit!)