### PR TITLE
temporarily re-enable CDN caching of our JS files

### DIFF
--- a/web/mux.go
+++ b/web/mux.go
@@ -64,10 +64,11 @@ func AddToMux(mux *http.ServeMux, cfg *conf.IMSConfig) *http.ServeMux {
 			http.StripPrefix("/ims/", http.FileServerFS(StaticFS)).ServeHTTP,
 			// Cache IMS's internal JS and CSS for a shorter duration than external JS/CSS
 			// and logos, since we want updates to these files to get sent out to users
-			// somewhat soon after deployment to production. If we don't do some custom
-			// overriding here, then Cloudflare sets a 4-hour Cache-Control header.
+			// somewhat soon after deployment to production.
 			CacheControl(cfg.Core.CacheControlShort),
-			CdnCacheControlOff(),
+			// Uncomment this line when larger code changes are expected to the frontend, so
+			// that clients won't cache the JS files for so long.
+			// CdnCacheControlOff(),
 		),
 	)
 	mux.Handle("GET /ims/app",


### PR DESCRIPTION
I've occasionally been seeing Cloudflare error pages when trying to access IMS staging, and I'm wondering our disabling of CDN caching could be impacting that.