### PR TITLE
do a "fetch auth" after making a new incident or FR

### DIFF
--- a/web/static/field_report.js
+++ b/web/static/field_report.js
@@ -284,6 +284,9 @@ async function frSendEdits(edits) {
         // Update browser history to update URL
         drawTitle();
         window.history.pushState(null, document.title, `${ims.urlReplace(url_viewFieldReports)}/${newNumber}`);
+        // Fetch auth info again with the newly updated URL, just to update
+        // the action log.
+        await ims.getAuthInfo();
     }
     await loadAndDisplayFieldReport();
     return { err: null };

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -300,8 +300,7 @@ export async function commonPageInit() {
     let authInfo = null;
     pathIds = idsFromPath();
     {
-        const url = url_auth + (pathIds.eventID ? `?event_id=${pathIds.eventID}` : "");
-        const { json, resp, err } = await fetchNoThrow(url, null);
+        const { json, resp, err } = await getAuthInfo();
         if (err != null || json == null) {
             console.log(`Failed to fetch auth info: ${err}, ${resp?.status}`);
             setErrorMessage(`Failed to fetch auth info: ${err}, ${resp?.status}`);
@@ -326,6 +325,10 @@ export async function commonPageInit() {
     }
     renderCommonPageItems(authInfo);
     return { authInfo: authInfo, eventDatas: eds };
+}
+export async function getAuthInfo() {
+    const url = url_auth + (pathIds.eventID ? `?event_id=${pathIds.eventID}` : "");
+    return await fetchNoThrow(url, null);
 }
 export async function redirectToLogin() {
     // This clears the refresh cookie

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -800,6 +800,9 @@ async function sendEdits(edits) {
         // Update browser history to update URL
         drawIncidentTitle();
         window.history.pushState(null, document.title, `${ims.urlReplace(url_viewIncidents)}/${newNumber}`);
+        // Fetch auth info again with the newly updated URL, just to update
+        // the action log.
+        await ims.getAuthInfo();
     }
     await loadAndDisplayIncident();
     return { err: null };

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -343,6 +343,10 @@ async function frSendEdits(edits: ims.FieldReport): Promise<{err:string|null}> {
             null, document.title,
             `${ims.urlReplace(url_viewFieldReports)}/${newNumber}`
         );
+
+        // Fetch auth info again with the newly updated URL, just to update
+        // the action log.
+        await ims.getAuthInfo();
     }
 
     await loadAndDisplayFieldReport();

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -339,8 +339,7 @@ export async function commonPageInit(): Promise<PageInitResult> {
     let authInfo: AuthInfo|null = null;
     pathIds = idsFromPath();
     {
-        const url = url_auth + (pathIds.eventID ? `?event_id=${pathIds.eventID}` : "");
-        const {json, resp, err} = await fetchNoThrow<AuthInfo>(url, null);
+        const {json, resp, err} = await getAuthInfo();
         if (err != null || json == null) {
             console.log(`Failed to fetch auth info: ${err}, ${resp?.status}`);
             setErrorMessage(`Failed to fetch auth info: ${err}, ${resp?.status}`);
@@ -367,6 +366,11 @@ export async function commonPageInit(): Promise<PageInitResult> {
     }
     renderCommonPageItems(authInfo);
     return {authInfo: authInfo, eventDatas: eds};
+}
+
+export async function getAuthInfo(): Promise<FetchRes<AuthInfo>> {
+    const url = url_auth + (pathIds.eventID ? `?event_id=${pathIds.eventID}` : "");
+    return await fetchNoThrow<AuthInfo>(url, null);
 }
 
 export async function redirectToLogin(): Promise<void> {

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1016,6 +1016,10 @@ async function sendEdits(edits: ims.Incident): Promise<{err:string|null}> {
         window.history.pushState(
             null, document.title, `${ims.urlReplace(url_viewIncidents)}/${newNumber}`
         );
+
+        // Fetch auth info again with the newly updated URL, just to update
+        // the action log.
+        await ims.getAuthInfo();
     }
 
     await loadAndDisplayIncident();


### PR DESCRIPTION
this just makes it simpler to read the action logs, since now we'll see a log entry with the newly created incident or FR number when the incident or FR is created.