### PR TITLE
stop logging when user needs a new refresh token

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -177,7 +177,7 @@ func tuneMemoryLimit() {
 	if err != nil {
 		return
 	}
-	slog.Info("found cgroup memory.stat file", "contents", string(cgroupMemStat), "err", err)
+	slog.Debug("found cgroup memory.stat file", "contents", string(cgroupMemStat), "err", err)
 	const targetLine = "hierarchical_memory_limit "
 	for _, line := range strings.Split(string(cgroupMemStat), "\n") {
 		if strings.HasPrefix(line, targetLine) {
@@ -192,10 +192,11 @@ func tuneMemoryLimit() {
 	}
 	if memLimitBytes != 0 {
 		// reduce by 20%, to allow for any other memory overhead needed in the VM.
-		memLimitBytes = memLimitBytes / 5 * 4
-		debug.SetMemoryLimit(memLimitBytes)
+		newMemLimitBytes := memLimitBytes / 5 * 4
+		debug.SetMemoryLimit(newMemLimitBytes)
 		slog.Info("Set Go memory limit below the cgroup-permitted amount",
-			"GOMEMLIMIT", memLimitBytes,
+			"cgroup-memlimit", memLimitBytes,
+			"GOMEMLIMIT", newMemLimitBytes,
 		)
 		return
 	}

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -810,7 +810,6 @@ function reportEntryElement(entry) {
             document.body.removeChild(tmpLink);
             URL.revokeObjectURL(blobUrl);
         };
-        entryContainer.append(downloadButt);
         if (entry.attachment?.previewable) {
             const previewButt = document.createElement("button");
             previewButt.textContent = "Preview";
@@ -844,6 +843,7 @@ function reportEntryElement(entry) {
             };
             entryContainer.append(previewButt);
         }
+        entryContainer.append(downloadButt);
     }
     // Add a horizontal line after each entry
     const hr = document.createElement("hr");

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -938,7 +938,6 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             document.body.removeChild(tmpLink);
             URL.revokeObjectURL(blobUrl);
         };
-        entryContainer.append(downloadButt);
 
         if (entry.attachment?.previewable) {
             const previewButt: HTMLButtonElement = document.createElement("button");
@@ -977,6 +976,7 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             };
             entryContainer.append(previewButt);
         }
+        entryContainer.append(downloadButt);
     }
 
     // Add a horizontal line after each entry


### PR DESCRIPTION
it was silly logging everytime a client called to refresh their access token when they had no refresh cookie.

this also cleans up the memlimit code a bit, to make the logging better.