### PR TITLE
make report entry spacing more sensible

### DIFF
--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -772,11 +772,13 @@ function reportEntryElement(entry) {
     metaDataContainer.append(":");
     entryContainer.append(metaDataContainer);
     // Add report text
-    const lines = entry.text.split("\n");
-    for (const line of lines) {
+    const paragraphs = entry.text.split(/\n\s*\n/);
+    for (const paragraph of paragraphs) {
         const textContainer = document.createElement("p");
         textContainer.classList.add("report_entry_text");
-        textContainer.textContent = line;
+        // innerText automatically converts "\n" into "<br>", which is what we want.
+        // Note that textContent does not do this.
+        textContainer.innerText = paragraph;
         entryContainer.append(textContainer);
     }
     if (entry.attachment?.name && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -901,12 +901,13 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
 
     // Add report text
 
-    const lines: string[] = entry.text!.split("\n");
-    for (const line of lines) {
+    const paragraphs: string[] = entry.text!.split(/\n\s*\n/);
+    for (const paragraph of paragraphs) {
         const textContainer: HTMLParagraphElement = document.createElement("p");
         textContainer.classList.add("report_entry_text");
-        textContainer.textContent = line;
-
+        // innerText automatically converts "\n" into "<br>", which is what we want.
+        // Note that textContent does not do this.
+        textContainer.innerText = paragraph;
         entryContainer.append(textContainer);
     }
     if (entry.attachment?.name && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {


### PR DESCRIPTION
Previously any newline in a report entry led to a new HTML paragraph when rendering. This changes that, so that only a double newline yields a new paragraph, while a single newline yields a <br>