### PR TITLE
improve datetime editing experience

### DIFF
--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -644,6 +644,16 @@ export const fullDateTime = new Intl.DateTimeFormat(undefined, {
     timeZoneName: "short",
     // timeZone not specified; will use user's timezone
 });
+export const editStyleDateTime = new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    hour12: false,
+    minute: "numeric",
+    timeZoneName: "short",
+    // timeZone not specified; will use user's timezone
+});
 export function renderDate(date, type, _incident) {
     const d = Date.parse(date);
     switch (type) {
@@ -921,7 +931,14 @@ export function toggleShowHistory() {
 export async function editFromElement(element, jsonKey, transform) {
     let value = element.value;
     if (transform != null) {
-        value = transform(value);
+        try {
+            value = transform(value);
+        }
+        catch (e) {
+            controlHasError(element);
+            console.error(e);
+            return;
+        }
     }
     // Build a JSON object representing the requested edits
     const edits = {};

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -156,7 +156,10 @@ async function initIncidentPage() {
     document.getElementById("override_started_button").addEventListener("click", function (_) {
         startTimeModal.show();
         const input = document.getElementById("override_start_datetime");
-        input.value = incident?.started ?? "";
+        if (incident?.started == null) {
+            return;
+        }
+        input.value = ims.editStyleDateTime.format(new Date(incident.started));
     });
 }
 //
@@ -725,7 +728,7 @@ async function editState() {
 async function overrideStartDateTime() {
     const startInput = document.getElementById("override_start_datetime");
     await ims.editFromElement(startInput, "started", (val) => {
-        return (val ?? "").trim();
+        return new Date((val ?? "").trim()).toISOString();
     });
 }
 async function editIncidentSummary() {

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -754,6 +754,17 @@ export const fullDateTime: Intl.DateTimeFormat = new Intl.DateTimeFormat(undefin
     // timeZone not specified; will use user's timezone
 });
 
+export const editStyleDateTime: Intl.DateTimeFormat = new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    hour12: false,
+    minute: "numeric",
+    timeZoneName: "short",
+    // timeZone not specified; will use user's timezone
+});
+
 export function renderDate(date: string, type: string, _incident: any): string|number|undefined {
     const d = Date.parse(date);
     switch (type) {
@@ -1071,7 +1082,13 @@ export async function editFromElement(element: HTMLInputElement|HTMLSelectElemen
     let value: string|null = element.value;
 
     if (transform != null) {
-        value = transform(value);
+        try {
+            value = transform(value);
+        } catch (e) {
+            controlHasError(element);
+            console.error(e);
+            return;
+        }
     }
 
     // Build a JSON object representing the requested edits

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -203,7 +203,10 @@ async function initIncidentPage(): Promise<void> {
         function (_: MouseEvent): void {
             startTimeModal.show();
             const input = document.getElementById("override_start_datetime") as HTMLInputElement;
-            input.value = incident?.started??"";
+            if (incident?.started == null) {
+                return;
+            }
+            input.value = ims.editStyleDateTime.format(new Date(incident.started));
         },
     )
 }
@@ -921,7 +924,7 @@ async function editState(): Promise<void> {
 async function overrideStartDateTime(): Promise<void> {
     const startInput = document.getElementById("override_start_datetime") as HTMLInputElement;
     await ims.editFromElement(startInput, "started", (val: string|null):string=> {
-        return (val??"").trim();
+        return new Date((val??"").trim()).toISOString();
     });
 }
 


### PR DESCRIPTION
now you'll see something like this as an editable string May 31, 2025, 23:12 EDT

rather than something like
2023-05-21T00:19:58.650000128Z