### PR TITLE
include inactive rangers in "add rangers" options

### DIFF
--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -279,9 +279,12 @@ async function loadPersonnel() {
         switch (record.status) {
             case "active":
             case "alpha":
+            case "inactive":
+            case "inactive extension":
             case "prospective":
                 _personnel[record.handle] = record;
                 break;
+            case "auditor":
             default:
                 // Don't add this person to the personnel list.
                 break;

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -367,9 +367,12 @@ async function loadPersonnel(): Promise<{err: string|null}> {
         switch (record.status) {
             case "active":
             case "alpha":
+            case "inactive":
+            case "inactive extension":
             case "prospective":
                 _personnel[record.handle] = record;
                 break
+            case "auditor":
             default:
                 // Don't add this person to the personnel list.
                 break;


### PR DESCRIPTION
an inactive ranger switches back to active *after* their first shift, which means they can't be listed on an incident during their first shift in a few years. It's better to just allow the user to add them even if they're inactive.

https://github.com/burningmantech/ranger-ims-go/issues/381

fixes #381