### PR TITLE
improve preview for file attachments, download with original name

### DIFF
--- a/api/attachment.go
+++ b/api/attachment.go
@@ -40,7 +40,10 @@ import (
 	"time"
 )
 
-const IMSAttachmentFormKey = "imsAttachment"
+const (
+	IMSAttachmentFormKey = "imsAttachment"
+	octetStream          = "application/octet-stream"
+)
 
 type GetIncidentAttachment struct {
 	imsDBQ           *store.DBQ
@@ -144,7 +147,7 @@ var safeMediaTypes = []string{
 	"video/x-msvideo",
 }
 
-// safeContentType returns contentType if we deem it to be safe, or octetStream otherwise.
+// safeContentType returns a safe form contentType if possible, or octetStream otherwise.
 //
 // This is important for the client side. For example, if we're serving an HTML document,
 // we want the client to think it's just text/plain, so that it doesn't attempt to render it.
@@ -153,7 +156,6 @@ var safeMediaTypes = []string{
 // for unsafe files. This function works conservatively by returning octetStream unless we
 // know the content type ought to be safe.
 func safeContentType(contentType string) string {
-	const octetStream = "application/octet-stream"
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		return octetStream
@@ -331,10 +333,12 @@ func (action AttachToIncident) attachToIncident(req *http.Request) (int32, *herr
 		return 0, errHTTP.From("[saveFile]")
 	}
 
-	reText := fmt.Sprintf("File Type: %v, Size: %v, Name:%v",
-		sniffedContentType, format.HumanByteSize(fiHead.Size), fiHead.Filename)
-	reID, errHTTP := addIncidentReportEntry(ctx, action.imsDBQ, action.imsDBQ, event.ID, incidentNumber,
-		jwtCtx.Claims.RangerHandle(), reText, false, newFileName)
+	reText := fmt.Sprintf("File Name: %v, Size: %v, Type:%v",
+		fiHead.Filename, format.HumanByteSize(fiHead.Size), sniffedContentType)
+	reID, errHTTP := addIncidentReportEntry(
+		ctx, action.imsDBQ, action.imsDBQ, event.ID, incidentNumber, jwtCtx.Claims.RangerHandle(),
+		reText, false, newFileName, fiHead.Filename, sniffedContentType,
+	)
 	if errHTTP != nil {
 		return 0, errHTTP.From("[addIncidentReportEntry]")
 	}
@@ -438,10 +442,13 @@ func (action AttachToFieldReport) attachToFieldReport(req *http.Request) (int32,
 		return 0, errHTTP.From("[saveFile]")
 	}
 
-	reText := fmt.Sprintf("File Type: %v, Size: %v, Name:%v",
-		sniffedContentType, format.HumanByteSize(fiHead.Size), fiHead.Filename)
-	reID, errHTTP := addFRReportEntry(ctx, action.imsDBQ, action.imsDBQ, event.ID, fieldReportNumber,
-		jwtCtx.Claims.RangerHandle(), reText, false, newFileName)
+	reText := fmt.Sprintf("File Name: %v, Size: %v, Type: %v",
+		fiHead.Filename, format.HumanByteSize(fiHead.Size), sniffedContentType)
+	reID, errHTTP := addFRReportEntry(
+		ctx, action.imsDBQ, action.imsDBQ, event.ID, fieldReportNumber,
+		jwtCtx.Claims.RangerHandle(), reText, false,
+		newFileName, fiHead.Filename, sniffedContentType,
+	)
 	if errHTTP != nil {
 		return 0, errHTTP.From("[addFRReportEntry]")
 	}

--- a/api/reportentry.go
+++ b/api/reportentry.go
@@ -96,7 +96,7 @@ func (action EditFieldReportReportEntry) editFieldReportEntry(req *http.Request)
 	if !*re.Stricken {
 		struckVerb = "Unstruck"
 	}
-	_, errHTTP = addFRReportEntry(ctx, action.imsDBQ, txn, event.ID, fieldReportNumber, author, fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId), true, "")
+	_, errHTTP = addFRReportEntry(ctx, action.imsDBQ, txn, event.ID, fieldReportNumber, author, fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId), true, "", "", "")
 	if errHTTP != nil {
 		return errHTTP.From("[addFRReportEntry]")
 	}
@@ -176,7 +176,7 @@ func (action EditIncidentReportEntry) editIncidentReportEntry(req *http.Request)
 	if !*re.Stricken {
 		struckVerb = "Unstruck"
 	}
-	_, errHTTP = addIncidentReportEntry(ctx, action.imsDBQ, txn, event.ID, incidentNumber, author, fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId), true, "")
+	_, errHTTP = addIncidentReportEntry(ctx, action.imsDBQ, txn, event.ID, incidentNumber, author, fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId), true, "", "", "")
 	if errHTTP != nil {
 		return errHTTP.From("[addIncidentReportEntry]")
 	}
@@ -189,6 +189,11 @@ func (action EditIncidentReportEntry) editIncidentReportEntry(req *http.Request)
 }
 
 func reportEntryToJSON(re imsdb.ReportEntry, attachmentsEnabled bool) imsjson.ReportEntry {
+	var attachment imsjson.Attachment
+	if attachmentsEnabled && re.AttachedFileOriginalName.Valid {
+		attachment.Name = re.AttachedFileOriginalName.String
+		attachment.Previewable = safeContentType(re.AttachedFileMediaType.String) != octetStream
+	}
 	return imsjson.ReportEntry{
 		ID:            re.ID,
 		Created:       time.Unix(int64(re.Created), 0),
@@ -197,6 +202,7 @@ func reportEntryToJSON(re imsdb.ReportEntry, attachmentsEnabled bool) imsjson.Re
 		Text:          re.Text,
 		Stricken:      ptr(re.Stricken),
 		HasAttachment: attachmentsEnabled && re.AttachedFile.String != "",
+		Attachment:    attachment,
 	}
 }
 

--- a/json/reportentry.go
+++ b/json/reportentry.go
@@ -19,11 +19,22 @@ package json
 import "time"
 
 type ReportEntry struct {
-	ID            int32     `json:"id"`
-	Created       time.Time `json:"created,omitzero"`
-	Author        string    `json:"author"`
-	SystemEntry   bool      `json:"system_entry"`
-	Text          string    `json:"text"`
-	Stricken      *bool     `json:"stricken"`
-	HasAttachment bool      `json:"has_attachment"`
+	ID          int32     `json:"id"`
+	Created     time.Time `json:"created,omitzero"`
+	Author      string    `json:"author"`
+	SystemEntry bool      `json:"system_entry"`
+	Text        string    `json:"text"`
+	Stricken    *bool     `json:"stricken"`
+
+	// HasAttachment is no longer needed, as it's the same as checking
+	// if Attachment.Name is not empty. We should wait until prod is no
+	// longer reading this before removing it though, due to the 4-hour
+	// caching of JS files done by CloudFlare.
+	HasAttachment bool       `json:"has_attachment"`
+	Attachment    Attachment `json:"attachment,omitzero"`
+}
+
+type Attachment struct {
+	Name        string `json:"name"`
+	Previewable bool   `json:"previewable"`
 }

--- a/lib/conv/convert.go
+++ b/lib/conv/convert.go
@@ -94,11 +94,19 @@ func SqlToString(v sql.NullString) *string {
 	return nil
 }
 
-func StringToSql(s *string) sql.NullString {
+// StringToSql converts a string pointer into a sql.NullString.
+//
+// The string will be truncated at maxLength, if maxLength > 0. This uses the fact
+// that Go and IMS's MariaDB tables encode strings in UTF-8.
+func StringToSql(s *string, maxLength int) sql.NullString {
 	if s == nil || *s == "" {
 		return sql.NullString{}
 	}
-	return sql.NullString{String: *s, Valid: true}
+	val := *s
+	if maxLength > 0 && len(val) > maxLength {
+		val = val[:maxLength]
+	}
+	return sql.NullString{String: val, Valid: true}
 }
 
 // FloatToTime converts the float number of seconds since Unix epoch into a time.Time.

--- a/lib/conv/convert_test.go
+++ b/lib/conv/convert_test.go
@@ -75,3 +75,19 @@ func TestMustInt(t *testing.T) {
 		MustInt32(math.MaxInt32 + 1)
 	})
 }
+
+func TestStringToSql(t *testing.T) {
+	t.Parallel()
+	assert.Zero(t, StringToSql(nil, 0))
+	assert.Equal(t, sql.NullString{String: "BRC", Valid: true}, StringToSql(ptr("BRC"), 0))
+	assert.Equal(t, sql.NullString{String: "abcd", Valid: true}, StringToSql(ptr("abcdefgh"), 4))
+	assert.Equal(t, sql.NullString{String: "😊", Valid: true}, StringToSql(ptr("😊😂"), 4))
+
+	input := ptr("successful round trip conversion?")
+	assert.Equal(t, *input, *SqlToString(StringToSql(input, 0)))
+	assert.Nil(t, SqlToString(StringToSql(nil, 1)))
+}
+
+func ptr[T any](s T) *T {
+	return &s
+}

--- a/store/imsdb/models.go
+++ b/store/imsdb/models.go
@@ -270,13 +270,15 @@ type IncidentType struct {
 }
 
 type ReportEntry struct {
-	ID           int32
-	Author       string
-	Text         string
-	Created      float64
-	Generated    bool
-	Stricken     bool
-	AttachedFile sql.NullString
+	ID                       int32
+	Author                   string
+	Text                     string
+	Created                  float64
+	Generated                bool
+	Stricken                 bool
+	AttachedFile             sql.NullString
+	AttachedFileOriginalName sql.NullString
+	AttachedFileMediaType    sql.NullString
 }
 
 type SchemaInfo struct {

--- a/store/imsdb/queries.sql.go
+++ b/store/imsdb/queries.sql.go
@@ -298,19 +298,22 @@ func (q *Queries) CreateIncidentTypeOrIgnore(ctx context.Context, db DBTX, arg C
 
 const createReportEntry = `-- name: CreateReportEntry :execlastid
 insert into REPORT_ENTRY (
-    AUTHOR, TEXT, CREATED, ` + "`" + `GENERATED` + "`" + `, STRICKEN, ATTACHED_FILE
+    AUTHOR, TEXT, CREATED, ` + "`" + `GENERATED` + "`" + `, STRICKEN,
+    ATTACHED_FILE, ATTACHED_FILE_ORIGINAL_NAME, ATTACHED_FILE_MEDIA_TYPE
 ) values (
-   ?, ?, ?, ?, ?, ?
+   ?, ?, ?, ?, ?, ?, ?, ?
 )
 `
 
 type CreateReportEntryParams struct {
-	Author       string
-	Text         string
-	Created      float64
-	Generated    bool
-	Stricken     bool
-	AttachedFile sql.NullString
+	Author                   string
+	Text                     string
+	Created                  float64
+	Generated                bool
+	Stricken                 bool
+	AttachedFile             sql.NullString
+	AttachedFileOriginalName sql.NullString
+	AttachedFileMediaType    sql.NullString
 }
 
 func (q *Queries) CreateReportEntry(ctx context.Context, db DBTX, arg CreateReportEntryParams) (int64, error) {
@@ -321,6 +324,8 @@ func (q *Queries) CreateReportEntry(ctx context.Context, db DBTX, arg CreateRepo
 		arg.Generated,
 		arg.Stricken,
 		arg.AttachedFile,
+		arg.AttachedFileOriginalName,
+		arg.AttachedFileMediaType,
 	)
 	if err != nil {
 		return 0, err
@@ -505,7 +510,7 @@ func (q *Queries) FieldReport(ctx context.Context, db DBTX, arg FieldReportParam
 
 const fieldReport_ReportEntries = `-- name: FieldReport_ReportEntries :many
 select
-    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file
+    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file, re.attached_file_original_name, re.attached_file_media_type
 from
     FIELD_REPORT__REPORT_ENTRY irre
         join REPORT_ENTRY re
@@ -541,6 +546,8 @@ func (q *Queries) FieldReport_ReportEntries(ctx context.Context, db DBTX, arg Fi
 			&i.ReportEntry.Generated,
 			&i.ReportEntry.Stricken,
 			&i.ReportEntry.AttachedFile,
+			&i.ReportEntry.AttachedFileOriginalName,
+			&i.ReportEntry.AttachedFileMediaType,
 		); err != nil {
 			return nil, err
 		}
@@ -597,7 +604,7 @@ func (q *Queries) FieldReports(ctx context.Context, db DBTX, event int32) ([]Fie
 const fieldReports_ReportEntries = `-- name: FieldReports_ReportEntries :many
 select
     irre.FIELD_REPORT_NUMBER,
-    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file
+    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file, re.attached_file_original_name, re.attached_file_media_type
 from
     FIELD_REPORT__REPORT_ENTRY irre
         join REPORT_ENTRY re
@@ -635,6 +642,8 @@ func (q *Queries) FieldReports_ReportEntries(ctx context.Context, db DBTX, arg F
 			&i.ReportEntry.Generated,
 			&i.ReportEntry.Stricken,
 			&i.ReportEntry.AttachedFile,
+			&i.ReportEntry.AttachedFileOriginalName,
+			&i.ReportEntry.AttachedFileMediaType,
 		); err != nil {
 			return nil, err
 		}
@@ -762,7 +771,7 @@ func (q *Queries) IncidentTypes(ctx context.Context, db DBTX) ([]IncidentTypesRo
 const incident_ReportEntries = `-- name: Incident_ReportEntries :many
 select
     ire.INCIDENT_NUMBER,
-    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file
+    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file, re.attached_file_original_name, re.attached_file_media_type
 from
     INCIDENT__REPORT_ENTRY ire
         join REPORT_ENTRY re
@@ -800,6 +809,8 @@ func (q *Queries) Incident_ReportEntries(ctx context.Context, db DBTX, arg Incid
 			&i.ReportEntry.Generated,
 			&i.ReportEntry.Stricken,
 			&i.ReportEntry.AttachedFile,
+			&i.ReportEntry.AttachedFileOriginalName,
+			&i.ReportEntry.AttachedFileMediaType,
 		); err != nil {
 			return nil, err
 		}
@@ -894,7 +905,7 @@ func (q *Queries) Incidents(ctx context.Context, db DBTX, event int32) ([]Incide
 const incidents_ReportEntries = `-- name: Incidents_ReportEntries :many
 select
     ire.INCIDENT_NUMBER,
-    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file
+    re.id, re.author, re.text, re.created, re.` + "`" + `generated` + "`" + `, re.stricken, re.attached_file, re.attached_file_original_name, re.attached_file_media_type
 from
     INCIDENT__REPORT_ENTRY ire
         join REPORT_ENTRY re
@@ -932,6 +943,8 @@ func (q *Queries) Incidents_ReportEntries(ctx context.Context, db DBTX, arg Inci
 			&i.ReportEntry.Generated,
 			&i.ReportEntry.Stricken,
 			&i.ReportEntry.AttachedFile,
+			&i.ReportEntry.AttachedFileOriginalName,
+			&i.ReportEntry.AttachedFileMediaType,
 		); err != nil {
 			return nil, err
 		}

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -229,9 +229,10 @@ where EVENT = ? and NUMBER = ?;
 
 -- name: CreateReportEntry :execlastid
 insert into REPORT_ENTRY (
-    AUTHOR, TEXT, CREATED, `GENERATED`, STRICKEN, ATTACHED_FILE
+    AUTHOR, TEXT, CREATED, `GENERATED`, STRICKEN,
+    ATTACHED_FILE, ATTACHED_FILE_ORIGINAL_NAME, ATTACHED_FILE_MEDIA_TYPE
 ) values (
-   ?, ?, ?, ?, ?, ?
+   ?, ?, ?, ?, ?, ?, ?, ?
 );
 
 -- name: AttachReportEntryToFieldReport :exec

--- a/store/schema/15-from-14.sql
+++ b/store/schema/15-from-14.sql
@@ -1,13 +1,14 @@
 alter table `INCIDENT`
-    add column `STARTED` double after `STATE`
-;
+add column `STARTED` double after `STATE`;
 
 update `INCIDENT`
-    set `STARTED` = `CREATED`
-;
+set `STARTED` = `CREATED`
+where true;
 
 alter table `INCIDENT`
-    modify column `STARTED` double not null;
+modify column `STARTED` double not null;
 
 /* Update schema version */
-update `SCHEMA_INFO` set `VERSION` = 15;
+update `SCHEMA_INFO`
+set `VERSION` = 15
+where true;

--- a/store/schema/16-from-15.sql
+++ b/store/schema/16-from-15.sql
@@ -1,0 +1,12 @@
+alter table `REPORT_ENTRY`
+add column `ATTACHED_FILE_ORIGINAL_NAME` varchar(128),
+add column `ATTACHED_FILE_MEDIA_TYPE` varchar(128);
+
+update `REPORT_ENTRY`
+set `ATTACHED_FILE_ORIGINAL_NAME` = `ATTACHED_FILE`,
+    `ATTACHED_FILE_MEDIA_TYPE` = 'application/octet-stream'
+where `ATTACHED_FILE` is not null;
+
+update `SCHEMA_INFO`
+set `VERSION` = 16
+where true;

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -6,7 +6,7 @@ create table SCHEMA_INFO (
 -- This value must be updated when you make a new migration file.
 --
 
-insert into SCHEMA_INFO (VERSION) values (15);
+insert into SCHEMA_INFO (VERSION) values (16);
 
 
 create table `EVENT` (
@@ -41,17 +41,16 @@ insert into INCIDENT_TYPE (NAME, HIDDEN) values ('Junk' , 0);
 
 
 create table REPORT_ENTRY (
-    ID        integer       not null auto_increment,
-    AUTHOR    varchar(64)   not null,
-    TEXT      mediumtext    not null,
-    CREATED   double        not null,
-    `GENERATED` boolean     not null,
-    STRICKEN  boolean       not null,
+    ID              integer         not null auto_increment,
+    AUTHOR          varchar(64)     not null,
+    TEXT            mediumtext      not null,
+    CREATED         double          not null,
+    `GENERATED`     boolean         not null,
+    STRICKEN        boolean         not null,
 
-    ATTACHED_FILE varchar(128),
-
-    -- FIXME: AUTHOR is an external non-primary key.
-    -- Primary key is DMS Person ID.
+    ATTACHED_FILE                   varchar(128),
+    ATTACHED_FILE_ORIGINAL_NAME     varchar(128),
+    ATTACHED_FILE_MEDIA_TYPE        varchar(128),
 
     primary key (ID)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -801,22 +801,19 @@ function reportEntryElement(entry) {
         textContainer.textContent = line;
         entryContainer.append(textContainer);
     }
-    if (entry.has_attachment && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {
+    if (entry.attachment?.name && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {
         let url = "";
-        let filename = "";
         if (pathIds.incidentNumber != null && entry.merged == null) {
             // incident attachment on incident page
             url = urlReplace(url_incidentAttachmentNumber)
                 .replace("<incident_number>", pathIds.incidentNumber.toString())
                 .replace("<attachment_number>", entry.id.toString());
-            filename = `ims_${pathIds.incidentNumber.toString()}_${entry.id.toString()}`;
         }
         else if (pathIds.incidentNumber != null && entry.merged != null) {
             // FR attachment on incident page
             url = urlReplace(url_fieldReportAttachmentNumber)
                 .replace("<field_report_number>", entry.merged.toString())
                 .replace("<attachment_number>", entry.id.toString());
-            filename = `fr_${entry.merged.toString()}_${entry.id.toString()}`;
         }
         else {
             // FR attachment on FR page
@@ -824,40 +821,9 @@ function reportEntryElement(entry) {
             url = urlReplace(url_fieldReportAttachmentNumber)
                 .replace("<field_report_number>", frNum)
                 .replace("<attachment_number>", entry.id.toString());
-            filename = `fr_${frNum}_${entry.id.toString()}`;
         }
-        const previewButt = document.createElement("button");
-        previewButt.textContent = "Preview file";
-        previewButt.classList.add("btn", "btn-default", "btn-sm", "btn-block", "btn-secondary", "my-1", "me-1", "form-control-lite", "no-print");
-        // We need to do a JavaScript fetch of the file, rather than simply
-        // opening a new browser tab that GETs it, because we have to send
-        // the Authorization header.
-        previewButt.onclick = async (e) => {
-            e.preventDefault();
-            const { resp, err } = await fetchJsonNoThrow(url, {});
-            if (err != null || resp == null) {
-                setErrorMessage(`Failed to fetch attachment: ${err}`);
-                return;
-            }
-            const blobUrl = window.URL.createObjectURL(await resp.blob());
-            const tmpLink = document.createElement("a");
-            // Preview mode: open a preview in a new window.
-            // We'd use window.open with target _blank, but Safari iOS doesn't support that,
-            // and a lot of Rangers use iPhones.
-            tmpLink.target = "_blank";
-            tmpLink.href = blobUrl;
-            document.body.appendChild(tmpLink);
-            tmpLink.click();
-            document.body.removeChild(tmpLink);
-            // Wait a little while before cleaning up the blob, in case the user opts
-            // to download the file from the preview (that will fail once the object URL
-            // has been revoked).
-            setTimeout(function () {
-                URL.revokeObjectURL(blobUrl);
-            }, 60_000 /* milliseconds */);
-        };
         const downloadButt = document.createElement("button");
-        downloadButt.textContent = "Download file";
+        downloadButt.textContent = "Download";
         downloadButt.classList.add("btn", "btn-default", "btn-sm", "btn-block", "btn-secondary", "my-1", "me-1", "form-control-lite", "no-print");
         downloadButt.onclick = async (e) => {
             e.preventDefault();
@@ -869,14 +835,47 @@ function reportEntryElement(entry) {
             const blobUrl = window.URL.createObjectURL(await resp.blob());
             const tmpLink = document.createElement("a");
             // Download mode: set a suggested filename.
-            tmpLink.download = filename;
+            tmpLink.download = entry?.attachment?.name ?? "imsfile";
             tmpLink.href = blobUrl;
             document.body.appendChild(tmpLink);
             tmpLink.click();
             document.body.removeChild(tmpLink);
             URL.revokeObjectURL(blobUrl);
         };
-        entryContainer.append(previewButt, downloadButt);
+        entryContainer.append(downloadButt);
+        if (entry.attachment?.previewable) {
+            const previewButt = document.createElement("button");
+            previewButt.textContent = "Preview";
+            previewButt.classList.add("btn", "btn-default", "btn-sm", "btn-block", "btn-secondary", "my-1", "me-1", "form-control-lite", "no-print");
+            // We need to do a JavaScript fetch of the file, rather than simply
+            // opening a new browser tab that GETs it, because we have to send
+            // the Authorization header.
+            previewButt.onclick = async (e) => {
+                e.preventDefault();
+                const { resp, err } = await fetchJsonNoThrow(url, {});
+                if (err != null || resp == null) {
+                    setErrorMessage(`Failed to fetch attachment: ${err}`);
+                    return;
+                }
+                const blobUrl = window.URL.createObjectURL(await resp.blob());
+                const tmpLink = document.createElement("a");
+                // Preview mode: open a preview in a new window.
+                // We'd use window.open with target _blank, but Safari iOS doesn't support that,
+                // and a lot of Rangers use iPhones.
+                tmpLink.target = "_blank";
+                tmpLink.href = blobUrl;
+                document.body.appendChild(tmpLink);
+                tmpLink.click();
+                document.body.removeChild(tmpLink);
+                // Wait a little while before cleaning up the blob, in case the user opts
+                // to download the file from the preview (that will fail once the object URL
+                // has been revoked).
+                setTimeout(function () {
+                    URL.revokeObjectURL(blobUrl);
+                }, 60_000 /* milliseconds */);
+            };
+            entryContainer.append(previewButt);
+        }
     }
     // Add a horizontal line after each entry
     const hr = document.createElement("hr");

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -935,68 +935,29 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
 
         entryContainer.append(textContainer);
     }
-    if (entry.has_attachment && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {
+    if (entry.attachment?.name && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {
 
         let url: string = "";
-        let filename: string = "";
         if (pathIds.incidentNumber != null && entry.merged == null) {
             // incident attachment on incident page
             url = urlReplace(url_incidentAttachmentNumber)
                 .replace("<incident_number>", pathIds.incidentNumber.toString())
                 .replace("<attachment_number>", entry.id!.toString());
-            filename = `ims_${pathIds.incidentNumber.toString()}_${entry.id!.toString()}`;
         } else if (pathIds.incidentNumber != null && entry.merged != null) {
             // FR attachment on incident page
             url = urlReplace(url_fieldReportAttachmentNumber)
                 .replace("<field_report_number>", entry.merged.toString())
                 .replace("<attachment_number>", entry.id!.toString());
-            filename = `fr_${entry.merged.toString()}_${entry.id!.toString()}`;
         } else {
             // FR attachment on FR page
             const frNum = (pathIds.fieldReportNumber??"wontHappen").toString();
             url = urlReplace(url_fieldReportAttachmentNumber)
                 .replace("<field_report_number>", frNum)
                 .replace("<attachment_number>", entry.id!.toString());
-            filename = `fr_${frNum}_${entry.id!.toString()}`;
         }
 
-        const previewButt: HTMLButtonElement = document.createElement("button");
-        previewButt.textContent = "Preview file";
-        previewButt.classList.add(
-            "btn", "btn-default", "btn-sm", "btn-block", "btn-secondary", "my-1", "me-1", "form-control-lite", "no-print",
-        );
-        // We need to do a JavaScript fetch of the file, rather than simply
-        // opening a new browser tab that GETs it, because we have to send
-        // the Authorization header.
-        previewButt.onclick = async (e: MouseEvent): Promise<void> => {
-            e.preventDefault();
-            const {resp, err} = await fetchJsonNoThrow(url, {});
-            if (err != null || resp == null) {
-                setErrorMessage(`Failed to fetch attachment: ${err}`);
-                return;
-            }
-            const blobUrl: string = window.URL.createObjectURL(await resp.blob());
-            const tmpLink: HTMLAnchorElement = document.createElement("a");
-
-            // Preview mode: open a preview in a new window.
-            // We'd use window.open with target _blank, but Safari iOS doesn't support that,
-            // and a lot of Rangers use iPhones.
-            tmpLink.target = "_blank";
-            tmpLink.href = blobUrl;
-            document.body.appendChild(tmpLink);
-            tmpLink.click();
-            document.body.removeChild(tmpLink);
-
-            // Wait a little while before cleaning up the blob, in case the user opts
-            // to download the file from the preview (that will fail once the object URL
-            // has been revoked).
-            setTimeout(function (): void {
-                URL.revokeObjectURL(blobUrl);
-            }, 60_000 /* milliseconds */);
-        };
-
         const downloadButt: HTMLButtonElement = document.createElement("button");
-        downloadButt.textContent = "Download file";
+        downloadButt.textContent = "Download";
         downloadButt.classList.add(
             "btn", "btn-default", "btn-sm", "btn-block", "btn-secondary", "my-1", "me-1", "form-control-lite", "no-print",
         );
@@ -1011,15 +972,52 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             const tmpLink: HTMLAnchorElement = document.createElement("a");
 
             // Download mode: set a suggested filename.
-            tmpLink.download = filename;
+            tmpLink.download = entry?.attachment?.name ?? "imsfile";
             tmpLink.href = blobUrl;
             document.body.appendChild(tmpLink);
             tmpLink.click();
             document.body.removeChild(tmpLink);
             URL.revokeObjectURL(blobUrl);
         };
+        entryContainer.append(downloadButt);
 
-        entryContainer.append(previewButt, downloadButt);
+        if (entry.attachment?.previewable) {
+            const previewButt: HTMLButtonElement = document.createElement("button");
+            previewButt.textContent = "Preview";
+            previewButt.classList.add(
+                "btn", "btn-default", "btn-sm", "btn-block", "btn-secondary", "my-1", "me-1", "form-control-lite", "no-print",
+            );
+            // We need to do a JavaScript fetch of the file, rather than simply
+            // opening a new browser tab that GETs it, because we have to send
+            // the Authorization header.
+            previewButt.onclick = async (e: MouseEvent): Promise<void> => {
+                e.preventDefault();
+                const {resp, err} = await fetchJsonNoThrow(url, {});
+                if (err != null || resp == null) {
+                    setErrorMessage(`Failed to fetch attachment: ${err}`);
+                    return;
+                }
+                const blobUrl: string = window.URL.createObjectURL(await resp.blob());
+                const tmpLink: HTMLAnchorElement = document.createElement("a");
+
+                // Preview mode: open a preview in a new window.
+                // We'd use window.open with target _blank, but Safari iOS doesn't support that,
+                // and a lot of Rangers use iPhones.
+                tmpLink.target = "_blank";
+                tmpLink.href = blobUrl;
+                document.body.appendChild(tmpLink);
+                tmpLink.click();
+                document.body.removeChild(tmpLink);
+
+                // Wait a little while before cleaning up the blob, in case the user opts
+                // to download the file from the preview (that will fail once the object URL
+                // has been revoked).
+                setTimeout(function (): void {
+                    URL.revokeObjectURL(blobUrl);
+                }, 60_000 /* milliseconds */);
+            };
+            entryContainer.append(previewButt);
+        }
     }
 
     // Add a horizontal line after each entry
@@ -1473,6 +1471,11 @@ export type EventData = {
     name: string,
 }
 
+export interface Attachment {
+    name?: string|null;
+    previewable?: boolean|null;
+}
+
 export interface ReportEntry {
     id?: number|null;
     created?: string|null;
@@ -1482,6 +1485,7 @@ export interface ReportEntry {
     system_entry?: boolean|null;
     stricken?: boolean|null;
     has_attachment?: boolean|null;
+    attachment?: Attachment|null;
 }
 
 export type UnauthenticatedAuthInfo = {


### PR DESCRIPTION
This change has two goals:
1. only show the "preview" button when previewing is possible. It's silly to show that button for octet-stream files, which aren't previewable, and just trigger a download anyway.
2. download files with their original filenames and extensions. That should improve UX somewhat.