### PR TITLE
add IMS action log

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -197,11 +197,8 @@ func (action GetAuth) getAuth(req *http.Request) (GetAuthResponse, *herr.HTTPErr
 		User:          handle,
 		Admin:         slices.Contains(roles, authz.Administrator),
 	}
-	if err := req.ParseForm(); err != nil {
-		return resp, herr.BadRequest("Failed to parse HTTP form", err).From("[ParseForm]")
-	}
 	// event_id is an optional query param for this endpoint
-	eventName := req.Form.Get("event_id")
+	eventName := req.FormValue("event_id")
 	if eventName != "" {
 		event, errHTTP := getEvent(req, eventName, action.imsDBQ)
 		if errHTTP != nil {

--- a/conf/imsconfig.go
+++ b/conf/imsconfig.go
@@ -41,6 +41,7 @@ func DefaultIMS() *IMSConfig {
 			CacheControlShort:    20 * time.Minute,
 			CacheControlLong:     2 * time.Hour,
 			MaxRequestBytes:      100 << 20,
+			ActionLogEnabled:     true,
 		},
 		Store: DBStore{
 			Type: DBStoreTypeFake,
@@ -247,6 +248,9 @@ type ConfigCore struct {
 	// MaxRequestBytes is a hard limit on request sizes that will be permitted by the API server.
 	// This serve as a backstop against accidentally or maliciously large requests.
 	MaxRequestBytes int64
+
+	// ActionLogEnabled is a global toggle switch for enabling writing to the ACTION_LOG table.
+	ActionLogEnabled bool
 }
 
 type DBStore struct {

--- a/lib/attachment/s3.go
+++ b/lib/attachment/s3.go
@@ -52,11 +52,14 @@ func NewS3Client(ctx context.Context) (*S3Client, error) {
 
 func (c *S3Client) UploadToS3(ctx context.Context, bucketName, objectName string, file io.Reader) *herr.HTTPError {
 	start := time.Now()
-	_, err := c.S3Funcs.PutObject(ctx, &s3.PutObjectInput{
-		Bucket: ptr(bucketName),
-		Key:    ptr(objectName),
-		Body:   file,
-	})
+	_, err := c.S3Funcs.PutObject(
+		ctx,
+		&s3.PutObjectInput{
+			Bucket: ptr(bucketName),
+			Key:    ptr(objectName),
+			Body:   file,
+		},
+	)
 	if err != nil {
 		return herr.InternalServerError("Failed to upload attachment to S3", err).From("[PutObject]")
 	}
@@ -66,10 +69,13 @@ func (c *S3Client) UploadToS3(ctx context.Context, bucketName, objectName string
 
 func (c *S3Client) GetObject(ctx context.Context, bucketName, objectName string) (file io.ReadSeeker, httpError *herr.HTTPError) {
 	start := time.Now()
-	output, err := c.S3Funcs.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: ptr(bucketName),
-		Key:    ptr(objectName),
-	})
+	output, err := c.S3Funcs.GetObject(
+		ctx,
+		&s3.GetObjectInput{
+			Bucket: ptr(bucketName),
+			Key:    ptr(objectName),
+		},
+	)
 	if err != nil {
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) && apiErr.ErrorCode() == "NoSuchKey" {

--- a/lib/conv/convert.go
+++ b/lib/conv/convert.go
@@ -119,3 +119,10 @@ func TimeToFloat(t time.Time) float64 {
 	decimalPart := float64(t.Nanosecond()) / 1e9
 	return decimalPart + float64(t.Unix())
 }
+
+func EmptyToNil(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/store/actionlog/actionlog.go
+++ b/store/actionlog/actionlog.go
@@ -1,0 +1,113 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package actionlog
+
+import (
+	"context"
+	"github.com/burningmantech/ranger-ims-go/store"
+	"github.com/burningmantech/ranger-ims-go/store/imsdb"
+	"log/slog"
+	"time"
+)
+
+const (
+	workQueueMaxLength = 1024
+	insertDeadline     = 10 * time.Second
+)
+
+type Logger struct {
+	work             chan imsdb.AddActionLogParams
+	imsDBQ           *store.DBQ
+	actionLogEnabled bool
+}
+
+func NewLogger(
+	ctx context.Context,
+	imsDBQ *store.DBQ,
+	actionLogEnabled bool,
+) *Logger {
+	logger := &Logger{
+		work:             make(chan imsdb.AddActionLogParams, workQueueMaxLength),
+		imsDBQ:           imsDBQ,
+		actionLogEnabled: actionLogEnabled,
+	}
+	go logger.startWorker(ctx)
+	return logger
+}
+
+func (l *Logger) Log(record imsdb.AddActionLogParams) {
+	if l.actionLogEnabled {
+		l.work <- record
+	}
+}
+
+func (l *Logger) Close() {}
+
+func (l *Logger) startWorker(ctx context.Context) {
+	for row := range l.work {
+		// We don't use loggerCtx here, since it gets cancelled soon after SIGINT.
+		// We use a different context, so that there's still a chance to write a final
+		// row before the server quits.
+		ctx, cancel := context.WithTimeout(ctx, insertDeadline)
+		_, err := l.imsDBQ.AddActionLog(ctx, l.imsDBQ, row)
+		if err != nil {
+			slog.Error("failed to add action log to db", "error", err)
+		}
+		cancel()
+	}
+	slog.Info("actionlog.Logger worker finished")
+}
+
+// Here's how this could work if we wanted to do batched inserts.
+// Delete this commented-out code by late 2025 if we never found the need for batched inserts.
+//
+// func (l *Logger) startWorker(insertBatchSize int, insertFlushInterval time.Duration) {
+//	var rows []imsdb.AddActionLogParams
+//	stillRunning := true
+//
+//	for stillRunning {
+//	innerLoop:
+//		for {
+//			select {
+//			case row := <-l.work:
+//				rows = append(rows, row)
+//				if len(rows) >= insertBatchSize {
+//					break innerLoop
+//				}
+//			case <-time.Tick(insertFlushInterval):
+//				break innerLoop
+//			case <-l.loggerCtx.Done():
+//				slog.Info("actionlog.Logger writing any final rows before shutting down")
+//				stillRunning = false
+//				break innerLoop
+//			}
+//		}
+//		if len(rows) > 0 {
+//			loggerCtx, cancel := context.WithTimeout(l.loggerCtx, insertDeadline)
+//			// TODO: do this with batched inserts instead, but we seemingly need sqlx for that
+//			for _, row := range rows {
+//				_, err := l.imsDBQ.AddActionLog(loggerCtx, l.imsDBQ, row)
+//				if err != nil {
+//					slog.Error("failed to add action log to db", "error", err)
+//				}
+//			}
+//			rows = rows[:0]
+//			cancel()
+//		}
+//	}
+//	slog.Info("actionlog.Logger worker stopped")
+//}

--- a/store/dbquerier.go
+++ b/store/dbquerier.go
@@ -335,3 +335,10 @@ func (l DBQ) DetachIncidentTypeFromIncident(ctx context.Context, db imsdb.DBTX, 
 	logQuery("DetachIncidentTypeFromIncident", start, err)
 	return err
 }
+
+func (l DBQ) AddActionLog(ctx context.Context, db imsdb.DBTX, arg imsdb.AddActionLogParams) (int64, error) {
+	start := time.Now()
+	id, err := l.q.AddActionLog(ctx, db, arg)
+	logQuery("AddActionLog", start, err)
+	return id, err
+}

--- a/store/imsdb/models.go
+++ b/store/imsdb/models.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"fmt"
+	"time"
 )
 
 type EventAccessMode string
@@ -194,6 +195,22 @@ func AllIncidentStateValues() []IncidentState {
 		IncidentStateOnScene,
 		IncidentStateClosed,
 	}
+}
+
+type ActionLog struct {
+	ID             int64
+	CreatedAt      time.Time
+	ActionType     string
+	Method         sql.NullString
+	Path           sql.NullString
+	Referrer       sql.NullString
+	UserID         sql.NullInt64
+	UserName       sql.NullString
+	PositionID     sql.NullInt64
+	PositionName   sql.NullString
+	ClientAddress  sql.NullString
+	HttpStatus     sql.NullInt16
+	DurationMicros sql.NullInt64
 }
 
 type ConcentricStreet struct {

--- a/store/imsdb/querier.go
+++ b/store/imsdb/querier.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Querier interface {
+	AddActionLog(ctx context.Context, db DBTX, arg AddActionLogParams) (int64, error)
 	AddEventAccess(ctx context.Context, db DBTX, arg AddEventAccessParams) (int64, error)
 	AttachFieldReportToIncident(ctx context.Context, db DBTX, arg AttachFieldReportToIncidentParams) error
 	AttachIncidentTypeToIncident(ctx context.Context, db DBTX, arg AttachIncidentTypeToIncidentParams) error

--- a/store/imsdb/queries.sql.go
+++ b/store/imsdb/queries.sql.go
@@ -10,6 +10,47 @@ import (
 	"database/sql"
 )
 
+const addActionLog = `-- name: AddActionLog :execlastid
+insert into ACTION_LOG
+    (ACTION_TYPE, METHOD, PATH, REFERRER, USER_ID, USER_NAME, POSITION_ID, POSITION_NAME, CLIENT_ADDRESS, HTTP_STATUS, DURATION_MICROS)
+values
+    (?,?,?,?,?,?,?,?,?,?,?)
+`
+
+type AddActionLogParams struct {
+	ActionType     string
+	Method         sql.NullString
+	Path           sql.NullString
+	Referrer       sql.NullString
+	UserID         sql.NullInt64
+	UserName       sql.NullString
+	PositionID     sql.NullInt64
+	PositionName   sql.NullString
+	ClientAddress  sql.NullString
+	HttpStatus     sql.NullInt16
+	DurationMicros sql.NullInt64
+}
+
+func (q *Queries) AddActionLog(ctx context.Context, db DBTX, arg AddActionLogParams) (int64, error) {
+	result, err := db.ExecContext(ctx, addActionLog,
+		arg.ActionType,
+		arg.Method,
+		arg.Path,
+		arg.Referrer,
+		arg.UserID,
+		arg.UserName,
+		arg.PositionID,
+		arg.PositionName,
+		arg.ClientAddress,
+		arg.HttpStatus,
+		arg.DurationMicros,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.LastInsertId()
+}
+
 const addEventAccess = `-- name: AddEventAccess :execlastid
 insert into EVENT_ACCESS (EVENT, EXPRESSION, MODE, VALIDITY)
 values (?, ?, ?, ?)

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -322,3 +322,10 @@ where ID = ?;
 -- name: CreateConcentricStreet :exec
 insert into CONCENTRIC_STREET (EVENT, ID, NAME)
 values (?, ?, ?);
+
+-- name: AddActionLog :execlastid
+insert into ACTION_LOG
+    (ACTION_TYPE, METHOD, PATH, REFERRER, USER_ID, USER_NAME, POSITION_ID, POSITION_NAME, CLIENT_ADDRESS, HTTP_STATUS, DURATION_MICROS)
+values
+    (?,?,?,?,?,?,?,?,?,?,?)
+;

--- a/store/schema/18-from-17.sql
+++ b/store/schema/18-from-17.sql
@@ -1,0 +1,27 @@
+create table `ACTION_LOG` (
+    `ID`                bigint not null auto_increment,
+    `CREATED_AT`        timestamp not null default current_timestamp,
+
+    -- request metadata
+    `ACTION_TYPE`       varchar(128) not null,
+    `METHOD`            varchar(128),
+    `PATH`              varchar(128),
+    `REFERRER`          varchar(128),
+
+    -- requestor metadata
+    `USER_ID`           bigint,
+    `USER_NAME`         varchar(128),
+    `POSITION_ID`       bigint,
+    `POSITION_NAME`     varchar(128),
+    `CLIENT_ADDRESS`    varchar(128),
+
+    -- response metadata
+    `HTTP_STATUS`       smallint,
+    `DURATION_MICROS`   bigint,
+
+    primary key (`ID`)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+update `SCHEMA_INFO`
+set `VERSION` = 18
+where true;

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -6,7 +6,7 @@ create table SCHEMA_INFO (
 -- This value must be updated when you make a new migration file.
 --
 
-insert into SCHEMA_INFO (VERSION) values (17);
+insert into SCHEMA_INFO (VERSION) values (18);
 
 
 create table `EVENT` (
@@ -172,4 +172,29 @@ create table FIELD_REPORT__REPORT_ENTRY (
         references REPORT_ENTRY(ID),
 
     primary key (`EVENT`, FIELD_REPORT_NUMBER, REPORT_ENTRY)
+) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+create table `ACTION_LOG` (
+    `ID`                bigint not null auto_increment,
+    `CREATED_AT`        timestamp not null default current_timestamp,
+
+    -- request metadata
+    `ACTION_TYPE`       varchar(128) not null,
+    `METHOD`            varchar(128),
+    `PATH`              varchar(128),
+    `REFERRER`          varchar(128),
+
+    -- requestor metadata
+    `USER_ID`           bigint,
+    `USER_NAME`         varchar(128),
+    `POSITION_ID`       bigint,
+    `POSITION_NAME`     varchar(128),
+    `CLIENT_ADDRESS`    varchar(128),
+
+    -- response metadata
+    `HTTP_STATUS`       smallint,
+    `DURATION_MICROS`   bigint,
+
+    primary key (`ID`)
 ) DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
this achieves a good balance of adding useful information without being too noisy. If we logged every API call for the incident and field report endpoints, we'd get way too much cruft, since SSEs on any incident/FR change cause all connected clients to update themselves constantly.

https://github.com/burningmantech/ranger-ims-go/issues/35