### PR TITLE
fix display of hidden incident types

### DIFF
--- a/api/integration/helpers_test.go
+++ b/api/integration/helpers_test.go
@@ -107,12 +107,9 @@ func (a ApiHelper) editType(ctx context.Context, req imsjson.IncidentType) (*int
 	return &num, httpResp
 }
 
-func (a ApiHelper) getTypes(ctx context.Context, includeHidden bool) (imsjson.IncidentTypes, *http.Response) {
+func (a ApiHelper) getTypes(ctx context.Context) (imsjson.IncidentTypes, *http.Response) {
 	a.t.Helper()
 	path := a.serverURL.JoinPath("/ims/api/incident_types").String()
-	if includeHidden {
-		path += "?hidden=true"
-	}
 	bod, resp := a.imsGet(ctx, path, &imsjson.IncidentTypes{})
 	return *bod.(*imsjson.IncidentTypes), resp
 }

--- a/api/itype.go
+++ b/api/itype.go
@@ -60,7 +60,6 @@ func (action GetIncidentTypes) getIncidentTypes(req *http.Request) (imsjson.Inci
 	if err := req.ParseForm(); err != nil {
 		return response, herr.BadRequest("Unable to parse HTTP form", err).From("[ParseForm]")
 	}
-	includeHidden := req.Form.Get("hidden") == "true"
 	typeRows, err := action.imsDBQ.IncidentTypes(req.Context(), action.imsDBQ)
 	if err != nil {
 		return response, herr.InternalServerError("Failed to fetch Incident Types", err).From("[IncidentTypes]")
@@ -68,14 +67,12 @@ func (action GetIncidentTypes) getIncidentTypes(req *http.Request) (imsjson.Inci
 
 	for _, typeRow := range typeRows {
 		t := typeRow.IncidentType
-		if includeHidden || !t.Hidden {
-			response = append(response, imsjson.IncidentType{
-				ID:          t.ID,
-				Name:        ptr(t.Name),
-				Description: conv.SqlToString(t.Description),
-				Hidden:      ptr(t.Hidden),
-			})
-		}
+		response = append(response, imsjson.IncidentType{
+			ID:          t.ID,
+			Name:        ptr(t.Name),
+			Description: conv.SqlToString(t.Description),
+			Hidden:      ptr(t.Hidden),
+		})
 	}
 	slices.SortFunc(response, func(a, b imsjson.IncidentType) int {
 		return int(a.ID) - int(b.ID)

--- a/web/static/admin_types.js
+++ b/web/static/admin_types.js
@@ -43,7 +43,7 @@ async function loadAndDrawIncidentTypes() {
 }
 let adminIncidentTypes = null;
 async function loadAllIncidentTypes() {
-    const { json, err } = await ims.fetchJsonNoThrow(url_incidentTypes + "?hidden=true", {
+    const { json, err } = await ims.fetchJsonNoThrow(url_incidentTypes, {
         headers: { "Cache-Control": "no-cache" },
     });
     if (err != null || json == null) {

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -943,8 +943,7 @@ async function addIncidentType() {
     // let validTypeInput: string = "";
     let validTypeInputId = null;
     for (const validType of allIncidentTypes) {
-        if (validType.name && normalizedTypeInput === normalize(validType.name)) {
-            // validTypeInput = validType.name;
+        if (!validType.hidden && validType.name && normalizedTypeInput === normalize(validType.name)) {
             validTypeInputId = validType.id ?? null;
             break;
         }

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -37,6 +37,8 @@ let _showRows = null;
 const defaultRows = 25;
 let allIncidentTypes = [];
 let allIncidentTypeIds = [];
+let visibleIncidentTypes = [];
+let visibleIncidentTypeIds = [];
 //
 // Initialize UI
 //
@@ -138,6 +140,8 @@ async function initIncidentsTable() {
         await ims.loadIncidentTypes().then(value => {
             allIncidentTypes = value.types;
             allIncidentTypeIds = value.types.map(it => it.id).filter(id => id != null);
+            visibleIncidentTypes = value.types.filter(it => !it.hidden);
+            visibleIncidentTypeIds = visibleIncidentTypes.map(it => it.id).filter(id => id != null);
         }),
         ims.loadStreets(ims.pathIds.eventID),
     ]).then(_ => { });
@@ -282,6 +286,7 @@ function initDataTables(tablePrereqs) {
                 "defaultContent": "",
                 "render": function (ids, _type, _incident) {
                     const vals = [];
+                    // render hidden incident types too here
                     for (const it of allIncidentTypes) {
                         if (ids.includes(it.id ?? -1) && it.name) {
                             vals.push(it.name);
@@ -368,7 +373,7 @@ function renderSummary(_data, type, incident) {
 //
 function initTableButtons() {
     const typeFilter = document.getElementById("ul_show_type");
-    for (const type of allIncidentTypes) {
+    for (const type of visibleIncidentTypes) {
         const a = document.createElement("a");
         a.href = "#";
         a.classList.add("dropdown-item", "dropdown-item-checkable", "dropdown-item-checked");
@@ -393,7 +398,7 @@ function initTableButtons() {
         let includeOthers = false;
         for (const t of types) {
             const typeId = ims.parseInt10(t);
-            if (typeId && allIncidentTypeIds.indexOf(typeId) !== -1) {
+            if (typeId && visibleIncidentTypeIds.indexOf(typeId) !== -1) {
                 validTypes.push(typeId);
             }
             else if (t === _blankPlaceholder) {
@@ -578,7 +583,7 @@ function setCheckedTypes(types, includeBlanks, includeOthers) {
     }
 }
 function toggleCheckAllTypes() {
-    if (_showTypes.length === 0 || _showTypes.length < allIncidentTypes.length) {
+    if (_showTypes.length === 0 || _showTypes.length < visibleIncidentTypes.length) {
         setCheckedTypes(allIncidentTypeIds, true, true);
     }
     else {
@@ -602,7 +607,7 @@ function readCheckedTypes() {
     }
 }
 function allTypesChecked() {
-    return _showTypes.length === allIncidentTypes.length && _showBlankType && _showOtherType;
+    return _showTypes.length === visibleIncidentTypes.length && _showBlankType && _showOtherType;
 }
 function showCheckedTypes(replaceState) {
     readCheckedTypes();

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -322,7 +322,8 @@ function initDataTables(tablePrereqs) {
             },
         ],
         "order": [
-            [0, "dsc"],
+            // 1 --> "Started" time
+            [1, "dsc"],
         ],
         "createdRow": function (row, incident, _index) {
             const openLink = function (e) {

--- a/web/typescript/admin_types.ts
+++ b/web/typescript/admin_types.ts
@@ -17,7 +17,6 @@
 "use strict";
 
 import * as ims from "./ims.ts";
-import {IncidentType} from "./ims.ts";
 
 declare global {
     interface Window {
@@ -65,7 +64,7 @@ async function loadAndDrawIncidentTypes(): Promise<void> {
 let adminIncidentTypes: ims.IncidentType[]|null = null;
 
 async function loadAllIncidentTypes(): Promise<{err:string|null}> {
-    const {json, err} = await ims.fetchJsonNoThrow<ims.IncidentType[]>(url_incidentTypes + "?hidden=true", {
+    const {json, err} = await ims.fetchJsonNoThrow<ims.IncidentType[]>(url_incidentTypes, {
         headers: {"Cache-Control": "no-cache"},
     });
     if (err != null || json == null) {
@@ -74,7 +73,7 @@ async function loadAllIncidentTypes(): Promise<{err:string|null}> {
         window.alert(message);
         return {err: message};
     }
-    json.sort((a: IncidentType, b: IncidentType): number => (a.name??"").localeCompare(b.name??""));
+    json.sort((a: ims.IncidentType, b: ims.IncidentType): number => (a.name??"").localeCompare(b.name??""));
     adminIncidentTypes = json;
     return {err: null};
 }

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1212,8 +1212,7 @@ async function addIncidentType(): Promise<void> {
     // let validTypeInput: string = "";
     let validTypeInputId: number|null = null;
     for (const validType of allIncidentTypes) {
-        if (validType.name && normalizedTypeInput === normalize(validType.name)) {
-            // validTypeInput = validType.name;
+        if (!validType.hidden && validType.name && normalizedTypeInput === normalize(validType.name)) {
             validTypeInputId = validType.id??null;
             break;
         }

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -377,7 +377,8 @@ function initDataTables(tablePrereqs: Promise<void>): void {
             },
         ],
         "order": [
-            [0, "dsc"],
+            // 1 --> "Started" time
+            [1, "dsc"],
         ],
         "createdRow": function (row: HTMLElement, incident: ims.Incident, _index: number) {
             const openLink = function(e: MouseEvent): void {

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -53,6 +53,8 @@ const defaultRows = 25;
 
 let allIncidentTypes: ims.IncidentType[] = [];
 let allIncidentTypeIds: number[] = [];
+let visibleIncidentTypes: ims.IncidentType[] = [];
+let visibleIncidentTypeIds: number[] = [];
 
 //
 // Initialize UI
@@ -177,6 +179,8 @@ async function initIncidentsTable(): Promise<void> {
             value=>{
                 allIncidentTypes=value.types;
                 allIncidentTypeIds=value.types.map(it=>it.id).filter(id=>id != null);
+                visibleIncidentTypes=value.types.filter(it=>!it.hidden);
+                visibleIncidentTypeIds=visibleIncidentTypes.map(it=>it.id).filter(id=>id != null);
             },
         ),
         ims.loadStreets(ims.pathIds.eventID),
@@ -337,6 +341,7 @@ function initDataTables(tablePrereqs: Promise<void>): void {
                 "defaultContent": "",
                 "render": function(ids: number[], _type: string, _incident: ims.Incident) {
                     const vals: string[] = [];
+                    // render hidden incident types too here
                     for (const it of allIncidentTypes) {
                         if (ids.includes(it.id??-1) && it.name) {
                             vals.push(it.name);
@@ -433,7 +438,7 @@ function renderSummary(_data: string|null, type: string, incident: ims.Incident)
 function initTableButtons(): void {
 
     const typeFilter = document.getElementById("ul_show_type") as HTMLUListElement;
-    for (const type of allIncidentTypes) {
+    for (const type of visibleIncidentTypes) {
         const a: HTMLAnchorElement = document.createElement("a");
         a.href = "#";
         a.classList.add("dropdown-item", "dropdown-item-checkable", "dropdown-item-checked");
@@ -462,7 +467,7 @@ function initTableButtons(): void {
         let includeOthers = false;
         for (const t of types) {
             const typeId = ims.parseInt10(t);
-            if (typeId && allIncidentTypeIds.indexOf(typeId) !== -1) {
+            if (typeId && visibleIncidentTypeIds.indexOf(typeId) !== -1) {
                 validTypes.push(typeId);
             } else if (t === _blankPlaceholder) {
                 includeBlanks = true;
@@ -683,7 +688,7 @@ function setCheckedTypes(types: number[], includeBlanks: boolean, includeOthers:
 }
 
 function toggleCheckAllTypes(): void {
-    if (_showTypes.length === 0 || _showTypes.length < allIncidentTypes.length) {
+    if (_showTypes.length === 0 || _showTypes.length < visibleIncidentTypes.length) {
         setCheckedTypes(allIncidentTypeIds, true, true);
     } else {
         setCheckedTypes([], false, false);
@@ -706,7 +711,7 @@ function readCheckedTypes(): void {
 }
 
 function allTypesChecked(): boolean {
-    return _showTypes.length === allIncidentTypes.length && _showBlankType && _showOtherType;
+    return _showTypes.length === visibleIncidentTypes.length && _showBlankType && _showOtherType;
 }
 
 function showCheckedTypes(replaceState: boolean): void {


### PR DESCRIPTION
I recently switched around the APIs to talk about incident types by their IDs, rather than by their names. That had a side effect of making hidden incident types vanish completely in the UI from incidents they had been previously attached to. This change does enough for those types to still appear in the UI on those incidents, but it stops the hidden incident types from showing up to be added to new incidents (or to be filtered by on the incidents page)