### PR TITLE
redirect /ims/app/events/EventName requests

### DIFF
--- a/web/mux.go
+++ b/web/mux.go
@@ -107,6 +107,11 @@ func AddToMux(mux *http.ServeMux, cfg *conf.IMSConfig) *http.ServeMux {
 			).ServeHTTP(w, r)
 		},
 	)
+	mux.HandleFunc("GET /ims/app/events/{eventName}",
+		func(w http.ResponseWriter, r *http.Request) {
+			http.Redirect(w, r, "/ims/app/events/"+r.PathValue("eventName")+"/incidents", http.StatusFound)
+		},
+	)
 	mux.Handle("GET /ims/auth/login",
 		AdaptTempl(template.Login(deployment), cfg.Core.CacheControlLong),
 	)

--- a/web/mux_test.go
+++ b/web/mux_test.go
@@ -73,7 +73,7 @@ func TestTemplEndpoints(t *testing.T) {
 	}
 }
 
-func TestCatchall(t *testing.T) {
+func TestRedirects(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 	cfg := conf.DefaultIMS()
@@ -96,6 +96,16 @@ func TestCatchall(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 	// Ta-da! Now there's no trailing slash
+	require.Equal(t, "/ims/app/events/SomeEvent/incidents", resp.Request.URL.Path)
+
+	// This will get redirected to the Incidents page
+	path = serverURL.JoinPath("/ims/app/events/SomeEvent")
+	httpReq, err = http.NewRequestWithContext(ctx, http.MethodGet, path.String(), nil)
+	require.NoError(t, err)
+	resp, err = client.Do(httpReq)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 	require.Equal(t, "/ims/app/events/SomeEvent/incidents", resp.Request.URL.Path)
 
 	// This won't match any endpoint


### PR DESCRIPTION
this sends those to /ims/app/events/EventName/incidents instead. I'm fairly sure the old IMS did that too.