### PR TITLE
revert #206: don't do stretched-links on Incidents/FRs tables

### DIFF
--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -184,9 +184,7 @@ function frInitDataTables() {
                 "className": "field_report_incident text-center",
                 "data": "incident",
                 "defaultContent": "-",
-                // don't use renderIncidentNumber, as that includes an <a> tag that messes
-                // with the whole-row linking from renderFieldReportNumber.
-                "render": renderNumber,
+                "render": ims.renderIncidentNumber,
                 "responsivePriority": 3,
             },
         ],
@@ -194,32 +192,35 @@ function frInitDataTables() {
             // creation time descending
             [1, "dsc"],
         ],
-        "createdRow": function (row, _fieldReport, _index) {
-            // Necessary to allow the stretched-link to work
-            row.classList.add("position-relative");
+        "createdRow": function (row, fieldReport, _index) {
+            const openLink = function (e) {
+                // If the user clicked on a link, then let them access that link without the JS below.
+                if (e.target?.constructor?.name === "HTMLAnchorElement") {
+                    return;
+                }
+                const isLeftClick = e.type === "click";
+                const isMiddleClick = e.type === "auxclick" && e.button === 1;
+                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
+                // Left click while not holding a modifier key: open in the same tab
+                if (isLeftClick && !holdingModifier) {
+                    window.location.href = `${ims.urlReplace(url_viewFieldReports)}/${fieldReport.number}`;
+                }
+                // Left click while holding modifier key or middle click: open in a new tab
+                if (isMiddleClick || (isLeftClick && holdingModifier)) {
+                    window.open(`${ims.urlReplace(url_viewFieldReports)}/${fieldReport.number}`, "Field_Report:" + fieldReport.number);
+                    return;
+                }
+            };
+            row.addEventListener("click", openLink);
+            row.addEventListener("auxclick", openLink);
         },
     });
-}
-function renderNumber(data, type, _fieldReport) {
-    switch (type) {
-        case "display":
-            if (data == null) {
-                return "";
-            }
-            return ims.renderCellText(DataTable.render.number().display(data), null);
-        case "sort":
-        case "filter":
-        case "type":
-            return data;
-    }
-    return undefined;
 }
 function renderSummary(_data, type, fieldReport) {
     switch (type) {
         case "display":
             // XSS prevention
-            const safeText = DataTable.render.text().display(ims.summarizeIncidentOrFR(fieldReport));
-            return ims.renderCellText(safeText, null);
+            return DataTable.render.text().display(ims.summarizeIncidentOrFR(fieldReport));
         case "sort":
             return ims.summarizeIncidentOrFR(fieldReport);
         case "filter":

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -564,8 +564,7 @@ function safeShortDescribeLocation(location) {
 export function renderSafeSorted(strings) {
     const sortedCopy = strings.toSorted((a, b) => a.localeCompare(b));
     const joined = sortedCopy.join(", ");
-    const safeText = DataTable.render.text().display(joined);
-    return renderCellText(safeText, null);
+    return DataTable.render.text().display(joined);
 }
 export function renderIncidentNumber(incidentNumber, type, _incident) {
     switch (type) {
@@ -574,7 +573,7 @@ export function renderIncidentNumber(incidentNumber, type, _incident) {
                 return null;
             }
             const dest = urlReplace(url_viewIncidentNumber).replace("<number>", incidentNumber.toString());
-            return `<a class="stretched-link" href="${dest}">${incidentNumber}</a>`;
+            return `<a href="${dest}">${incidentNumber}</a>`;
         case "filter":
         case "type":
         case "sort":
@@ -589,7 +588,7 @@ export function renderFieldReportNumber(fieldReportNumber, type, _fieldReport) {
                 return null;
             }
             const dest = urlReplace(url_viewFieldReportNumber).replace("<number>", fieldReportNumber.toString());
-            return `<a class="stretched-link" href="${dest}">${fieldReportNumber}</a>`;
+            return `<a href="${dest}">${fieldReportNumber}</a>`;
         case "filter":
         case "type":
         case "sort":
@@ -655,7 +654,7 @@ export function renderDate(date, type, _incident) {
     const fullDate = fullDateTime.format(d);
     switch (type) {
         case "display":
-            return renderCellText(`${shortDate.format(d)}<wbr />@${shortTime.format(d)}`, fullDate);
+            return `<span title="${fullDate}">${shortDate.format(d)}<wbr />@${shortTime.format(d)}</span>`;
         case "filter":
             return shortDate.format(d) + " " + shortTime.format(d);
         case "type":
@@ -670,7 +669,6 @@ export function renderState(state, type, incident) {
     }
     switch (type) {
         case "display":
-            return renderCellText(stateNameFromID(state), null);
         case "filter":
             return stateNameFromID(state);
         case "type":
@@ -687,17 +685,12 @@ export function renderLocation(data, type, _incident) {
     switch (type) {
         case "filter":
         case "sort":
-            return safeShortDescribeLocation(data) ?? "";
         case "display":
-            return renderCellText(safeShortDescribeLocation(data) ?? "", null);
+            return safeShortDescribeLocation(data) ?? "";
         case "type":
             return "";
     }
     return undefined;
-}
-export function renderCellText(rawHtml, title) {
-    const titlePart = title ? `title="${title}"` : "";
-    return `<span class="datatable-cell-text" ${titlePart}>${rawHtml}</span>`;
 }
 //
 // Populate report entry text

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -308,9 +308,27 @@ function initDataTables(tablePrereqs) {
         "order": [
             [0, "dsc"],
         ],
-        "createdRow": function (row, _incident, _index) {
-            // Necessary to allow the stretched-link to work
-            row.classList.add("position-relative");
+        "createdRow": function (row, incident, _index) {
+            const openLink = function (e) {
+                // If the user clicked on a link, then let them access that link without the JS below.
+                if (e.target?.constructor?.name === "HTMLAnchorElement") {
+                    return;
+                }
+                const isLeftClick = e.type === "click";
+                const isMiddleClick = e.type === "auxclick" && e.button === 1;
+                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
+                // Left click while not holding a modifier key: open in the same tab
+                if (isLeftClick && !holdingModifier) {
+                    window.location.href = `${ims.urlReplace(url_viewIncidents)}/${incident.number}`;
+                }
+                // Left click while holding modifier key or middle click: open in a new tab
+                if (isMiddleClick || (isLeftClick && holdingModifier)) {
+                    window.open(`${ims.urlReplace(url_viewIncidents)}/${incident.number}`, "Incident:" + ims.pathIds.eventID + "#" + incident.number);
+                    return;
+                }
+            };
+            row.addEventListener("click", openLink);
+            row.addEventListener("auxclick", openLink);
         },
     });
 }
@@ -323,8 +341,7 @@ function renderSummary(_data, type, incident) {
                 summarized = summarized.substring(0, maxDisplayLength - 3) + "...";
             }
             // XSS prevention
-            const safeSummary = DataTable.render.text().display(summarized);
-            return ims.renderCellText(safeSummary, null);
+            return DataTable.render.text().display(summarized);
         }
         case "sort":
             return ims.summarizeIncidentOrFR(incident);

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -196,14 +196,6 @@ h1 {
   display: inline-block;
 }
 
-/* Actually, don't do this, because it's annoying that so much of the row then becomes non-linkified...
-/*!* On non-touch devices, elevate the cell text above the stretched-link for the row.*/
-/* * This allows the user to select the text and to see "title" on hover. *!*/
-/*.no-touch .datatable-cell-text {*/
-/*  position: relative;*/
-/*  z-index: 2;*/
-/*}*/
-
 /* Disable on touch devices if editing is disabled. */
 .no-edit .remove-badge {
   display: none;
@@ -337,6 +329,14 @@ h1 {
   left: .4rem;
   content: '✓';
   font-weight: 600;
+}
+
+#queue_table>tbody>tr {
+  cursor: pointer;
+}
+
+#field_reports_table>tbody>tr {
+  cursor: pointer;
 }
 
 .show-pointer {

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -661,8 +661,7 @@ function safeShortDescribeLocation(location: EventLocation): string {
 export function renderSafeSorted(strings: string[]): string {
     const sortedCopy = strings.toSorted((a, b) => a.localeCompare(b));
     const joined = sortedCopy.join(", ");
-    const safeText: string = DataTable.render.text().display(joined);
-    return renderCellText(safeText, null);
+    return DataTable.render.text().display(joined) as string;
 }
 
 export function renderIncidentNumber(incidentNumber: number|null, type: string, _incident: any): number|string|null|undefined {
@@ -672,7 +671,7 @@ export function renderIncidentNumber(incidentNumber: number|null, type: string, 
                 return null;
             }
             const dest = urlReplace(url_viewIncidentNumber).replace("<number>", incidentNumber.toString());
-            return `<a class="stretched-link" href="${dest}">${incidentNumber}</a>`;
+            return `<a href="${dest}">${incidentNumber}</a>`;
         case "filter":
         case "type":
         case "sort":
@@ -688,7 +687,7 @@ export function renderFieldReportNumber(fieldReportNumber: number|null, type: st
                 return null;
             }
             const dest = urlReplace(url_viewFieldReportNumber).replace("<number>", fieldReportNumber.toString());
-            return `<a class="stretched-link" href="${dest}">${fieldReportNumber}</a>`;
+            return `<a href="${dest}">${fieldReportNumber}</a>`;
         case "filter":
         case "type":
         case "sort":
@@ -763,7 +762,7 @@ export function renderDate(date: string, type: string, _incident: any): string|n
     const fullDate = fullDateTime.format(d);
     switch (type) {
         case "display":
-            return renderCellText(`${shortDate.format(d)}<wbr />@${shortTime.format(d)}`, fullDate);
+            return `<span title="${fullDate}">${shortDate.format(d)}<wbr />@${shortTime.format(d)}</span>`;
         case "filter":
             return shortDate.format(d) + " " + shortTime.format(d);
         case "type":
@@ -780,7 +779,6 @@ export function renderState(state: string, type: string, incident: Incident): st
 
     switch (type) {
         case "display":
-            return renderCellText(stateNameFromID(state), null);
         case "filter":
             return stateNameFromID(state);
         case "type":
@@ -798,18 +796,12 @@ export function renderLocation(data: EventLocation|null, type: string, _incident
     switch (type) {
         case "filter":
         case "sort":
-            return safeShortDescribeLocation(data)??""
         case "display":
-            return renderCellText(safeShortDescribeLocation(data)??"", null);
+            return safeShortDescribeLocation(data)??"";
         case "type":
             return "";
     }
     return undefined;
-}
-
-export function renderCellText(rawHtml: string, title: string|null): string {
-    const titlePart = title ? `title="${title}"` : "";
-    return `<span class="datatable-cell-text" ${titlePart}>${rawHtml}</span>`
 }
 
 //

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -363,9 +363,32 @@ function initDataTables(tablePrereqs: Promise<void>): void {
         "order": [
             [0, "dsc"],
         ],
-        "createdRow": function (row: HTMLElement, _incident: ims.Incident, _index: number) {
-            // Necessary to allow the stretched-link to work
-            row.classList.add("position-relative");
+        "createdRow": function (row: HTMLElement, incident: ims.Incident, _index: number) {
+            const openLink = function(e: MouseEvent): void {
+                // If the user clicked on a link, then let them access that link without the JS below.
+                if (e.target?.constructor?.name === "HTMLAnchorElement") {
+                    return;
+                }
+
+                const isLeftClick = e.type === "click";
+                const isMiddleClick = e.type === "auxclick" && e.button === 1;
+                const holdingModifier = e.altKey || e.ctrlKey || e.metaKey;
+
+                // Left click while not holding a modifier key: open in the same tab
+                if (isLeftClick && !holdingModifier) {
+                    window.location.href = `${ims.urlReplace(url_viewIncidents)}/${incident.number}`;
+                }
+                // Left click while holding modifier key or middle click: open in a new tab
+                if (isMiddleClick || (isLeftClick && holdingModifier)) {
+                    window.open(
+                        `${ims.urlReplace(url_viewIncidents)}/${incident.number}`,
+                        "Incident:" + ims.pathIds.eventID + "#" + incident.number,
+                    );
+                    return;
+                }
+            }
+            row.addEventListener("click", openLink);
+            row.addEventListener("auxclick", openLink);
         },
     });
 }
@@ -379,8 +402,7 @@ function renderSummary(_data: string|null, type: string, incident: ims.Incident)
                 summarized = summarized.substring(0, maxDisplayLength - 3) + "...";
             }
             // XSS prevention
-            const safeSummary = DataTable.render.text().display(summarized);
-            return ims.renderCellText(safeSummary, null);
+            return DataTable.render.text().display(summarized) as string;
         }
         case "sort":
             return ims.summarizeIncidentOrFR(incident);


### PR DESCRIPTION
it turns out this doesn't work at all in Safari :(. This goes back to the old way of full row click listeners.

https://github.com/burningmantech/ranger-ims-go/pull/206