### PR TITLE
focus on add field after ranger/incident type is added

### DIFF
--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -813,6 +813,7 @@ async function addRanger() {
     addRanger.value = "";
     addRanger.disabled = false;
     ims.controlHasSuccess(addRanger, 1000);
+    addRanger.focus();
 }
 async function addIncidentType() {
     const addType = document.getElementById("incident_type_add");
@@ -852,6 +853,7 @@ async function addIncidentType() {
     addType.value = "";
     addType.disabled = false;
     ims.controlHasSuccess(addType, 1000);
+    addType.focus();
 }
 async function detachFieldReport(sender) {
     const parent = sender.parentElement;

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1041,6 +1041,7 @@ async function addRanger(): Promise<void> {
     addRanger.value = "";
     addRanger.disabled = false;
     ims.controlHasSuccess(addRanger, 1000);
+    addRanger.focus();
 }
 
 
@@ -1087,6 +1088,7 @@ async function addIncidentType(): Promise<void> {
     addType.value = "";
     addType.disabled = false;
     ims.controlHasSuccess(addType, 1000);
+    addType.focus();
 }
 
 


### PR DESCRIPTION
This lets a user do "abraham", enter, "tool", enter, etc. As things were, focus would be lost after hitting enter.