### PR TITLE
fix regexp-based searching involving spaces

### DIFF
--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -254,11 +254,13 @@ function frInitSearchField() {
         frReplaceWindowState();
         let q = searchInput.value;
         let isRegex = false;
+        let smartSearch = true;
         if (q.startsWith("/") && q.endsWith("/")) {
             isRegex = true;
+            smartSearch = false;
             q = q.slice(1, q.length - 1);
         }
-        fieldReportsTable.search(q, isRegex);
+        fieldReportsTable.search(q, isRegex, smartSearch);
         fieldReportsTable.draw();
     }
     const fragmentParams = ims.windowFragmentParams();

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -426,11 +426,13 @@ function initSearchField() {
         replaceWindowState();
         let q = searchInput.value;
         let isRegex = false;
+        let smartSearch = true;
         if (q.startsWith("/") && q.endsWith("/")) {
             isRegex = true;
+            smartSearch = false;
             q = q.slice(1, q.length - 1);
         }
-        incidentsTable.search(q, isRegex);
+        incidentsTable.search(q, isRegex, smartSearch);
         incidentsTable.draw();
     }
     const fragmentParams = ims.windowFragmentParams();

--- a/web/typescript/field_reports.ts
+++ b/web/typescript/field_reports.ts
@@ -300,11 +300,13 @@ function frInitSearchField(): void {
         frReplaceWindowState();
         let q = searchInput.value;
         let isRegex = false;
+        let smartSearch = true;
         if (q.startsWith("/") && q.endsWith("/")) {
             isRegex = true;
+            smartSearch = false;
             q = q.slice(1, q.length-1);
         }
-        fieldReportsTable!.search(q, isRegex);
+        fieldReportsTable!.search(q, isRegex, smartSearch);
         fieldReportsTable!.draw();
     }
 

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -498,11 +498,13 @@ function initSearchField() {
         replaceWindowState();
         let q = searchInput.value;
         let isRegex = false;
+        let smartSearch = true;
         if (q.startsWith("/") && q.endsWith("/")) {
             isRegex = true;
+            smartSearch = false;
             q = q.slice(1, q.length-1);
         }
-        incidentsTable!.search(q, isRegex);
+        incidentsTable!.search(q, isRegex, smartSearch);
         incidentsTable!.draw();
     }
 


### PR DESCRIPTION
Previously a search of /dog cat/ would match any incident containing dog and cat, because "smart search" separates the input on spaces before actually considering it as a regexp. Clearly we should want /dog cat/ to only match "dog cat".

fixes #288