### PR TITLE
fix redirect when user goes to nonexistent event

### DIFF
--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -332,7 +332,9 @@ export async function commonPageInit() {
     return { authInfo: authInfo, eventDatas: eds };
 }
 export async function redirectToLogin() {
+    // This clears the refresh cookie
     await fetch(url_logout);
+    clearAccessToken();
     console.log("Logged out. Redirecting to login page");
     window.location.replace(`${url_login}?o=${encodeURIComponent(window.location.pathname)}`);
 }

--- a/web/static/root.js
+++ b/web/static/root.js
@@ -24,6 +24,8 @@ initRootPage();
 async function initRootPage() {
     const params = new URLSearchParams(window.location.search);
     if (params.get("logout") != null) {
+        // this clears the refresh cookie
+        await fetch(url_logout);
         ims.clearAccessToken();
         window.history.replaceState(null, "", url_app);
     }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -377,7 +377,9 @@ export async function commonPageInit(): Promise<PageInitResult> {
 }
 
 export async function redirectToLogin(): Promise<void> {
+    // This clears the refresh cookie
     await fetch(url_logout);
+    clearAccessToken();
     console.log("Logged out. Redirecting to login page")
     window.location.replace(`${url_login}?o=${encodeURIComponent(window.location.pathname)}`);
 }

--- a/web/typescript/root.ts
+++ b/web/typescript/root.ts
@@ -27,6 +27,8 @@ initRootPage();
 async function initRootPage(): Promise<void> {
     const params = new URLSearchParams(window.location.search);
     if (params.get("logout") != null) {
+        // this clears the refresh cookie
+        await fetch(url_logout);
         ims.clearAccessToken();
         window.history.replaceState(null, "", url_app);
     }


### PR DESCRIPTION
previously when you went to the incidents page for a nonexistent event name, you'd get logged out. It's cleaner to stay on that incidents page, but to show a "not authorized" message instead (I think that's what the prior IMS app did).