### PR TITLE
start populating summary value from the first report entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Each month below should look like the following, using the same ordering for the
 ### Changed
 
 - Started including inactive Rangers in "add Rangers" options. This makes it possible to add a Ranger to an incident while they're on their first shift in years. https://github.com/burningmantech/ranger-ims-go/pull/382
+- Began populating summary values from the first report entry. Previously we just populated the placeholder. This makes it easier for a user to modify that value, rather than just start from scratch. https://github.com/burningmantech/ranger-ims-go/pull/397
 
 ### Added
 

--- a/web/static/field_report.js
+++ b/web/static/field_report.js
@@ -231,12 +231,7 @@ function drawSummary() {
         summaryInput.placeholder = "";
         return;
     }
-    summaryInput.value = "";
-    const summarized = ims.summarizeIncidentOrFR(fieldReport);
-    if (summarized) {
-        // only replace the placeholder if it would be nonempty
-        summaryInput.placeholder = summarized;
-    }
+    summaryInput.value = ims.summarizeIncidentOrFR(fieldReport);
 }
 //
 // Editing

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -499,12 +499,7 @@ function drawIncidentSummary() {
         summaryElement.placeholder = "";
         return;
     }
-    summaryElement.value = "";
-    const summarized = ims.summarizeIncidentOrFR(incident);
-    // only replace the placeholder if it would be nonempty
-    if (summarized) {
-        summaryElement.placeholder = summarized;
-    }
+    summaryElement.value = ims.summarizeIncidentOrFR(incident);
 }
 //
 // Populate Rangers list

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -279,12 +279,7 @@ function drawSummary(): void {
         return;
     }
 
-    summaryInput.value = "";
-    const summarized = ims.summarizeIncidentOrFR(fieldReport!);
-    if (summarized) {
-        // only replace the placeholder if it would be nonempty
-        summaryInput.placeholder = summarized;
-    }
+    summaryInput.value = ims.summarizeIncidentOrFR(fieldReport!);
 }
 
 

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -635,12 +635,7 @@ function drawIncidentSummary(): void {
         return;
     }
 
-    summaryElement.value = "";
-    const summarized = ims.summarizeIncidentOrFR(incident!);
-    // only replace the placeholder if it would be nonempty
-    if (summarized) {
-        summaryElement.placeholder = summarized;
-    }
+    summaryElement.value = ims.summarizeIncidentOrFR(incident!);
 }
 
 


### PR DESCRIPTION
previously we just populated the placeholder in this case. Operators complained to me that the old behavior was annoying, because it was impossible to alter the text a little bit into something different (you'd have to start from scratch)