### PR TITLE
don't record eventsource calls to action log

### DIFF
--- a/api/mux.go
+++ b/api/mux.go
@@ -348,7 +348,7 @@ func AddToMux(
 		Adapt(
 			es.Server.Handler(EventSourceChannel),
 			RecoverFromPanic(),
-			LogRequest(true, actionLogger, userStore),
+			LogRequest(false, actionLogger, userStore),
 			LimitRequestBytes(cfg.Core.MaxRequestBytes),
 		),
 	)


### PR DESCRIPTION
this is way too chatty on AWS, where connections have to be re-established every 100 seconds