### PR TITLE
use Mutex rather than WeightedSemaphore to limit Argon2id access

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -91,7 +91,7 @@ func (action PostAuth) postAuth(req *http.Request) (PostAuthResponse, *http.Cook
 		)
 	}
 
-	correct, err := authn.Verify(req.Context(), vals.Password, matchedPerson.Password)
+	correct, err := authn.Verify(vals.Password, matchedPerson.Password)
 	if err != nil {
 		return empty, nil, herr.InternalServerError("Invalid stored password. Get in touch with the tech team.", err).From("[Verify]")
 	}

--- a/directory/fakeclubhousedb/seed.sql
+++ b/directory/fakeclubhousedb/seed.sql
@@ -11,6 +11,7 @@ alter table `person`
 insert into `person`
 (`id`,  `callsign`, `email`,                `password`,                     `status`,   `on_site`)
 values
+-- This password is "Hardware"
 (600,   "Hardware", "hardware@example.com", "$argon2id$v=19$m=65536,t=3,p=4$ipVDinFcaxnDwt20s1YPZg$Y1XUdJBb4+VVy7hQ29ORNZvgsMu7ySbzLfdXgGMO6lo",  "active",   true),
 (601,   "Loosy",    "loosy@example.com",    concat(":", sha1("Loosy")),     "active",   true),
 (602,   "Doggy",    "doggy@example.com",    concat(":", sha1("Doggy")),     "active",   true),

--- a/lib/authn/password_test.go
+++ b/lib/authn/password_test.go
@@ -32,11 +32,11 @@ func TestVerifyPassword_success(t *testing.T) {
 	assert.Equal(t, hashed, authn.Hash(pw, s))
 
 	stored := "my_little_salty:" + hashed
-	vp, err := authn.Verify(t.Context(), pw, stored)
+	vp, err := authn.Verify(pw, stored)
 	require.NoError(t, err)
 	assert.True(t, vp)
 
-	vp, err = authn.Verify(t.Context(), "wrong password", stored)
+	vp, err = authn.Verify("wrong password", stored)
 	require.NoError(t, err)
 	assert.False(t, vp)
 }
@@ -44,7 +44,7 @@ func TestVerifyPassword_success(t *testing.T) {
 func TestVerifyPassword_badStoredValue(t *testing.T) {
 	t.Parallel()
 	noColonInThisString := "abcdefg"
-	_, err := authn.Verify(t.Context(), "some_password", noColonInThisString)
+	_, err := authn.Verify("some_password", noColonInThisString)
 	require.Error(t, err)
 	require.Contains(t, "invalid hashed password", err.Error())
 }
@@ -53,7 +53,7 @@ func TestNewSalted(t *testing.T) {
 	t.Parallel()
 	pw := "this is my password"
 	saltedPw := authn.NewSaltedSha1(pw)
-	isValid, err := authn.Verify(t.Context(), pw, saltedPw)
+	isValid, err := authn.Verify(pw, saltedPw)
 	require.NoError(t, err)
 	require.True(t, isValid)
 }
@@ -71,7 +71,7 @@ func FuzzNewSaltedVerify(f *testing.F) {
 		assert.Contains(t, saltedHashed, ":")
 		// we use a base64-encoded salt that takes 22 bytes, then ":" is 1, and the hash is 40
 		assert.Len(t, saltedHashed, 63)
-		isValid, err := authn.Verify(t.Context(), pw, saltedHashed)
+		isValid, err := authn.Verify(pw, saltedHashed)
 		require.NoError(t, err)
 		assert.True(t, isValid)
 	})
@@ -81,11 +81,11 @@ func TestHashArgon2id(t *testing.T) {
 	t.Parallel()
 	hash := authn.NewSaltedArgon2idDevOnly("my password 123")
 
-	isValid, err := authn.Verify(t.Context(), "my password wrong", hash)
+	isValid, err := authn.Verify("my password wrong", hash)
 	require.NoError(t, err)
 	assert.False(t, isValid)
 
-	isValid, err = authn.Verify(t.Context(), "my password 123", hash)
+	isValid, err = authn.Verify("my password 123", hash)
 	require.NoError(t, err)
 	assert.True(t, isValid)
 }


### PR DESCRIPTION
the WeightedSemaphore approach seemed needlessly complicated. We're fine just restricting to no more than one Argon2id hash invocation at once, which means we can use a simple Mutex.

https://github.com/burningmantech/ranger-ims-go/issues/294