### PR TITLE
set CDN-Cache-Control header for our JS files

### DIFF
--- a/web/mux.go
+++ b/web/mux.go
@@ -152,6 +152,8 @@ func NoStore() Adapter {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Cache-Control", "max-age=0, no-store")
+			// https://developers.cloudflare.com/cache/concepts/cdn-cache-control/
+			w.Header().Set("CDN-Cache-Control", "max-age=0, no-store")
 			next.ServeHTTP(w, r.WithContext(r.Context()))
 		})
 	}


### PR DESCRIPTION
This should get Cloudflare to stop caching our JS files for so long (4 hours). I like caching of external JS deps, logos, etc, but not of our own JS files, because when I push a new deployment to prod, I want people to start getting the new files quickly.