### PR TITLE
allow keyboard shortcuts to work when a checkbox/button/modal is active

### DIFF
--- a/web/static/field_report.js
+++ b/web/static/field_report.js
@@ -73,7 +73,7 @@ async function initFieldReportPage() {
     // Keyboard shortcuts
     document.addEventListener("keydown", function (e) {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
+        if (ims.blockKeyboardShortcutFieldActive()) {
             return;
         }
         // No shortcuts when ctrl, alt, or meta is being held down

--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -48,7 +48,7 @@ async function initFieldReportsPage() {
     // Keyboard shortcuts
     document.addEventListener("keydown", function (e) {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
+        if (ims.blockKeyboardShortcutFieldActive()) {
             return;
         }
         // No shortcuts when ctrl, alt, or meta is being held down

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -1168,6 +1168,23 @@ export function hideLoadingOverlay() {
         overlay.style.display = "none";
     }
 }
+// Returns whether an input text-ish field is active. This is meant to talk about fields
+// for which keyboard a-z letters are used, such as text field and select fields.
+export function blockKeyboardShortcutFieldActive() {
+    if (document.activeElement === document.body) {
+        return false;
+    }
+    if (document.activeElement instanceof HTMLElement && document.activeElement.classList.contains("modal")) {
+        return false;
+    }
+    if (document.activeElement instanceof HTMLInputElement) {
+        return document.activeElement.type !== "checkbox";
+    }
+    if (document.activeElement instanceof HTMLButtonElement) {
+        return false;
+    }
+    return true;
+}
 // Remove the old LocalStorage caches that IMS no longer uses, so that
 // they can't act against the ~5 MB per-domain limit of HTML5 LocalStorage.
 // This can probably be removed after the 2025 event, when all the relevant

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -122,7 +122,7 @@ async function initIncidentPage() {
     // Keyboard shortcuts
     document.addEventListener("keydown", function (e) {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
+        if (ims.blockKeyboardShortcutFieldActive()) {
             return;
         }
         // No shortcuts when ctrl, alt, or meta is being held down

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -75,7 +75,7 @@ async function initIncidentsPage() {
     // Keyboard shortcuts
     document.addEventListener("keydown", function (e) {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
+        if (ims.blockKeyboardShortcutFieldActive()) {
             return;
         }
         // No shortcuts when ctrl, alt, or meta is being held down

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -101,9 +101,10 @@ async function initFieldReportPage(): Promise<void> {
     // Keyboard shortcuts
     document.addEventListener("keydown", function(e: KeyboardEvent): void {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
+        if (ims.blockKeyboardShortcutFieldActive()) {
             return;
         }
+
         // No shortcuts when ctrl, alt, or meta is being held down
         if (e.altKey || e.ctrlKey || e.metaKey) {
             return;

--- a/web/typescript/field_reports.ts
+++ b/web/typescript/field_reports.ts
@@ -68,7 +68,7 @@ async function initFieldReportsPage(): Promise<void> {
     // Keyboard shortcuts
     document.addEventListener("keydown", function(e: KeyboardEvent): void {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
+        if (ims.blockKeyboardShortcutFieldActive()) {
             return;
         }
         // No shortcuts when ctrl, alt, or meta is being held down

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -1353,6 +1353,24 @@ export function hideLoadingOverlay(): void {
     }
 }
 
+// Returns whether an input text-ish field is active. This is meant to talk about fields
+// for which keyboard a-z letters are used, such as text field and select fields.
+export function blockKeyboardShortcutFieldActive(): boolean {
+    if (document.activeElement === document.body) {
+        return false;
+    }
+    if (document.activeElement instanceof HTMLElement && document.activeElement.classList.contains("modal")) {
+        return false;
+    }
+    if (document.activeElement instanceof HTMLInputElement) {
+        return document.activeElement.type !== "checkbox";
+    }
+    if (document.activeElement instanceof HTMLButtonElement) {
+        return false;
+    }
+    return true;
+}
+
 // Remove the old LocalStorage caches that IMS no longer uses, so that
 // they can't act against the ~5 MB per-domain limit of HTML5 LocalStorage.
 // This can probably be removed after the 2025 event, when all the relevant

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -172,8 +172,8 @@ async function initIncidentPage(): Promise<void> {
     // Keyboard shortcuts
     document.addEventListener("keydown", function(e: KeyboardEvent): void {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
-            return;
+        if (ims.blockKeyboardShortcutFieldActive()) {
+            return
         }
         // No shortcuts when ctrl, alt, or meta is being held down
         if (e.altKey || e.ctrlKey || e.metaKey) {

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -100,8 +100,8 @@ async function initIncidentsPage(): Promise<void> {
     // Keyboard shortcuts
     document.addEventListener("keydown", function(e: KeyboardEvent): void {
         // No shortcuts when an input field is active
-        if (document.activeElement !== document.body) {
-            return;
+        if (ims.blockKeyboardShortcutFieldActive()) {
+            return
         }
         // No shortcuts when ctrl, alt, or meta is being held down
         if (e.altKey || e.ctrlKey || e.metaKey) {


### PR DESCRIPTION
people gave feedback that they expected the shortcuts to work when elements like these were selected. This is kind of annoying logic to maintain in the JS, but it seems to work