### PR TITLE
improve error message when IMS can't connect to S3

### DIFF
--- a/lib/attachment/s3.go
+++ b/lib/attachment/s3.go
@@ -61,7 +61,7 @@ func (c *S3Client) UploadToS3(ctx context.Context, bucketName, objectName string
 		},
 	)
 	if err != nil {
-		return herr.InternalServerError("Failed to upload attachment to S3", err).From("[PutObject]")
+		return herr.InternalServerError("IMS failed to upload the file to S3. There may be an internet connectivity issue.", err).From("[PutObject]")
 	}
 	slog.Debug("Uploaded attachment to S3", "objectName", objectName, "duration", time.Since(start))
 	return nil
@@ -83,7 +83,7 @@ func (c *S3Client) GetObject(ctx context.Context, bucketName, objectName string)
 
 			return nil, herr.NotFound("File does not exist", err).From("[GetObject]")
 		}
-		return nil, herr.InternalServerError("Failed to get attachment", err).From("[GetObject]")
+		return nil, herr.InternalServerError("IMS failed to pull the file from S3. There may be an internet connectivity issue.", err).From("[GetObject]")
 	}
 
 	// This reads the whole object in memory, which isn't ideal, but it lets us use the

--- a/web/static/admin_action_logs.js
+++ b/web/static/admin_action_logs.js
@@ -72,7 +72,7 @@ async function initAdminActionLogsPage() {
                 if (filterPath) {
                     params.set("path", filterPath);
                 }
-                const { json, err } = await ims.fetchJsonNoThrow(`${url_actionlogs}?${params.toString()}`, null);
+                const { json, err } = await ims.fetchNoThrow(`${url_actionlogs}?${params.toString()}`, null);
                 if (err != null || json == null) {
                     ims.setErrorMessage(`Failed to load table: ${err}`);
                     return;
@@ -174,7 +174,7 @@ function renderPage(pagePath, type, _data) {
     return undefined;
 }
 async function fetchActionLogs() {
-    const { json, err } = await ims.fetchJsonNoThrow(url_actionlogs, {});
+    const { json, err } = await ims.fetchNoThrow(url_actionlogs, {});
     if (err != null) {
         throw err;
     }

--- a/web/static/admin_debug.js
+++ b/web/static/admin_debug.js
@@ -32,7 +32,7 @@ async function initAdminDebugPage() {
     window.performGC = performGC;
 }
 async function fetchBuildInfo() {
-    const { resp, err } = await ims.fetchJsonNoThrow(url_debugBuildInfo, {});
+    const { resp, err } = await ims.fetchNoThrow(url_debugBuildInfo, {});
     if (err != null || resp == null) {
         throw err;
     }
@@ -62,7 +62,7 @@ function substringBetween(s, start, end) {
     return s.substring(substrBeginInd, endInd);
 }
 async function fetchRuntimeMetrics() {
-    const { resp, err } = await ims.fetchJsonNoThrow(url_debugRuntimeMetrics, {});
+    const { resp, err } = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
     if (err != null || resp == null) {
         throw err;
     }
@@ -72,7 +72,7 @@ async function fetchRuntimeMetrics() {
     targetDiv.style.display = "";
 }
 async function performGC() {
-    const { resp, err } = await ims.fetchJsonNoThrow(url_debugGC, { body: JSON.stringify({}) });
+    const { resp, err } = await ims.fetchNoThrow(url_debugGC, { body: JSON.stringify({}) });
     if (err != null || resp == null) {
         throw err;
     }

--- a/web/static/admin_events.js
+++ b/web/static/admin_events.js
@@ -48,10 +48,10 @@ let accessControlList = null;
 async function loadAccessControlList() {
     // we don't actually need the response from this API, but we want to
     // invalidate the local HTTP cache in the admin's browser
-    ims.fetchJsonNoThrow(url_events, {
+    ims.fetchNoThrow(url_events, {
         headers: { "Cache-Control": "no-cache" },
     });
-    const { json, err } = await ims.fetchJsonNoThrow(url_acl, null);
+    const { json, err } = await ims.fetchNoThrow(url_acl, null);
     if (err != null) {
         const message = `Failed to load access control list: ${err}`;
         console.error(message);
@@ -142,7 +142,7 @@ function updateEventAccess(event, mode) {
 }
 async function addEvent(sender) {
     const event = sender.value.trim();
-    const { err } = await ims.fetchJsonNoThrow(url_events, {
+    const { err } = await ims.fetchNoThrow(url_events, {
         body: JSON.stringify({
             "add": [event],
         }),
@@ -269,7 +269,7 @@ async function setValidity(sender) {
     sender.value = ""; // Clear input field
 }
 async function sendACL(edits) {
-    const { err } = await ims.fetchJsonNoThrow(url_acl, {
+    const { err } = await ims.fetchNoThrow(url_acl, {
         body: JSON.stringify(edits),
     });
     if (err == null) {

--- a/web/static/admin_streets.js
+++ b/web/static/admin_streets.js
@@ -37,7 +37,7 @@ async function initAdminStreetsPage() {
 }
 let streets = {};
 async function loadStreets() {
-    const { json, err } = await ims.fetchJsonNoThrow(url_streets, null);
+    const { json, err } = await ims.fetchNoThrow(url_streets, null);
     if (err != null) {
         const message = `Failed to load streets: ${err}`;
         console.error(message);
@@ -114,7 +114,7 @@ function removeStreet(_sender) {
     alert("Remove is unsupported for streets. Do this via SQL instead.");
 }
 async function sendStreets(edits) {
-    const { err } = await ims.fetchJsonNoThrow(url_streets, {
+    const { err } = await ims.fetchNoThrow(url_streets, {
         body: JSON.stringify(edits),
     });
     if (err != null) {

--- a/web/static/admin_types.js
+++ b/web/static/admin_types.js
@@ -43,7 +43,7 @@ async function loadAndDrawIncidentTypes() {
 }
 let adminIncidentTypes = null;
 async function loadAllIncidentTypes() {
-    const { json, err } = await ims.fetchJsonNoThrow(url_incidentTypes, {
+    const { json, err } = await ims.fetchNoThrow(url_incidentTypes, {
         headers: { "Cache-Control": "no-cache" },
     });
     if (err != null || json == null) {
@@ -162,7 +162,7 @@ async function setIncidentTypeDescription(sender) {
     await loadAndDrawIncidentTypes();
 }
 async function sendIncidentTypes(edits) {
-    const { err } = await ims.fetchJsonNoThrow(url_incidentTypes, {
+    const { err } = await ims.fetchNoThrow(url_incidentTypes, {
         body: JSON.stringify(edits),
     });
     if (err == null) {

--- a/web/static/field_report.js
+++ b/web/static/field_report.js
@@ -136,7 +136,7 @@ async function loadFieldReport() {
         };
     }
     else {
-        const { json, err } = await ims.fetchJsonNoThrow(`${ims.urlReplace(url_fieldReports)}/${number}`, null);
+        const { json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_fieldReports)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
             const message = "Failed to load field report: " + err;
@@ -255,7 +255,7 @@ async function frSendEdits(edits) {
         edits.number = number;
         url += `/${number}`;
     }
-    const { resp, err } = await ims.fetchJsonNoThrow(url, {
+    const { resp, err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify(edits),
     });
     if (err != null) {
@@ -307,7 +307,7 @@ async function makeIncident() {
     if (fieldReport.report_entries) {
         authors.push(fieldReport.report_entries[0].author ?? "null");
     }
-    const { resp, err } = await ims.fetchJsonNoThrow(incidentsURL, {
+    const { resp, err } = await ims.fetchNoThrow(incidentsURL, {
         body: JSON.stringify({
             "summary": fieldReport.summary,
             "ranger_handles": authors,
@@ -328,7 +328,7 @@ async function makeIncident() {
     // Attach this FR to that new incident
     const attachToIncidentUrl = `${ims.urlReplace(url_fieldReports)}/${fieldReport.number}` +
         `?action=attach&incident=${fieldReport.incident}`;
-    const { err: attachErr } = await ims.fetchJsonNoThrow(attachToIncidentUrl, {
+    const { err: attachErr } = await ims.fetchNoThrow(attachToIncidentUrl, {
         body: JSON.stringify({}),
     });
     if (attachErr != null) {
@@ -361,11 +361,11 @@ async function attachFile() {
     }
     const attachURL = ims.urlReplace(url_fieldReportAttachments)
         .replace("<field_report_number>", (ims.pathIds.fieldReportNumber ?? "").toString());
-    const { err } = await ims.fetchJsonNoThrow(attachURL, {
+    const { text, err } = await ims.fetchNoThrow(attachURL, {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
+        const message = `Failed to attach file. ${text}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -146,7 +146,7 @@ function frInitDataTables() {
         // https://datatables.net/forums/discussion/47411/i-always-get-error-when-i-use-table-ajax-reload
         "ajax": function (_data, callback, _settings) {
             async function doAjax() {
-                const { json, err } = await ims.fetchJsonNoThrow(
+                const { json, err } = await ims.fetchNoThrow(
                 // don't use exclude_system_entries here, since the field reports
                 // per-user authorization can exclude field reports entirely from
                 // someone who created a field report but then didn't add an

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -223,7 +223,7 @@ async function loadIncident() {
         };
     }
     else {
-        const { json, err } = await ims.fetchJsonNoThrow(`${ims.urlReplace(url_incidents)}/${number}`, null);
+        const { json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_incidents)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
             const message = `Failed to load Incident ${number}: ${err}`;
@@ -267,7 +267,7 @@ function renderFieldReportData() {
 //
 let personnel = null;
 async function loadPersonnel() {
-    const { json, err } = await ims.fetchJsonNoThrow(ims.urlReplace(url_personnel + "?event_id=<event_id>"), null);
+    const { json, err } = await ims.fetchNoThrow(ims.urlReplace(url_personnel + "?event_id=<event_id>"), null);
     if (err != null) {
         const message = `Failed to load personnel: ${err}`;
         console.error(message);
@@ -298,7 +298,7 @@ async function loadAllFieldReports() {
     if (allFieldReports === undefined) {
         return { err: null };
     }
-    const { resp, json, err } = await ims.fetchJsonNoThrow(ims.urlReplace(url_fieldReports), null);
+    const { resp, json, err } = await ims.fetchNoThrow(ims.urlReplace(url_fieldReports), null);
     if (err != null) {
         if (resp != null && resp.status === 403) {
             // We're not allowed to look these up.
@@ -329,7 +329,7 @@ async function loadOneFieldReport(fieldReportNumber) {
     if (allFieldReports === undefined) {
         return { err: null };
     }
-    const { resp, json, err } = await ims.fetchJsonNoThrow(ims.urlReplace(url_fieldReport).replace("<field_report_number>", fieldReportNumber.toString()), null);
+    const { resp, json, err } = await ims.fetchNoThrow(ims.urlReplace(url_fieldReport).replace("<field_report_number>", fieldReportNumber.toString()), null);
     if (err != null) {
         if (resp == null || resp.status !== 403) {
             const message = `Failed to load field report ${fieldReportNumber} ${err}`;
@@ -768,7 +768,7 @@ async function sendEdits(edits) {
         edits.number = number;
         url += `/${number}`;
     }
-    const { resp, err } = await ims.fetchJsonNoThrow(url, {
+    const { resp, err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify(edits),
     });
     if (err != null) {
@@ -981,7 +981,7 @@ async function detachFieldReport(sender) {
     const frNumber = parent.dataset["frNumber"];
     const url = (`${ims.urlReplace(url_fieldReports)}/${frNumber}` +
         `?action=detach&incident=${ims.pathIds.incidentNumber}`);
-    const { err } = await ims.fetchJsonNoThrow(url, {
+    const { err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify({}),
     });
     if (err != null) {
@@ -1007,7 +1007,7 @@ async function attachFieldReport() {
     const fieldReportNumber = select.value;
     const url = (`${ims.urlReplace(url_fieldReports)}/${fieldReportNumber}` +
         `?action=attach&incident=${ims.pathIds.incidentNumber}`);
-    const { err } = await ims.fetchJsonNoThrow(url, {
+    const { err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify({}),
     });
     if (err != null) {
@@ -1047,11 +1047,11 @@ async function attachFile() {
     }
     const attachURL = ims.urlReplace(url_incidentAttachments)
         .replace("<incident_number>", (ims.pathIds.incidentNumber ?? "").toString());
-    const { err } = await ims.fetchJsonNoThrow(attachURL, {
+    const { text, err } = await ims.fetchNoThrow(attachURL, {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
+        const message = `Failed to attach file. ${text}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -115,7 +115,7 @@ async function initIncidentsPage() {
 // attached field reports.
 let eventFieldReports = undefined;
 async function loadEventFieldReports() {
-    const { json, err } = await ims.fetchJsonNoThrow(ims.urlReplace(url_fieldReports + "?exclude_system_entries=true"), null);
+    const { json, err } = await ims.fetchNoThrow(ims.urlReplace(url_fieldReports + "?exclude_system_entries=true"), null);
     if (err != null) {
         const message = `Failed to load event field reports: ${err}`;
         console.error(message);
@@ -169,7 +169,7 @@ async function initIncidentsTable() {
         if (event !== ims.pathIds.eventID) {
             return;
         }
-        const { json, err } = await ims.fetchJsonNoThrow(ims.urlReplace(url_incidentNumber).replace("<incident_number>", number.toString()), null);
+        const { json, err } = await ims.fetchNoThrow(ims.urlReplace(url_incidentNumber).replace("<incident_number>", number.toString()), null);
         if (err != null) {
             const message = `Failed to update Incident ${number}: ${err}`;
             console.error(message);
@@ -231,7 +231,7 @@ function initDataTables(tablePrereqs) {
                 await Promise.all([
                     tablePrereqs,
                     loadEventFieldReports(),
-                    ims.fetchJsonNoThrow(ims.urlReplace(url_incidents + "?exclude_system_entries=true"), null).then(res => {
+                    ims.fetchNoThrow(ims.urlReplace(url_incidents + "?exclude_system_entries=true"), null).then(res => {
                         if (res.err != null || res.json == null) {
                             ims.setErrorMessage(`Failed to load table: ${res.err}`);
                             return;

--- a/web/static/login.js
+++ b/web/static/login.js
@@ -32,7 +32,7 @@ async function initLoginPage() {
 async function login() {
     const username = document.getElementById("username_input").value;
     const password = document.getElementById("password_input").value;
-    const { json, err } = await ims.fetchJsonNoThrow(url_auth, {
+    const { json, err } = await ims.fetchNoThrow(url_auth, {
         body: JSON.stringify({
             "identification": username,
             "password": password,

--- a/web/typescript/admin_action_logs.ts
+++ b/web/typescript/admin_action_logs.ts
@@ -92,7 +92,7 @@ async function initAdminActionLogsPage(): Promise<void> {
                     params.set("path", filterPath);
                 }
 
-                const {json, err} = await ims.fetchJsonNoThrow<ActionLog[]>(
+                const {json, err} = await ims.fetchNoThrow<ActionLog[]>(
                     `${url_actionlogs}?${params.toString()}`, null,
                 );
                 if (err != null || json == null) {
@@ -200,7 +200,7 @@ function renderPage(pagePath: string|null, type: string, _data: any): string|und
 }
 
 async function fetchActionLogs(): Promise<void> {
-    const {json, err} = await ims.fetchJsonNoThrow<ActionLog>(url_actionlogs, {});
+    const {json, err} = await ims.fetchNoThrow<ActionLog>(url_actionlogs, {});
     if (err != null) {
         throw err;
     }

--- a/web/typescript/admin_debug.ts
+++ b/web/typescript/admin_debug.ts
@@ -44,7 +44,7 @@ async function initAdminDebugPage(): Promise<void> {
 }
 
 async function fetchBuildInfo(): Promise<void> {
-    const {resp, err} = await ims.fetchJsonNoThrow(url_debugBuildInfo, {});
+    const {resp, err} = await ims.fetchNoThrow(url_debugBuildInfo, {});
     if (err != null || resp == null) {
         throw err;
     }
@@ -77,7 +77,7 @@ function substringBetween(s: string, start: string, end: string): string {
 }
 
 async function fetchRuntimeMetrics(): Promise<void> {
-    const {resp, err} = await ims.fetchJsonNoThrow(url_debugRuntimeMetrics, {});
+    const {resp, err} = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
     if (err != null || resp == null) {
         throw err;
     }
@@ -88,7 +88,7 @@ async function fetchRuntimeMetrics(): Promise<void> {
 }
 
 async function performGC(): Promise<void> {
-    const {resp, err} = await ims.fetchJsonNoThrow(url_debugGC, {body: JSON.stringify({})});
+    const {resp, err} = await ims.fetchNoThrow(url_debugGC, {body: JSON.stringify({})});
     if (err != null || resp == null) {
         throw err;
     }

--- a/web/typescript/admin_events.ts
+++ b/web/typescript/admin_events.ts
@@ -84,10 +84,10 @@ let accessControlList: EventsAccess|null = null;
 async function loadAccessControlList() : Promise<{err: string|null}> {
     // we don't actually need the response from this API, but we want to
     // invalidate the local HTTP cache in the admin's browser
-    ims.fetchJsonNoThrow<ims.EventData[]>(url_events, {
+    ims.fetchNoThrow<ims.EventData[]>(url_events, {
         headers: {"Cache-Control": "no-cache"},
     });
-    const {json, err} = await ims.fetchJsonNoThrow<EventsAccess>(url_acl, null);
+    const {json, err} = await ims.fetchNoThrow<EventsAccess>(url_acl, null);
     if (err != null) {
         const message = `Failed to load access control list: ${err}`;
         console.error(message);
@@ -198,7 +198,7 @@ function updateEventAccess(event: string, mode: AccessMode): void {
 
 async function addEvent(sender: HTMLInputElement): Promise<void> {
     const event = sender.value.trim();
-    const {err} = await ims.fetchJsonNoThrow(url_events, {
+    const {err} = await ims.fetchNoThrow(url_events, {
         body: JSON.stringify({
             "add": [event],
         }),
@@ -356,7 +356,7 @@ async function setValidity(sender: HTMLSelectElement): Promise<void> {
 
 
 async function sendACL(edits: EventsAccess): Promise<{err:string|null}> {
-    const {err} = await ims.fetchJsonNoThrow(url_acl, {
+    const {err} = await ims.fetchNoThrow(url_acl, {
         body: JSON.stringify(edits),
     });
     if (err == null) {

--- a/web/typescript/admin_streets.ts
+++ b/web/typescript/admin_streets.ts
@@ -51,7 +51,7 @@ async function initAdminStreetsPage(): Promise<void> {
 let streets: ims.EventsStreets = {};
 
 async function loadStreets(): Promise<{err:string|null}> {
-    const {json, err} = await ims.fetchJsonNoThrow<ims.EventsStreets>(url_streets, null);
+    const {json, err} = await ims.fetchNoThrow<ims.EventsStreets>(url_streets, null);
     if (err != null) {
         const message = `Failed to load streets: ${err}`;
         console.error(message);
@@ -154,7 +154,7 @@ function removeStreet(_sender: HTMLInputElement): void {
 
 
 async function sendStreets(edits: ims.EventsStreets): Promise<{err: string|null}> {
-    const {err} = await ims.fetchJsonNoThrow(url_streets, {
+    const {err} = await ims.fetchNoThrow(url_streets, {
         body: JSON.stringify(edits),
     });
     if (err != null) {

--- a/web/typescript/admin_types.ts
+++ b/web/typescript/admin_types.ts
@@ -64,7 +64,7 @@ async function loadAndDrawIncidentTypes(): Promise<void> {
 let adminIncidentTypes: ims.IncidentType[]|null = null;
 
 async function loadAllIncidentTypes(): Promise<{err:string|null}> {
-    const {json, err} = await ims.fetchJsonNoThrow<ims.IncidentType[]>(url_incidentTypes, {
+    const {json, err} = await ims.fetchNoThrow<ims.IncidentType[]>(url_incidentTypes, {
         headers: {"Cache-Control": "no-cache"},
     });
     if (err != null || json == null) {
@@ -209,7 +209,7 @@ async function setIncidentTypeDescription(sender: HTMLTextAreaElement): Promise<
 }
 
 async function sendIncidentTypes(edits: ims.IncidentType): Promise<{err:string|null}> {
-    const {err} = await ims.fetchJsonNoThrow(url_incidentTypes, {
+    const {err} = await ims.fetchNoThrow(url_incidentTypes, {
         body: JSON.stringify(edits),
     });
     if (err == null) {

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -166,7 +166,7 @@ async function loadFieldReport(): Promise<{err: string|null}> {
             "created": null,
         };
     } else {
-        const {json, err} = await ims.fetchJsonNoThrow<ims.FieldReport>(
+        const {json, err} = await ims.fetchNoThrow<ims.FieldReport>(
             `${ims.urlReplace(url_fieldReports)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -307,7 +307,7 @@ async function frSendEdits(edits: ims.FieldReport): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
-    const {resp, err} = await ims.fetchJsonNoThrow(url, {
+    const {resp, err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify(edits),
     });
     if (err != null) {
@@ -372,7 +372,7 @@ async function makeIncident(): Promise<void> {
     if (fieldReport.report_entries) {
         authors.push(fieldReport.report_entries[0]!.author??"null");
     }
-    const {resp, err} = await ims.fetchJsonNoThrow(incidentsURL, {
+    const {resp, err} = await ims.fetchNoThrow(incidentsURL, {
         body:JSON.stringify({
             "summary": fieldReport.summary,
             "ranger_handles": authors,
@@ -395,7 +395,7 @@ async function makeIncident(): Promise<void> {
     const attachToIncidentUrl =
         `${ims.urlReplace(url_fieldReports)}/${fieldReport.number}` +
         `?action=attach&incident=${fieldReport.incident}`;
-    const {err: attachErr} = await ims.fetchJsonNoThrow(attachToIncidentUrl, {
+    const {err: attachErr} = await ims.fetchNoThrow(attachToIncidentUrl, {
         body: JSON.stringify({}),
     });
     if (attachErr != null) {
@@ -433,11 +433,11 @@ async function attachFile(): Promise<void> {
 
     const attachURL = ims.urlReplace(url_fieldReportAttachments)
         .replace("<field_report_number>", (ims.pathIds.fieldReportNumber??"").toString());
-    const {err} = await ims.fetchJsonNoThrow(attachURL, {
+    const {text, err} = await ims.fetchNoThrow(attachURL, {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
+        const message = `Failed to attach file. ${text}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/typescript/field_reports.ts
+++ b/web/typescript/field_reports.ts
@@ -177,7 +177,7 @@ function frInitDataTables() {
         // https://datatables.net/forums/discussion/47411/i-always-get-error-when-i-use-table-ajax-reload
         "ajax": function (_data: unknown, callback: (resp: {data: ims.FieldReport[]})=>void, _settings: unknown): void {
             async function doAjax(): Promise<void> {
-                const {json, err} = await ims.fetchJsonNoThrow<ims.FieldReport[]>(
+                const {json, err} = await ims.fetchNoThrow<ims.FieldReport[]>(
                     // don't use exclude_system_entries here, since the field reports
                     // per-user authorization can exclude field reports entirely from
                     // someone who created a field report but then didn't add an

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -289,7 +289,7 @@ async function loadIncident(): Promise<{err: string|null}> {
             "summary": "",
         };
     } else {
-        const {json, err} = await ims.fetchJsonNoThrow<ims.Incident>(
+        const {json, err} = await ims.fetchNoThrow<ims.Incident>(
             `${ims.urlReplace(url_incidents)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -355,7 +355,7 @@ interface Personnel {
 type PersonnelMap = Record<string, Personnel>;
 
 async function loadPersonnel(): Promise<{err: string|null}> {
-    const {json, err} = await ims.fetchJsonNoThrow<Personnel[]>(ims.urlReplace(url_personnel + "?event_id=<event_id>"), null);
+    const {json, err} = await ims.fetchNoThrow<Personnel[]>(ims.urlReplace(url_personnel + "?event_id=<event_id>"), null);
     if (err != null) {
         const message = `Failed to load personnel: ${err}`;
         console.error(message);
@@ -390,7 +390,7 @@ async function loadAllFieldReports(): Promise<{err: string|null}> {
         return {err: null};
     }
 
-    const {resp, json, err} = await ims.fetchJsonNoThrow<ims.FieldReport[]>(ims.urlReplace(url_fieldReports), null);
+    const {resp, json, err} = await ims.fetchNoThrow<ims.FieldReport[]>(ims.urlReplace(url_fieldReports), null);
     if (err != null) {
         if (resp != null && resp.status === 403) {
             // We're not allowed to look these up.
@@ -422,7 +422,7 @@ async function loadOneFieldReport(fieldReportNumber: number): Promise<{err: stri
         return {err: null};
     }
 
-    const {resp, json, err} = await ims.fetchJsonNoThrow<ims.FieldReport>(
+    const {resp, json, err} = await ims.fetchNoThrow<ims.FieldReport>(
         ims.urlReplace(url_fieldReport).replace("<field_report_number>", fieldReportNumber.toString()), null);
     if (err != null) {
         if (resp == null || resp.status !== 403) {
@@ -976,7 +976,7 @@ async function sendEdits(edits: ims.Incident): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
-    const {resp, err} = await ims.fetchJsonNoThrow(url, {
+    const {resp, err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify(edits),
     });
 
@@ -1258,7 +1258,7 @@ async function detachFieldReport(sender: HTMLElement): Promise<void> {
         `${ims.urlReplace(url_fieldReports)}/${frNumber}` +
         `?action=detach&incident=${ims.pathIds.incidentNumber}`
     );
-    const {err} = await ims.fetchJsonNoThrow(url, {
+    const {err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({}),
     });
     if (err != null) {
@@ -1290,7 +1290,7 @@ async function attachFieldReport(): Promise<void> {
         `${ims.urlReplace(url_fieldReports)}/${fieldReportNumber}` +
         `?action=attach&incident=${ims.pathIds.incidentNumber}`
     );
-    const {err} = await ims.fetchJsonNoThrow(url, {
+    const {err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({}),
     });
     if (err != null) {
@@ -1335,11 +1335,11 @@ async function attachFile(): Promise<void> {
 
     const attachURL = ims.urlReplace(url_incidentAttachments)
         .replace("<incident_number>", (ims.pathIds.incidentNumber??"").toString());
-    const {err} = await ims.fetchJsonNoThrow(attachURL, {
+    const {text, err} = await ims.fetchNoThrow(attachURL, {
         body: formData
     });
     if (err != null) {
-        const message = `Failed to attach file, possibly due to IMS being unable to reach AWS: ${err}`;
+        const message = `Failed to attach file. ${text}`;
         ims.setErrorMessage(message);
         return;
     }

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -146,7 +146,7 @@ async function initIncidentsPage(): Promise<void> {
 let eventFieldReports: ims.FieldReportsByNumber|undefined = undefined;
 
 async function loadEventFieldReports(): Promise<{err: string|null}> {
-    const {json, err} = await ims.fetchJsonNoThrow<ims.FieldReport[]>(
+    const {json, err} = await ims.fetchNoThrow<ims.FieldReport[]>(
         ims.urlReplace(url_fieldReports + "?exclude_system_entries=true"), null,
     );
     if (err != null) {
@@ -214,7 +214,7 @@ async function initIncidentsTable(): Promise<void> {
             return;
         }
 
-        const {json, err} = await ims.fetchJsonNoThrow(
+        const {json, err} = await ims.fetchNoThrow(
             ims.urlReplace(url_incidentNumber).replace("<incident_number>", number.toString()),
             null,
         );
@@ -284,7 +284,7 @@ function initDataTables(tablePrereqs: Promise<void>): void {
                 await Promise.all([
                     tablePrereqs,
                     loadEventFieldReports(),
-                    ims.fetchJsonNoThrow<ims.Incident[]>(
+                    ims.fetchNoThrow<ims.Incident[]>(
                         ims.urlReplace(url_incidents + "?exclude_system_entries=true"), null,
                     ).then(res => {
                         if (res.err != null || res.json == null) {

--- a/web/typescript/login.ts
+++ b/web/typescript/login.ts
@@ -42,7 +42,7 @@ async function initLoginPage(): Promise<void> {
 async function login(): Promise<void> {
     const username = (document.getElementById("username_input") as HTMLInputElement).value;
     const password = (document.getElementById("password_input") as HTMLInputElement).value;
-    const {json, err} = await ims.fetchJsonNoThrow<AuthResponse>(url_auth, {
+    const {json, err} = await ims.fetchNoThrow<AuthResponse>(url_auth, {
         body: JSON.stringify({
             "identification": username,
             "password": password,


### PR DESCRIPTION
this has us pass along the server's error message to the web client when a file upload or download fails. I want it to be clear to users on playa when this sort of error happens, so that they know they should try again when internet connectivity is restored.

As part of this, I renamed fetchJsonNoThrow to fetchNoThrow, because it's really no longer just about handling JSON responses.