### PR TITLE
don't reset pagination on SSE update

### DIFF
--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -136,7 +136,8 @@ function initFieldReportsTable() {
         //  Field Reports for which they're not authorized, and those errors
         //  show up in the browser console. I'd like to find a way to avoid
         //  bringing those errors into the console constantly.
-        fieldReportsTable.ajax.reload();
+        // maintain page location if user is not on page 1
+        fieldReportsTable.ajax.reload(null, false);
         ims.clearErrorMessage();
     };
 }

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -218,7 +218,7 @@ async function initIncidentsTable() {
         }
         ims.clearErrorMessage();
         incidentsTable.processing(false);
-        incidentsTable.draw();
+        incidentsTable.draw("full-hold");
     };
 }
 //

--- a/web/typescript/field_reports.ts
+++ b/web/typescript/field_reports.ts
@@ -173,7 +173,9 @@ function initFieldReportsTable() {
         //  Field Reports for which they're not authorized, and those errors
         //  show up in the browser console. I'd like to find a way to avoid
         //  bringing those errors into the console constantly.
-        fieldReportsTable!.ajax.reload();
+
+        // maintain page location if user is not on page 1
+        fieldReportsTable!.ajax.reload(null, false);
         ims.clearErrorMessage();
     };
 }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -1557,7 +1557,7 @@ export type FetchRes<T> = {
 }
 
 interface DTAjax {
-    reload(): void;
+    reload(callback?: any, resetPaging?: boolean): void;
 }
 
 type DTData = Record<number, object>;
@@ -1568,7 +1568,7 @@ export interface DataTablesTable {
     data(): DTData;
     search: any;
     page: any;
-    draw(): unknown;
+    draw(paging?: boolean|"full-hold"|"full-reset"|"page"): unknown;
     ajax: DTAjax;
     processing(b: boolean): unknown;
 }

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -276,7 +276,8 @@ async function initIncidentsTable(): Promise<void> {
         }
         ims.clearErrorMessage();
         incidentsTable!.processing(false);
-        incidentsTable!.draw();
+        // maintain page location if user is not on page 1
+        incidentsTable!.draw("full-hold");
     };
 }
 


### PR DESCRIPTION
an Operator observed this year than when she was on a search results page other than 1, she got sent back to page 1 automatically on any update to any incident (due to the SSE-induced update to the table). This tweak makes it so that DataTables keeps the user on the page they were on in that case.