### PR TITLE
show user-entered whitespace in report entries

### DIFF
--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -760,10 +760,10 @@ function reportEntryElement(entry) {
     const paragraphs = entry.text.split(/\n\s*\n/);
     for (const paragraph of paragraphs) {
         const textContainer = document.createElement("p");
+        // Don't collapse whitespace; leave it how the user entered it.
+        textContainer.style.whiteSpace = "pre-wrap";
         textContainer.classList.add("report_entry_text");
-        // innerText automatically converts "\n" into "<br>", which is what we want.
-        // Note that textContent does not do this.
-        textContainer.innerText = paragraph;
+        textContainer.textContent = paragraph;
         entryContainer.append(textContainer);
     }
     if (entry.attachment?.name && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {
@@ -925,7 +925,7 @@ export function setSendEdits(func) {
     sendEditsFunc = func;
 }
 export async function submitReportEntry() {
-    const text = document.getElementById("report_entry_add").value.trim();
+    const text = document.getElementById("report_entry_add").value;
     if (!text) {
         return;
     }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -883,14 +883,13 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
     entryContainer.append(metaDataContainer);
 
     // Add report text
-
     const paragraphs: string[] = entry.text!.split(/\n\s*\n/);
     for (const paragraph of paragraphs) {
         const textContainer: HTMLParagraphElement = document.createElement("p");
+        // Don't collapse whitespace; leave it how the user entered it.
+        textContainer.style.whiteSpace = "pre-wrap";
         textContainer.classList.add("report_entry_text");
-        // innerText automatically converts "\n" into "<br>", which is what we want.
-        // Note that textContent does not do this.
-        textContainer.innerText = paragraph;
+        textContainer.textContent = paragraph;
         entryContainer.append(textContainer);
     }
     if (entry.attachment?.name && (pathIds.incidentNumber != null || pathIds.fieldReportNumber != null)) {
@@ -1071,7 +1070,7 @@ export function setSendEdits(func: ((edits: Incident|FieldReport)=>Promise<{err:
 }
 
 export async function submitReportEntry(): Promise<void> {
-    const text = (document.getElementById("report_entry_add") as HTMLTextAreaElement).value.trim();
+    const text = (document.getElementById("report_entry_add") as HTMLTextAreaElement).value;
 
     if (!text) {
         return;


### PR DESCRIPTION
previously we were always collapsing whitespace, so leading/trailing spaces wouldn't be shown at all, and repeated spaces would be collapsed into a single space.