### PR TITLE
fix "text/plain" file attachments

### DIFF
--- a/web/static/admin_debug.js
+++ b/web/static/admin_debug.js
@@ -32,11 +32,11 @@ async function initAdminDebugPage() {
     window.performGC = performGC;
 }
 async function fetchBuildInfo() {
-    const { text, err } = await ims.fetchNoThrow(url_debugBuildInfo, {});
-    if (err != null || text == null) {
+    const { resp, err } = await ims.fetchNoThrow(url_debugBuildInfo, {});
+    if (err != null || resp == null) {
         throw err;
     }
-    const buildInfoText = text;
+    const buildInfoText = await resp.text();
     const targetPre = document.getElementById("build-info");
     targetPre.textContent = buildInfoText;
     const ref = substringBetween(buildInfoText, "build\tvcs.revision=", "\n");
@@ -62,22 +62,22 @@ function substringBetween(s, start, end) {
     return s.substring(substrBeginInd, endInd);
 }
 async function fetchRuntimeMetrics() {
-    const { text, err } = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
-    if (err != null || text == null) {
+    const { resp, err } = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
+    if (err != null || resp == null) {
         throw err;
     }
     const targetPre = document.getElementById("runtime-metrics");
-    targetPre.textContent = text;
+    targetPre.textContent = await resp.text();
     const targetDiv = document.getElementById("runtime-metrics-div");
     targetDiv.style.display = "";
 }
 async function performGC() {
-    const { text, err } = await ims.fetchNoThrow(url_debugGC, { body: JSON.stringify({}) });
-    if (err != null || text == null) {
+    const { resp, err } = await ims.fetchNoThrow(url_debugGC, { body: JSON.stringify({}) });
+    if (err != null || resp == null) {
         throw err;
     }
     const targetPre = document.getElementById("gc");
-    targetPre.textContent = text;
+    targetPre.textContent = await resp.text();
     const targetDiv = document.getElementById("gc-div");
     targetDiv.style.display = "";
 }

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -178,7 +178,11 @@ export async function fetchNoThrow(url, init) {
         if (response.headers.get("content-type") === "application/json") {
             json = await response.json();
         }
-        else if ((response.headers.get("content-type") ?? "").startsWith("text/plain")) {
+        // TODO: clean this up post-2025 event. It broke attachment downloads for "text/plain" files
+        //  to await response.text() in those cases, because then `await response.blob()` would barf,
+        //  saying that the response body had already been read. I only really wanted to read the text
+        //  here when there was an error response anyway.
+        else if (response.status >= 400 && (response.headers.get("content-type") ?? "").startsWith("text/plain")) {
             text = await response.text();
         }
         return { resp: response, text: text, json: json, err: err };

--- a/web/typescript/admin_debug.ts
+++ b/web/typescript/admin_debug.ts
@@ -44,11 +44,11 @@ async function initAdminDebugPage(): Promise<void> {
 }
 
 async function fetchBuildInfo(): Promise<void> {
-    const {text, err} = await ims.fetchNoThrow(url_debugBuildInfo, {});
-    if (err != null || text == null) {
+    const {resp, err} = await ims.fetchNoThrow(url_debugBuildInfo, {});
+    if (err != null || resp == null) {
         throw err;
     }
-    const buildInfoText = text;
+    const buildInfoText = await resp.text();
     const targetPre = document.getElementById("build-info") as HTMLPreElement
     targetPre.textContent = buildInfoText;
 
@@ -77,23 +77,23 @@ function substringBetween(s: string, start: string, end: string): string {
 }
 
 async function fetchRuntimeMetrics(): Promise<void> {
-    const {text, err} = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
-    if (err != null || text == null) {
+    const {resp, err} = await ims.fetchNoThrow(url_debugRuntimeMetrics, {});
+    if (err != null || resp == null) {
         throw err;
     }
     const targetPre = document.getElementById("runtime-metrics") as HTMLPreElement
-    targetPre.textContent = text;
+    targetPre.textContent = await resp.text();
     const targetDiv = document.getElementById("runtime-metrics-div") as HTMLParagraphElement;
     targetDiv.style.display = "";
 }
 
 async function performGC(): Promise<void> {
-    const {text, err} = await ims.fetchNoThrow(url_debugGC, {body: JSON.stringify({})});
-    if (err != null || text == null) {
+    const {resp, err} = await ims.fetchNoThrow(url_debugGC, {body: JSON.stringify({})});
+    if (err != null || resp == null) {
         throw err;
     }
     const targetPre = document.getElementById("gc") as HTMLPreElement
-    targetPre.textContent = text;
+    targetPre.textContent = await resp.text();
     const targetDiv = document.getElementById("gc-div") as HTMLParagraphElement;
     targetDiv.style.display = "";
 }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -191,7 +191,12 @@ export async function fetchNoThrow<T>(url: string, init: RequestInit|null): Prom
         let text: string|null = null;
         if (response.headers.get("content-type") === "application/json") {
             json = await response.json();
-        } else if ((response.headers.get("content-type")??"").startsWith("text/plain")) {
+        }
+        // TODO: clean this up post-2025 event. It broke attachment downloads for "text/plain" files
+        //  to await response.text() in those cases, because then `await response.blob()` would barf,
+        //  saying that the response body had already been read. I only really wanted to read the text
+        //  here when there was an error response anyway.
+        else if (response.status >= 400 && (response.headers.get("content-type")??"").startsWith("text/plain")) {
             text = await response.text();
         }
         return {resp: response, text: text, json: json, err: err};


### PR DESCRIPTION
the client was unable to preview/download file attachments with MIME type text/plain. This is a janky last-minute fix for that problem. I'll find a better solution (and work on test coverage) in the fall.