### PR TITLE
centralize MariaDB TestContainers code, remove NoOp DB usage

### DIFF
--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -93,7 +93,7 @@ func TestEventFromFormValue(t *testing.T) {
 	db, err := sql.Open("noop", "")
 	require.NoError(t, err)
 	req = &http.Request{URL: u}
-	_, errHTTP = eventFromFormValue(req, store.New(db, imsdb.New()))
+	_, errHTTP = eventFromFormValue(req, store.NewDBQ(db, imsdb.New()))
 	require.NotNil(t, errHTTP)
 	require.Equal(t, http.StatusInternalServerError, errHTTP.Code)
 	require.Contains(t, errHTTP.ResponseMessage, "Failed to get event")
@@ -102,7 +102,7 @@ func TestEventFromFormValue(t *testing.T) {
 func TestGetEvent(t *testing.T) {
 	t.Parallel()
 	dbNoop, err := sql.Open("noop", "")
-	db := store.New(dbNoop, imsdb.New())
+	db := store.NewDBQ(dbNoop, imsdb.New())
 	require.NoError(t, err)
 
 	// no eventName provided

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -137,6 +137,7 @@ func runServerInternal(
 `)
 
 	listeningAddr <- addr
+	close(listeningAddr)
 	// The goroutine will hang here until the NotifyContext is done
 	<-notifyCtx.Done()
 	stop()

--- a/directory/clubhousedb.go
+++ b/directory/clubhousedb.go
@@ -37,6 +37,11 @@ func MariaDB(ctx context.Context, directoryCfg conf.Directory) (*sql.DB, error) 
 	var chDBCfg conf.ClubhouseDB
 	var err error
 	switch directoryCfg.Directory {
+	case conf.DirectoryTypeNoOp:
+		// This is a DB that does nothing and returns nothing on querying.
+		// It's really only useful as a stand-in for testing.
+		slog.Info("Using NoOp DB")
+		return sql.Open("noop", "")
 	case conf.DirectoryTypeFake:
 		chDBCfg, err = startFakeDB(ctx, directoryCfg.FakeDB)
 		if err != nil {

--- a/directory/clubhousedb.go
+++ b/directory/clubhousedb.go
@@ -37,11 +37,6 @@ func MariaDB(ctx context.Context, directoryCfg conf.Directory) (*sql.DB, error) 
 	var chDBCfg conf.ClubhouseDB
 	var err error
 	switch directoryCfg.Directory {
-	case conf.DirectoryTypeNoOp:
-		// This is a DB that does nothing and returns nothing on querying.
-		// It's really only useful as a stand-in for testing.
-		slog.Info("Using NoOp DB")
-		return sql.Open("noop", "")
 	case conf.DirectoryTypeFake:
 		chDBCfg, err = startFakeDB(ctx, directoryCfg.FakeDB)
 		if err != nil {
@@ -106,12 +101,7 @@ type DBQ struct {
 
 var _ chqueries.Querier = (*DBQ)(nil)
 
-// NewMariaDBQ creates a DBQ that uses a standard MariaDB Clubhouse database.
-func NewMariaDBQ(db *sql.DB, cacheTTL time.Duration) *DBQ {
-	return newDBQ(db, chqueries.New(), cacheTTL)
-}
-
-func newDBQ(db *sql.DB, querier chqueries.Querier, cacheTTL time.Duration) *DBQ {
+func NewDBQ(db *sql.DB, querier chqueries.Querier, cacheTTL time.Duration) *DBQ {
 	dbq := &DBQ{
 		DB: db,
 		q:  querier,

--- a/directory/clubhousedb_test.go
+++ b/directory/clubhousedb_test.go
@@ -22,10 +22,9 @@ import (
 	"fmt"
 	"github.com/burningmantech/ranger-ims-go/conf"
 	"github.com/burningmantech/ranger-ims-go/directory"
-	"github.com/burningmantech/ranger-ims-go/store"
+	"github.com/burningmantech/ranger-ims-go/lib/testctr"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"io"
 	"testing"
 )
@@ -62,27 +61,10 @@ func shut(t *testing.T, s io.Closer) {
 func newEmptyDB(t *testing.T, ctx context.Context, database, username, password string) (testcontainers.Container, *sql.DB) {
 	t.Helper()
 
-	ctr, err := testcontainers.GenericContainer(ctx,
-		testcontainers.GenericContainerRequest{
-			ContainerRequest: testcontainers.ContainerRequest{
-				Image:        store.MariaDBDockerImage,
-				ExposedPorts: []string{"3306/tcp"},
-				WaitingFor:   wait.ForLog("port: 3306  mariadb.org binary distribution"),
-				Env: map[string]string{
-					"MARIADB_RANDOM_ROOT_PASSWORD": "true",
-					"MARIADB_DATABASE":             database,
-					"MARIADB_USER":                 username,
-					"MARIADB_PASSWORD":             password,
-				},
-			},
-			Started: true,
-		},
-	)
-	testcontainers.CleanupContainer(t, ctr)
+	ctr, cleanup, dbHostPort, err := testctr.MariaDBContainer(ctx, database, username, password)
+	t.Cleanup(cleanup)
 	require.NoError(t, err)
-	port, err := ctr.MappedPort(ctx, "3306/tcp")
-	require.NoError(t, err)
-	dbHostPort := int32(port.Int())
+
 	db, err := directory.MariaDB(ctx,
 		conf.Directory{
 			ClubhouseDB: conf.ClubhouseDB{

--- a/lib/testctr/mariadb.go
+++ b/lib/testctr/mariadb.go
@@ -1,0 +1,76 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package testctr
+
+import (
+	"context"
+	"errors"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"log/slog"
+)
+
+const (
+	MariaDBVersion     = "10.5.27"
+	MariaDBDockerImage = "mariadb:" + MariaDBVersion
+)
+
+// MariaDBContainer creates and runs a MariaDB TestContainer.
+//
+// If there is an error on startup, this function will terminate the TestContainer before returning.
+// After calling this function, the caller must be sure to defer cleanup, e.g. by `t.Cleanup(cleanup)`.
+func MariaDBContainer(ctx context.Context, database, username, password string) (
+	ctr testcontainers.Container,
+	cleanup func(),
+	port int32,
+	err error,
+) {
+	var errs []error
+	ctr, err = testcontainers.GenericContainer(
+		ctx,
+		testcontainers.GenericContainerRequest{
+			ContainerRequest: testcontainers.ContainerRequest{
+				Image:        MariaDBDockerImage,
+				ExposedPorts: []string{"3306/tcp"},
+				WaitingFor:   wait.ForLog("port: 3306  mariadb.org binary distribution"),
+				Env: map[string]string{
+					"MARIADB_RANDOM_ROOT_PASSWORD": "true",
+					"MARIADB_DATABASE":             database,
+					"MARIADB_USER":                 username,
+					"MARIADB_PASSWORD":             password,
+				},
+			},
+			Started: true,
+		},
+	)
+	cleanup = func() {
+		err := ctr.Terminate(ctx)
+		if err != nil {
+			slog.Error("Failed to terminate container", "error", err)
+		}
+	}
+	errs = append(errs, err)
+	natPort, err := ctr.MappedPort(ctx, "3306/tcp")
+	errs = append(errs, err)
+	dbHostPort := int32(natPort.Int())
+
+	err = errors.Join(errs...)
+	if err != nil {
+		cleanup()
+	}
+	return ctr, cleanup, dbHostPort, errors.Join(errs...)
+}

--- a/store/dbquerier.go
+++ b/store/dbquerier.go
@@ -31,7 +31,7 @@ type DBQ struct {
 	q imsdb.Querier
 }
 
-func New(sqlDB *sql.DB, querier imsdb.Querier) *DBQ {
+func NewDBQ(sqlDB *sql.DB, querier imsdb.Querier) *DBQ {
 	return &DBQ{
 		DB: sqlDB,
 		q:  querier,

--- a/store/migrate.go
+++ b/store/migrate.go
@@ -52,7 +52,7 @@ func repoSchemaVersion() (schemaVersion, error) {
 }
 
 func dbSchemaVersion(ctx context.Context, db *sql.DB) (schemaVersion, error) {
-	dbq := New(db, imsdb.New())
+	dbq := NewDBQ(db, imsdb.New())
 	result, err := dbq.SchemaVersion(ctx, db)
 	if err == nil {
 		return schemaVersion(result), nil

--- a/store/store.go
+++ b/store/store.go
@@ -28,11 +28,6 @@ import (
 	"log/slog"
 )
 
-const (
-	MariaDBVersion     = "10.5.27"
-	MariaDBDockerImage = "mariadb:" + MariaDBVersion
-)
-
 //go:embed schema/current.sql
 var CurrentSchema string
 
@@ -43,11 +38,6 @@ func SqlDB(ctx context.Context, dbStoreCfg conf.DBStore, migrateDB bool) (*sql.D
 	var mariaCfg conf.DBStoreMaria
 	var err error
 	switch dbStoreCfg.Type {
-	case conf.DBStoreTypeNoOp:
-		// This is a DB that does nothing and returns nothing on querying.
-		// It's really only useful as a stand-in for testing.
-		slog.Info("Using NoOp DB")
-		return sql.Open("noop", "")
 	case conf.DBStoreTypeFake:
 		mariaCfg, err = startFakeDB(ctx, dbStoreCfg.Fake)
 		if err != nil {


### PR DESCRIPTION
this removes a bunch of duplicate code and gets rid of NoOp DB use in serve_test