### PR TITLE
don't cache IMS's own JS files

### DIFF
--- a/web/mux.go
+++ b/web/mux.go
@@ -34,10 +34,25 @@ func AddToMux(mux *http.ServeMux, cfg *conf.IMSConfig) *http.ServeMux {
 	}
 
 	deployment := string(cfg.Core.Deployment)
-	mux.Handle("GET /ims/static/",
+	mux.Handle("GET /ims/static/ext/",
 		Adapt(
 			http.StripPrefix("/ims/", http.FileServerFS(StaticFS)).ServeHTTP,
 			Static(cfg.Core.CacheControlLong),
+		),
+	)
+	mux.Handle("GET /ims/static/logos/",
+		Adapt(
+			http.StripPrefix("/ims/", http.FileServerFS(StaticFS)).ServeHTTP,
+			Static(cfg.Core.CacheControlLong),
+		),
+	)
+	mux.Handle("GET /ims/static/",
+		Adapt(
+			http.StripPrefix("/ims/", http.FileServerFS(StaticFS)).ServeHTTP,
+			// Don't cache IMS's own JS/CSS files, because Cloudflare ups this duration to
+			// 4 hours, and that's a pain when we're trying to push fixes out. We can remove
+			// this and allow caching again once we're nearer to event time.
+			Static(0),
 		),
 	)
 	mux.Handle("GET /ims/app",


### PR DESCRIPTION
this makes it hard to get fixes to prod, because Cloudflare automatically bumps up the max-age to 4 hours, regardless of what we set as the value in the server. Hopefully setting it to 0 will disable Cloudflare caching.