### PR TITLE
disable govulncheck in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   skip:
     - fetch-build-deps
     - golangci-lint-full
-    - govulncheck
+    # - govulncheck
     - prepend-license
     - go-fmt
     - go-mod-tidy
@@ -52,12 +52,13 @@ repos:
         language: system
         pass_filenames: false
 
-      - id: govulncheck
-        name: govulncheck
-        entry: go tool govulncheck ./...
-        language: system
-        types_or: [ go, go-mod, go-sum ]
-        pass_filenames: false
+      # TODO: re-enable once there's a fix for https://github.com/moby/moby/security/advisories/GHSA-4vq8-7jfc-9cvp
+      # - id: govulncheck
+      #   name: govulncheck
+      #   entry: go tool govulncheck ./...
+      #   language: system
+      #   types_or: [ go, go-mod, go-sum ]
+      #   pass_filenames: false
 
       - id: go-fmt
         name: go fmt


### PR DESCRIPTION
it's broken at head with no remedy, and that will block any PRs from merging in our repo