### PR TITLE
state in file attachment errors that AWS connectivity may be to blame

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ run: build
 .PHONY: run/live
 run/live:
 	go tool air \
-		--build.cmd "make build" --build.bin "./${binary_name} serve --print-config=false" --build.delay "100" \
+		--build.cmd "make build" --build.bin "./${binary_name}" --build.args_bin "serve,--print-config=false" --build.delay "100" \
 		--build.include_ext "go,tpl,tmpl,templ,html,css,scss,js,ts,sql,jpeg,jpg,gif,png,bmp,svg,webp,ico,env" \
 		--build.exclude_file "web/template/*_templ.go,web/static/*.js,store/imsdb/*.go,directory/clubhousedb/*.go" \
 		--build.exclude_dir "playwright,ims-attachments" \

--- a/web/static/field_report.js
+++ b/web/static/field_report.js
@@ -365,7 +365,7 @@ async function attachFile() {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file: ${err}`;
+        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -796,7 +796,7 @@ function reportEntryElement(entry) {
             e.preventDefault();
             const { resp, err } = await fetchJsonNoThrow(url, {});
             if (err != null || resp == null) {
-                setErrorMessage(`Failed to fetch attachment: ${err}`);
+                setErrorMessage(`Failed to fetch attachment, possibly due to IMS being unable to reach AWS: ${err}`);
                 return;
             }
             const blobUrl = window.URL.createObjectURL(await resp.blob());
@@ -818,7 +818,7 @@ function reportEntryElement(entry) {
                 e.preventDefault();
                 const { resp, err } = await fetchJsonNoThrow(url, {});
                 if (err != null || resp == null) {
-                    setErrorMessage(`Failed to fetch attachment: ${err}`);
+                    setErrorMessage(`Failed to fetch attachment, possibly due to IMS being unable to reach AWS: ${err}`);
                     return;
                 }
                 const blobUrl = window.URL.createObjectURL(await resp.blob());

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -1051,7 +1051,7 @@ async function attachFile() {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file: ${err}`;
+        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -437,7 +437,7 @@ async function attachFile(): Promise<void> {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file: ${err}`;
+        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -922,7 +922,7 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             e.preventDefault();
             const {resp, err} = await fetchJsonNoThrow(url, {});
             if (err != null || resp == null) {
-                setErrorMessage(`Failed to fetch attachment: ${err}`);
+                setErrorMessage(`Failed to fetch attachment, possibly due to IMS being unable to reach AWS: ${err}`);
                 return;
             }
             const blobUrl: string = window.URL.createObjectURL(await resp.blob());
@@ -947,7 +947,7 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
                 e.preventDefault();
                 const {resp, err} = await fetchJsonNoThrow(url, {});
                 if (err != null || resp == null) {
-                    setErrorMessage(`Failed to fetch attachment: ${err}`);
+                    setErrorMessage(`Failed to fetch attachment, possibly due to IMS being unable to reach AWS: ${err}`);
                     return;
                 }
                 const blobUrl: string = window.URL.createObjectURL(await resp.blob());

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1339,7 +1339,7 @@ async function attachFile(): Promise<void> {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file: ${err}`;
+        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
         ims.setErrorMessage(message);
         return;
     }


### PR DESCRIPTION
we'll be running on-playa with IMS uploading/downloading files to S3. If there are internet outages, file attachments will be temporarily unavailable.

also fix an issue with the `make run/live` for `air`. That broke recently due to https://github.com/air-verse/air/issues/773