### PR TITLE
stop using NoOp DB in docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,8 @@ COPY --from=build /app/ranger-ims-go /opt/ims/bin/ims
 # Docker-specific default configuration
 ENV IMS_HOSTNAME="0.0.0.0"
 ENV IMS_PORT="80"
-ENV IMS_DB_STORE_TYPE="MariaDB"
-ENV IMS_DIRECTORY="ClubhouseDB"
+ENV IMS_DB_STORE_TYPE="mariadb"
+ENV IMS_DIRECTORY="clubhousedb"
 
 # Use a non-root user to run the server
 USER daemon:daemon

--- a/directory/clubhousedb.go
+++ b/directory/clubhousedb.go
@@ -37,11 +37,6 @@ func MariaDB(ctx context.Context, directoryCfg conf.Directory) (*sql.DB, error) 
 	var chDBCfg conf.ClubhouseDB
 	var err error
 	switch directoryCfg.Directory {
-	case conf.DirectoryTypeNoOp:
-		// This is a DB that does nothing and returns nothing on querying.
-		// It's really only useful as a stand-in for testing.
-		slog.Info("Using NoOp DB")
-		return sql.Open("noop", "")
 	case conf.DirectoryTypeFake:
 		chDBCfg, err = startFakeDB(ctx, directoryCfg.FakeDB)
 		if err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,21 +5,20 @@ services:
     image: "ranger-ims-go:${IMAGE_TAG:-latest}"
     container_name: "ranger-ims-go"
     environment:
-      # This is a totally empty user directory, so no one will be able to log in.
-      # We can't use a ClubhouseDB directory here because CI doesn't have one to
-      # access, and we can't use a Fake directory, because CI builds of IMS don't
-      # compile the fake MySQL server into the program. If people want to use
-      # docker compose for local dev, we should make a separate Dockerfile and
-      # docker-compose.yml for that.
-      IMS_DIRECTORY: "NoOp"
       IMS_DB_HOST_NAME: "ranger-ims-database"
       IMS_DB_PORT: "${IMS_DB_PORT:-3306}"
       IMS_DB_USER_NAME: "${IMS_DB_USER_NAME:-ims}"
       IMS_DB_PASSWORD: "${IMS_DB_PASSWORD:-ims}"
+      IMS_DMS_HOSTNAME: "ranger-clubhouse-database:3306"
+      IMS_DMS_DATABASE: "${IMS_DMS_DATABASE:-rangers}"
+      IMS_DMS_USERNAME: "${IMS_DMS_USERNAME:-clubhouseuser}"
+      IMS_DMS_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
     ports:
       - "${IMS_PORT:-8080}:80"
     depends_on:
       database:
+        condition: service_healthy
+      clubhouse-database:
         condition: service_healthy
     healthcheck:
       test: [ "CMD", "/opt/ims/bin/ims", "healthcheck", "--server_url", "http://app:80" ]
@@ -39,6 +38,26 @@ services:
       - "${IMS_DB_PORT:-3306}"
     volumes:
       - ./.docker/mysql/data/:/var/lib/mysql
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
+  # Be aware that this database isn't seeded with any data, so while the IMS server
+  # will successfully start up, there won't be any users with whom to log in.
+  clubhouse-database:
+    image: "mariadb:10.5.27"
+    container_name: "ranger-clubhouse-database"
+    environment:
+      MARIADB_DATABASE: "${IMS_DMS_DATABASE:-rangers}"
+      MARIADB_USER: "${IMS_DMS_USERNAME:-clubhouseuser}"
+      MARIADB_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
+      MARIADB_RANDOM_ROOT_PASSWORD: "yes"
+    ports:
+      - "3306"
+    volumes:
+      - ./.docker/mysql/data-ch/:/var/lib/mysql
     healthcheck:
       test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
       interval: 1s

--- a/lib/redact/redact.go
+++ b/lib/redact/redact.go
@@ -95,15 +95,21 @@ func writeSliceFields(w *bytesBuffer, fieldName string, fieldVal reflect.Value, 
 }
 
 func writeStructField(w *bytesBuffer, fieldName string, fieldVal reflect.Value, redact bool, indent string) {
-	w.fprintf("%v%v\n", indent, fieldName)
 	// If this field is redacted, we just print that out.
-	// If it's not redacted, we do a recursive call to print the field's own fields.
+	// If it's a nonredacted zero-valued struct, we print out that fact.
+	// Otherwise, we do a recursive call to print the field's own fields.
 	if redact {
+		w.fprintf("%v%v\n", indent, fieldName)
 		w.fprintf("%v🤐🤐🤐🤐🤐\n", indent+nestIndent)
-	} else {
-		x1 := reflect.ValueOf(fieldVal.Interface())
-		toBuffer(w, x1, indent+nestIndent)
+		return
 	}
+	if fieldVal.IsZero() {
+		w.fprintf("%v%v is zero value\n", indent, fieldName)
+		return
+	}
+	w.fprintf("%v%v\n", indent, fieldName)
+	x1 := reflect.ValueOf(fieldVal.Interface())
+	toBuffer(w, x1, indent+nestIndent)
 }
 
 type bytesBuffer struct {

--- a/lib/redact/redact_test.go
+++ b/lib/redact/redact_test.go
@@ -35,6 +35,7 @@ type ExampleType struct {
 	MoreSecrets []Secret `redact:"true"`
 	Dir1        *os.Root
 	Dir2        *os.Root
+	SomeStruct  struct{}
 }
 
 type Secret struct {
@@ -74,6 +75,7 @@ Secrets[1]
 MoreSecrets[]: [empty]
 Dir1 = <nil>
 Dir2 = %v
+SomeStruct is zero value
 `, root.Name())
 	b := redact.ToBytes(&e)
 	assert.Equal(t, strings.TrimSpace(expected), strings.TrimSpace(string(b)))


### PR DESCRIPTION
This was a silly standin for a real database. We should just start up a separate MariaDB container instead to fill the role of Clubhouse's database.

This PR also (unrelatedly) improves the config-printing redactor's handling of zero values