### PR TITLE
read cgroup memory.stat file

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -75,16 +75,17 @@ func runServerInternal(
 
 	configureLogger(imsCfg)
 
+	cgroupMemStat, err := os.ReadFile("/sys/fs/cgroup/memory/memory.stat")
+	slog.Info("found cgroup memory.stat file", "contents", string(cgroupMemStat), "err", err)
+
 	ecsMetadataUri := os.Getenv("ECS_CONTAINER_METADATA_URI_V4")
 	if ecsMetadataUri != "" {
-		go func() {
-			// From AWS docs:
-			// Amazon ECS tasks on AWS Fargate require that the container run
-			// for ~1 second prior to returning the container stats.
-			time.Sleep(5 * time.Second)
-			err := fetchECSDockerStats(ecsMetadataUri)
-			slog.Info("Fetched ECS Docker stats", "err", err)
-		}()
+		// From AWS docs:
+		// Amazon ECS tasks on AWS Fargate require that the container run
+		// for ~1 second prior to returning the container stats.
+		time.Sleep(2 * time.Second)
+		err := fetchECSDockerStats(ecsMetadataUri)
+		slog.Info("Fetched ECS Docker stats", "err", err)
 	}
 
 	if printConfig {


### PR DESCRIPTION
I think I've finally found the number I've been seeking, and it's hierarchical_memory_limit in /sys/fs/cgroup/memory/memory.stat

that should tell me how much memory the container is allowed to use when running on Fargate/ECS.

https://github.com/burningmantech/ranger-ims-go/issues/302