### PR TITLE
use whole-row <a> links on Incidents and Field Reports tables

### DIFF
--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -184,7 +184,9 @@ function frInitDataTables() {
                 "className": "field_report_incident text-center",
                 "data": "incident",
                 "defaultContent": "-",
-                "render": ims.renderIncidentNumber,
+                // don't use renderIncidentNumber, as that includes an <a> tag that messes
+                // with the whole-row linking from renderFieldReportNumber.
+                "render": ims.renderNumber,
                 "responsivePriority": 3,
             },
         ],
@@ -193,26 +195,8 @@ function frInitDataTables() {
             [1, "dsc"],
         ],
         "createdRow": function (row, fieldReport, _index) {
-            const openLink = function (e) {
-                // If the user clicked on a link, then let them access that link without the JS below.
-                if (e.target?.constructor?.name === "HTMLAnchorElement") {
-                    return;
-                }
-                const isLeftClick = e.type === "click";
-                const isMiddleClick = e.type === "auxclick" && e.button === 1;
-                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
-                // Left click while not holding a modifier key: open in the same tab
-                if (isLeftClick && !holdingModifier) {
-                    window.location.href = `${ims.urlReplace(url_viewFieldReports)}/${fieldReport.number}`;
-                }
-                // Left click while holding modifier key or middle click: open in a new tab
-                if (isMiddleClick || (isLeftClick && holdingModifier)) {
-                    window.open(`${ims.urlReplace(url_viewFieldReports)}/${fieldReport.number}`, "Field_Report:" + fieldReport.number);
-                    return;
-                }
-            };
-            row.addEventListener("click", openLink);
-            row.addEventListener("auxclick", openLink);
+            // Necessary to allow the stretched-link to work
+            row.classList.add("position-relative");
             row.getElementsByClassName("field_report_created")[0]
                 .setAttribute("title", ims.fullDateTime.format(Date.parse(fieldReport.created)));
         },

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -581,9 +581,8 @@ export function renderIncidentNumber(incidentNumber, type, _incident) {
                 return null;
             }
             const dest = urlReplace(url_viewIncidentNumber).replace("<number>", incidentNumber.toString());
-            return `<a href="${dest}">${incidentNumber}</a>`;
+            return `<a class="stretched-link" href="${dest}">${incidentNumber}</a>`;
         case "filter":
-            return incidentNumber;
         case "type":
         case "sort":
             return incidentNumber;
@@ -597,12 +596,22 @@ export function renderFieldReportNumber(fieldReportNumber, type, _fieldReport) {
                 return null;
             }
             const dest = urlReplace(url_viewFieldReportNumber).replace("<number>", fieldReportNumber.toString());
-            return `<a href="${dest}">${fieldReportNumber}</a>`;
+            return `<a class="stretched-link" href="${dest}">${fieldReportNumber}</a>`;
         case "filter":
-            return fieldReportNumber;
         case "type":
         case "sort":
             return fieldReportNumber;
+    }
+    return undefined;
+}
+export function renderNumber(num, type, _obj) {
+    switch (type) {
+        case "display":
+            return num?.toString() ?? null;
+        case "filter":
+        case "type":
+        case "sort":
+            return num;
     }
     return undefined;
 }

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -309,26 +309,8 @@ function initDataTables(tablePrereqs) {
             [0, "dsc"],
         ],
         "createdRow": function (row, incident, _index) {
-            const openLink = function (e) {
-                // If the user clicked on a link, then let them access that link without the JS below.
-                if (e.target?.constructor?.name === "HTMLAnchorElement") {
-                    return;
-                }
-                const isLeftClick = e.type === "click";
-                const isMiddleClick = e.type === "auxclick" && e.button === 1;
-                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
-                // Left click while not holding a modifier key: open in the same tab
-                if (isLeftClick && !holdingModifier) {
-                    window.location.href = `${ims.urlReplace(url_viewIncidents)}/${incident.number}`;
-                }
-                // Left click while holding modifier key or middle click: open in a new tab
-                if (isMiddleClick || (isLeftClick && holdingModifier)) {
-                    window.open(`${ims.urlReplace(url_viewIncidents)}/${incident.number}`, "Incident:" + ims.pathIds.eventID + "#" + incident.number);
-                    return;
-                }
-            };
-            row.addEventListener("click", openLink);
-            row.addEventListener("auxclick", openLink);
+            // Necessary to allow the stretched-link to work
+            row.classList.add("position-relative");
             row.getElementsByClassName("incident_started")[0]
                 .setAttribute("title", ims.fullDateTime.format(Date.parse(incident.started)));
             row.getElementsByClassName("incident_last_modified")[0]

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -330,14 +330,6 @@ h1 {
   font-weight: 600;
 }
 
-#queue_table>tbody>tr {
-  cursor: pointer;
-}
-
-#field_reports_table>tbody>tr {
-  cursor: pointer;
-}
-
 .show-pointer {
   cursor: pointer;
 }

--- a/web/typescript/field_reports.ts
+++ b/web/typescript/field_reports.ts
@@ -214,7 +214,9 @@ function frInitDataTables() {
                 "className": "field_report_incident text-center",
                 "data": "incident",
                 "defaultContent": "-",
-                "render": ims.renderIncidentNumber,
+                // don't use renderIncidentNumber, as that includes an <a> tag that messes
+                // with the whole-row linking from renderFieldReportNumber.
+                "render": ims.renderNumber,
                 "responsivePriority": 3,
             },
         ],
@@ -223,31 +225,8 @@ function frInitDataTables() {
             [1, "dsc"],
         ],
         "createdRow": function (row: HTMLElement, fieldReport: ims.FieldReport, _index: number) {
-            const openLink = function(e: MouseEvent): void {
-                // If the user clicked on a link, then let them access that link without the JS below.
-                if (e.target?.constructor?.name === "HTMLAnchorElement") {
-                    return;
-                }
-
-                const isLeftClick = e.type === "click";
-                const isMiddleClick = e.type === "auxclick" && e.button === 1;
-                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
-
-                // Left click while not holding a modifier key: open in the same tab
-                if (isLeftClick && !holdingModifier) {
-                    window.location.href = `${ims.urlReplace(url_viewFieldReports)}/${fieldReport.number}`;
-                }
-                // Left click while holding modifier key or middle click: open in a new tab
-                if (isMiddleClick || (isLeftClick && holdingModifier)) {
-                    window.open(
-                        `${ims.urlReplace(url_viewFieldReports)}/${fieldReport.number}`,
-                        "Field_Report:" + fieldReport.number,
-                    );
-                    return;
-                }
-            }
-            row.addEventListener("click", openLink);
-            row.addEventListener("auxclick", openLink);
+            // Necessary to allow the stretched-link to work
+            row.classList.add("position-relative");
 
             row.getElementsByClassName("field_report_created")[0]!
                 .setAttribute(

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -682,9 +682,8 @@ export function renderIncidentNumber(incidentNumber: number|null, type: string, 
                 return null;
             }
             const dest = urlReplace(url_viewIncidentNumber).replace("<number>", incidentNumber.toString());
-            return `<a href="${dest}">${incidentNumber}</a>`;
+            return `<a class="stretched-link" href="${dest}">${incidentNumber}</a>`;
         case "filter":
-            return incidentNumber;
         case "type":
         case "sort":
             return incidentNumber;
@@ -699,12 +698,23 @@ export function renderFieldReportNumber(fieldReportNumber: number|null, type: st
                 return null;
             }
             const dest = urlReplace(url_viewFieldReportNumber).replace("<number>", fieldReportNumber.toString());
-            return `<a href="${dest}">${fieldReportNumber}</a>`;
+            return `<a class="stretched-link" href="${dest}">${fieldReportNumber}</a>`;
         case "filter":
-            return fieldReportNumber;
         case "type":
         case "sort":
             return fieldReportNumber;
+    }
+    return undefined;
+}
+
+export function renderNumber(num: number|null, type: string, _obj: any): number|string|null|undefined {
+    switch (type) {
+        case "display":
+            return num?.toString() ?? null;
+        case "filter":
+        case "type":
+        case "sort":
+            return num;
     }
     return undefined;
 }

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -364,31 +364,8 @@ function initDataTables(tablePrereqs: Promise<void>): void {
             [0, "dsc"],
         ],
         "createdRow": function (row: HTMLElement, incident: ims.Incident, _index: number) {
-            const openLink = function(e: MouseEvent): void {
-                // If the user clicked on a link, then let them access that link without the JS below.
-                if (e.target?.constructor?.name === "HTMLAnchorElement") {
-                    return;
-                }
-
-                const isLeftClick = e.type === "click";
-                const isMiddleClick = e.type === "auxclick" && e.button === 1;
-                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
-
-                // Left click while not holding a modifier key: open in the same tab
-                if (isLeftClick && !holdingModifier) {
-                    window.location.href = `${ims.urlReplace(url_viewIncidents)}/${incident.number}`;
-                }
-                // Left click while holding modifier key or middle click: open in a new tab
-                if (isMiddleClick || (isLeftClick && holdingModifier)) {
-                    window.open(
-                        `${ims.urlReplace(url_viewIncidents)}/${incident.number}`,
-                        "Incident:" + ims.pathIds.eventID + "#" + incident.number,
-                    );
-                    return;
-                }
-            }
-            row.addEventListener("click", openLink);
-            row.addEventListener("auxclick", openLink);
+            // Necessary to allow the stretched-link to work
+            row.classList.add("position-relative");
 
             row.getElementsByClassName("incident_started")[0]!
                 .setAttribute(


### PR DESCRIPTION
I just learned about this "stretched-row" thing, which allows one anchor tag's href to cover surrounding elements as well. That makes these tables a lot simpler, since each row becomes linkable using a normal HTML link, and we can get rid of those magical click event listeners.