### PR TITLE
get GetEventAccesses to show permissions for each rule

### DIFF
--- a/api/integration/event_test.go
+++ b/api/integration/event_test.go
@@ -60,6 +60,7 @@ func TestGetAndEditEvent(t *testing.T) {
 		Readers:   []imsjson.AccessRule{},
 		Reporters: []imsjson.AccessRule{},
 	}
+	expectedAccessResult.Writers[0].DebugInfo.MatchesUsers = []string{userAdminHandle}
 	accessResult, httpResp := apisAdmin.getAccess(ctx)
 	require.Equal(t, http.StatusOK, httpResp.StatusCode)
 	require.Equal(t, expectedAccessResult, accessResult[testEventName])

--- a/api/integration/main_test.go
+++ b/api/integration/main_test.go
@@ -116,7 +116,7 @@ func setup(ctx context.Context, tempDir string) {
 		chqueries.New(),
 		shared.cfg.Directory.InMemoryCacheTTL,
 	)
-	shared.userStore = directory.NewUserStore(clubhouseDBQ)
+	shared.userStore = directory.NewUserStore(clubhouseDBQ, shared.cfg.Directory.InMemoryCacheTTL)
 
 	ctr, cleanup, dbHostPort, err := testctr.MariaDBContainer(
 		ctx,

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -83,7 +83,7 @@ func runServerInternal(
 	clubhouseDB, err := directory.MariaDB(ctx, imsCfg.Directory)
 	must(err)
 	clubhouseDBQ := directory.NewDBQ(clubhouseDB, chqueries.New(), imsCfg.Directory.InMemoryCacheTTL)
-	userStore := directory.NewUserStore(clubhouseDBQ)
+	userStore := directory.NewUserStore(clubhouseDBQ, imsCfg.Directory.InMemoryCacheTTL)
 
 	var s3Client *attachment.S3Client
 	if imsCfg.AttachmentsStore.Type == conf.AttachmentsStoreS3 {

--- a/directory/directory.go
+++ b/directory/directory.go
@@ -20,126 +20,154 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/burningmantech/ranger-ims-go/directory/clubhousedb"
 	imsjson "github.com/burningmantech/ranger-ims-go/json"
-	"slices"
+	"github.com/burningmantech/ranger-ims-go/lib/cache"
+	"time"
 )
 
 type UserStore struct {
-	DBQ *DBQ
+	DBQ           *DBQ
+	userCache     *cache.InMemory[map[int64]*User]
+	positionCache *cache.InMemory[map[int64]string]
+	teamCache     *cache.InMemory[map[int64]string]
 }
 
-func NewUserStore(dbq *DBQ) *UserStore {
-	return &UserStore{DBQ: dbq}
+type User struct {
+	Person        clubhousedb.RangersByIdRow
+	PositionIDs   []int64
+	PositionNames []string
+	TeamIDs       []int64
+	TeamNames     []string
+}
+
+func NewUserStore(dbq *DBQ, cacheTTL time.Duration) *UserStore {
+	us := &UserStore{
+		DBQ: dbq,
+	}
+	us.userCache = cache.New(
+		cacheTTL,
+		us.refreshUserCache,
+	)
+	us.positionCache = cache.New(
+		cacheTTL,
+		us.refreshPositionCache,
+	)
+	us.teamCache = cache.New(
+		cacheTTL,
+		us.refreshTeamCache,
+	)
+
+	return us
+}
+
+func (store *UserStore) GetAllUsers(ctx context.Context) (map[int64]*User, error) {
+	users, err := store.userCache.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("[userCache.Get] %w", err)
+	}
+	return *users, nil
 }
 
 func (store *UserStore) GetRangers(ctx context.Context) ([]imsjson.Person, error) {
-	results, err := store.DBQ.RangersById(ctx, store.DBQ)
+	usersPtr, err := store.userCache.Get(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("[RangersById] %w", err)
+		return nil, fmt.Errorf("[userCache.Get] %w", err)
 	}
-	response := make([]imsjson.Person, 0, len(results))
-	for _, r := range results {
+	users := *usersPtr
+
+	response := make([]imsjson.Person, 0, len(users))
+	for _, r := range users {
 		response = append(response, imsjson.Person{
-			Handle:      r.Callsign,
-			Email:       r.Email.String,
-			Password:    r.Password.String,
-			Status:      string(r.Status),
-			Onsite:      r.OnSite,
-			DirectoryID: r.ID,
+			Handle:      r.Person.Callsign,
+			Email:       r.Person.Email.String,
+			Password:    r.Person.Password.String,
+			Status:      string(r.Person.Status),
+			Onsite:      r.Person.OnSite,
+			DirectoryID: r.Person.ID,
 		})
 	}
 
 	return response, nil
 }
 
-func (store *UserStore) GetUserPositionsTeams(ctx context.Context, userID int64) (positions, teams []string, err error) {
-	var errs []error
-
-	teamRows, err := store.DBQ.Teams(ctx, store.DBQ)
-	errs = append(errs, err)
-	positionRows, err := store.DBQ.Positions(ctx, store.DBQ)
-	errs = append(errs, err)
-	personTeams, err := store.DBQ.PersonTeams(ctx, store.DBQ)
-	errs = append(errs, err)
-	personPositions, err := store.DBQ.PersonPositions(ctx, store.DBQ)
-	errs = append(errs, err)
-
-	if err := errors.Join(errs...); err != nil {
-		return nil, nil, fmt.Errorf("[Teams,Positions,PersonTeams,PersonPositions] %w", err)
-	}
-
-	var foundPositions []int64
-	var foundPositionNames []string
-	for _, pp := range personPositions {
-		if pp.PersonID == userID {
-			foundPositions = append(foundPositions, pp.PositionID)
-		}
-	}
-	for _, pos := range positionRows {
-		if slices.Contains(foundPositions, pos.ID) {
-			foundPositionNames = append(foundPositionNames, pos.Title)
-		}
-	}
-
-	var foundTeams []int64
-	var foundTeamNames []string
-	for _, pt := range personTeams {
-		if pt.PersonID == userID {
-			foundTeams = append(foundTeams, pt.TeamID)
-		}
-	}
-	for _, team := range teamRows {
-		if slices.Contains(foundTeams, team.ID) {
-			foundTeamNames = append(foundTeamNames, team.Title)
-		}
-	}
-	return foundPositionNames, foundTeamNames, nil
-}
-
-func (store *UserStore) GetUserPositionsTeamsIDs(ctx context.Context, userID int64) (positions, teams []int64, err error) {
-	var errs []error
-
-	personTeams, err := store.DBQ.PersonTeams(ctx, store.DBQ)
-	errs = append(errs, err)
-	personPositions, err := store.DBQ.PersonPositions(ctx, store.DBQ)
-	errs = append(errs, err)
-
-	if err := errors.Join(errs...); err != nil {
-		return nil, nil, fmt.Errorf("[PersonTeams,PersonPositions] %w", err)
-	}
-
-	var foundPositions []int64
-	for _, pp := range personPositions {
-		if pp.PersonID == userID {
-			foundPositions = append(foundPositions, pp.PositionID)
-		}
-	}
-
-	var foundTeams []int64
-	for _, pt := range personTeams {
-		if pt.PersonID == userID {
-			foundTeams = append(foundTeams, pt.TeamID)
-		}
-	}
-	return foundPositions, foundTeams, nil
-}
-
 func (store *UserStore) GetPositionsAndTeams(ctx context.Context) (positions, teams map[int64]string, err error) {
+	var errs []error
+	posMap, err := store.positionCache.Get(ctx)
+	errs = append(errs, err)
+	teamMap, err := store.teamCache.Get(ctx)
+	errs = append(errs, err)
+	if errors.Join(errs...) != nil {
+		return nil, nil, fmt.Errorf("[GetPositionsAndTeams] %w", err)
+	}
+	return *posMap, *teamMap, nil
+}
+
+func (store *UserStore) refreshUserCache(ctx context.Context) (map[int64]*User, error) {
+	var errs []error
+	rangers, err := store.DBQ.RangersById(ctx, store.DBQ)
+	errs = append(errs, err)
+	teamRows, err := store.DBQ.Teams(ctx, store.DBQ)
+	errs = append(errs, err)
+	positionRows, err := store.DBQ.Positions(ctx, store.DBQ)
+	errs = append(errs, err)
+	personTeams, err := store.DBQ.PersonTeams(ctx, store.DBQ)
+	errs = append(errs, err)
+	personPositions, err := store.DBQ.PersonPositions(ctx, store.DBQ)
+	errs = append(errs, err)
+	if err := errors.Join(errs...); err != nil {
+		return nil, fmt.Errorf("[Teams,Positions,PersonTeams,PersonPositions] %w", err)
+	}
+
+	m := make(map[int64]*User, len(rangers))
+	for _, ranger := range rangers {
+		m[ranger.ID] = &User{Person: ranger}
+	}
+	positions := make(map[int64]string, len(positionRows))
+	for _, positionRow := range positionRows {
+		positions[positionRow.ID] = positionRow.Title
+	}
+	teams := make(map[int64]string, len(teamRows))
+	for _, teamRow := range teamRows {
+		teams[teamRow.ID] = teamRow.Title
+	}
+	for _, pp := range personPositions {
+		if _, ok := m[pp.PersonID]; ok {
+			person := m[pp.PersonID]
+			person.PositionIDs = append(person.PositionIDs, pp.PositionID)
+			person.PositionNames = append(person.PositionNames, positions[pp.PositionID])
+		}
+	}
+	for _, pt := range personTeams {
+		if _, ok := m[pt.PersonID]; ok {
+			person := m[pt.PersonID]
+			person.TeamIDs = append(person.TeamIDs, pt.TeamID)
+			person.TeamNames = append(person.TeamNames, teams[pt.TeamID])
+		}
+	}
+	return m, nil
+}
+
+func (store *UserStore) refreshPositionCache(ctx context.Context) (map[int64]string, error) {
 	positionRows, err := store.DBQ.Positions(ctx, store.DBQ)
 	if err != nil {
-		return nil, nil, fmt.Errorf("[Positions]: %w", err)
+		return nil, fmt.Errorf("[Positions]: %w", err)
 	}
-	teamRows, err := store.DBQ.Teams(ctx, store.DBQ)
-	if err != nil {
-		return nil, nil, fmt.Errorf("[Teams]: %w", err)
-	}
-	positions = make(map[int64]string, len(positionRows))
-	teams = make(map[int64]string, len(teamRows))
-	for _, row := range teamRows {
-		teams[row.ID] = row.Title
-	}
+	positions := make(map[int64]string, len(positionRows))
 	for _, row := range positionRows {
 		positions[row.ID] = row.Title
 	}
-	return positions, teams, nil
+	return positions, nil
+}
+
+func (store *UserStore) refreshTeamCache(ctx context.Context) (map[int64]string, error) {
+	teamRows, err := store.DBQ.Teams(ctx, store.DBQ)
+	if err != nil {
+		return nil, fmt.Errorf("[Teams]: %w", err)
+	}
+	teams := make(map[int64]string, len(teamRows))
+	for _, row := range teamRows {
+		teams[row.ID] = row.Title
+	}
+	return teams, nil
 }

--- a/directory/schema/current.sql
+++ b/directory/schema/current.sql
@@ -18,8 +18,7 @@ CREATE TABLE `person` (
     `on_site` tinyint(1) NOT NULL DEFAULT 0,
     `vehicle_blacklisted` tinyint(1) NOT NULL DEFAULT 0,
     `date_verified` date DEFAULT NULL,
-    -- TODO: the actual Clubhouse DB has a varchar(64) here. It's varchar(128) to support upcoming argon2id keys.
-    `password` varchar(128) DEFAULT NULL,
+    `password` varchar(255) DEFAULT NULL,
     `created_at` datetime DEFAULT current_timestamp(),
     `has_note_on_file` tinyint(1) NOT NULL DEFAULT 0,
     `callsign_approved` tinyint(1) NOT NULL DEFAULT 0,

--- a/json/eventaccess.go
+++ b/json/eventaccess.go
@@ -21,6 +21,12 @@ type EventsAccess map[string]EventAccess
 type AccessRule struct {
 	Expression string `json:"expression"`
 	Validity   string `json:"validity"`
+
+	DebugInfo struct {
+		MatchesUsers    []string `json:"matches_users,omitempty"`
+		MatchesAllUsers bool     `json:"matches_all_users,omitempty"`
+		MatchesNoOne    bool     `json:"matches_no_one,omitempty"`
+	} `json:"debug_info"`
 }
 
 type EventAccess struct {

--- a/lib/authz/permission.go
+++ b/lib/authz/permission.go
@@ -154,33 +154,43 @@ func ManyEventPermissions(
 	for eventID, accesses := range accessByEvent {
 		eventPermissions[eventID] = EventNoPermissions
 		for _, ea := range accesses {
-			matchExpr := false
-			if ea.Expression == "*" {
-				matchExpr = true
-			}
-			if strings.HasPrefix(ea.Expression, "person:") &&
-				strings.TrimPrefix(ea.Expression, "person:") == handle {
-				matchExpr = true
-			}
-			if strings.HasPrefix(ea.Expression, "position:") &&
-				slices.Contains(positions, strings.TrimPrefix(ea.Expression, "position:")) {
-				matchExpr = true
-			}
-			if strings.HasPrefix(ea.Expression, "team:") &&
-				slices.Contains(teams, strings.TrimPrefix(ea.Expression, "team:")) {
-				matchExpr = true
-			}
-			matchValidity := false
-			if ea.Validity == imsdb.EventAccessValidityAlways {
-				matchValidity = true
-			}
-			if ea.Validity == imsdb.EventAccessValidityOnsite && onsite {
-				matchValidity = true
-			}
-			if matchExpr && matchValidity {
+			if PersonMatches(ea, handle, positions, teams, onsite) {
 				eventPermissions[eventID] |= RolesToEventPerms[modeToRole[ea.Mode]]
 			}
 		}
 	}
 	return eventPermissions, globalPermissions
+}
+
+func PersonMatches(
+	ea imsdb.EventAccess,
+	handle string,
+	positions []string,
+	teams []string,
+	onsite bool,
+) bool {
+	matchExpr := false
+	if ea.Expression == "*" {
+		matchExpr = true
+	}
+	if strings.HasPrefix(ea.Expression, "person:") &&
+		strings.TrimPrefix(ea.Expression, "person:") == handle {
+		matchExpr = true
+	}
+	if strings.HasPrefix(ea.Expression, "position:") &&
+		slices.Contains(positions, strings.TrimPrefix(ea.Expression, "position:")) {
+		matchExpr = true
+	}
+	if strings.HasPrefix(ea.Expression, "team:") &&
+		slices.Contains(teams, strings.TrimPrefix(ea.Expression, "team:")) {
+		matchExpr = true
+	}
+	matchValidity := false
+	if ea.Validity == imsdb.EventAccessValidityAlways {
+		matchValidity = true
+	}
+	if ea.Validity == imsdb.EventAccessValidityOnsite && onsite {
+		matchValidity = true
+	}
+	return matchExpr && matchValidity
 }

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -785,7 +785,9 @@ async function overrideStartDate() {
 function newDateTimeVal(dateInput, timeInput, localTz) {
     const val = `${dateInput.trim()} ${timeInput.trim()} ${localTz}`;
     const date = new Date(val);
-    if (date.getFullYear() < 1980 || date.getFullYear() > 2100) {
+    // Just do a check on the year to prevent obvious mistakes.
+    // This will break in year 2099. Feel free to update maximum year.
+    if (date.getFullYear() < 2000 || date.getFullYear() > 2099) {
         throw new Error(`year seems incorrect: ${date.getFullYear()}`);
     }
     return date.toISOString();

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -998,7 +998,9 @@ async function overrideStartDate(): Promise<void> {
 function newDateTimeVal(dateInput: string, timeInput: string, localTz: string): string {
     const val = `${dateInput.trim()} ${timeInput.trim()} ${localTz}`;
     const date = new Date(val);
-    if (date.getFullYear() < 1980 || date.getFullYear() > 2100) {
+    // Just do a check on the year to prevent obvious mistakes.
+    // This will break in year 2099. Feel free to update maximum year.
+    if (date.getFullYear() < 2000 || date.getFullYear() > 2099) {
         throw new Error(`year seems incorrect: ${date.getFullYear()}`);
     }
     return date.toISOString();


### PR DESCRIPTION
Mostly I wanted to make it easier for IMS admins to see what each rule ends up doing.

This involved a bunch of refactoring that leaves UserStore in better shape than it was in. Now the caching of users happens at a higher level, with positions and teams merged into that cache.