### PR TITLE
fix the admin debug page

### DIFF
--- a/web/static/admin_debug.js
+++ b/web/static/admin_debug.js
@@ -32,11 +32,11 @@ async function initAdminDebugPage() {
     window.performGC = performGC;
 }
 async function fetchBuildInfo() {
-    const { resp, err } = await ims.fetchNoThrow(url_debugBuildInfo, {});
-    if (err != null || resp == null) {
+    const { text, err } = await ims.fetchNoThrow(url_debugBuildInfo, {});
+    if (err != null || text == null) {
         throw err;
     }
-    const buildInfoText = await resp.text();
+    const buildInfoText = text;
     const targetPre = document.getElementById("build-info");
     targetPre.textContent = buildInfoText;
     const ref = substringBetween(buildInfoText, "build\tvcs.revision=", "\n");
@@ -62,22 +62,22 @@ function substringBetween(s, start, end) {
     return s.substring(substrBeginInd, endInd);
 }
 async function fetchRuntimeMetrics() {
-    const { resp, err } = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
-    if (err != null || resp == null) {
+    const { text, err } = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
+    if (err != null || text == null) {
         throw err;
     }
     const targetPre = document.getElementById("runtime-metrics");
-    targetPre.textContent = await resp.text();
+    targetPre.textContent = text;
     const targetDiv = document.getElementById("runtime-metrics-div");
     targetDiv.style.display = "";
 }
 async function performGC() {
-    const { resp, err } = await ims.fetchNoThrow(url_debugGC, { body: JSON.stringify({}) });
-    if (err != null || resp == null) {
+    const { text, err } = await ims.fetchNoThrow(url_debugGC, { body: JSON.stringify({}) });
+    if (err != null || text == null) {
         throw err;
     }
     const targetPre = document.getElementById("gc");
-    targetPre.textContent = await resp.text();
+    targetPre.textContent = text;
     const targetDiv = document.getElementById("gc-div");
     targetDiv.style.display = "";
 }

--- a/web/typescript/admin_debug.ts
+++ b/web/typescript/admin_debug.ts
@@ -44,11 +44,11 @@ async function initAdminDebugPage(): Promise<void> {
 }
 
 async function fetchBuildInfo(): Promise<void> {
-    const {resp, err} = await ims.fetchNoThrow(url_debugBuildInfo, {});
-    if (err != null || resp == null) {
+    const {text, err} = await ims.fetchNoThrow(url_debugBuildInfo, {});
+    if (err != null || text == null) {
         throw err;
     }
-    const buildInfoText = await resp.text();
+    const buildInfoText = text;
     const targetPre = document.getElementById("build-info") as HTMLPreElement
     targetPre.textContent = buildInfoText;
 
@@ -77,23 +77,23 @@ function substringBetween(s: string, start: string, end: string): string {
 }
 
 async function fetchRuntimeMetrics(): Promise<void> {
-    const {resp, err} = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
-    if (err != null || resp == null) {
+    const {text, err} = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
+    if (err != null || text == null) {
         throw err;
     }
     const targetPre = document.getElementById("runtime-metrics") as HTMLPreElement
-    targetPre.textContent = await resp.text();
+    targetPre.textContent = text;
     const targetDiv = document.getElementById("runtime-metrics-div") as HTMLParagraphElement;
     targetDiv.style.display = "";
 }
 
 async function performGC(): Promise<void> {
-    const {resp, err} = await ims.fetchNoThrow(url_debugGC, {body: JSON.stringify({})});
-    if (err != null || resp == null) {
+    const {text, err} = await ims.fetchNoThrow(url_debugGC, {body: JSON.stringify({})});
+    if (err != null || text == null) {
         throw err;
     }
     const targetPre = document.getElementById("gc") as HTMLPreElement
-    targetPre.textContent = await resp.text();
+    targetPre.textContent = text;
     const targetDiv = document.getElementById("gc-div") as HTMLParagraphElement;
     targetDiv.style.display = "";
 }


### PR DESCRIPTION
I broke the page's buttons when I refactored fetchNoThrow. The error I saw today was as follows, which makes sense, because I started reading the text field as part of fetchNoThrow now.
admin_debug.js:39 Uncaught (in promise) TypeError: Failed to execute 'text' on 'Response': body stream already read
    at fetchBuildInfo (admin_debug.js:39:38)