### PR TITLE
fix race condition that resulted in all rows being shown twice

### DIFF
--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -115,31 +115,36 @@ function initFieldReportsTable() {
     if (ims.eventAccess?.writeFieldReports) {
         ims.enableEditing();
     }
-    ims.requestEventSourceLock();
-    ims.newFieldReportChannel().onmessage = function (e) {
-        if (e.data.update_all) {
-            console.log("Reloading the whole table to be cautious, as an SSE was missed");
-            fieldReportsTable.ajax.reload();
+    // Wait until the table is initialized before starting to listen for updates.
+    // https://github.com/burningmantech/ranger-ims-go/issues/399
+    fieldReportsTable.on("init", function () {
+        console.log("Table initialized. Requesting EventSource lock");
+        ims.requestEventSourceLock();
+        ims.newFieldReportChannel().onmessage = function (e) {
+            if (e.data.update_all) {
+                console.log("Reloading the whole table to be cautious, as an SSE was missed");
+                fieldReportsTable.ajax.reload();
+                ims.clearErrorMessage();
+                return;
+            }
+            const number = e.data.field_report_number;
+            const event = e.data.event_name;
+            if (event !== ims.pathIds.eventID) {
+                return;
+            }
+            console.log("Got field report update: " + number);
+            // TODO(issue/1498): this reloads the entire Field Report table on any
+            //  update to any Field Report. That's not ideal. The thing of which
+            //  to be mindful when GETting a particular single Field Report is that
+            //  limited access users will receive errors when they try to access
+            //  Field Reports for which they're not authorized, and those errors
+            //  show up in the browser console. I'd like to find a way to avoid
+            //  bringing those errors into the console constantly.
+            // maintain page location if user is not on page 1
+            fieldReportsTable.ajax.reload(null, false);
             ims.clearErrorMessage();
-            return;
-        }
-        const number = e.data.field_report_number;
-        const event = e.data.event_name;
-        if (event !== ims.pathIds.eventID) {
-            return;
-        }
-        console.log("Got field report update: " + number);
-        // TODO(issue/1498): this reloads the entire Field Report table on any
-        //  update to any Field Report. That's not ideal. The thing of which
-        //  to be mindful when GETting a particular single Field Report is that
-        //  limited access users will receive errors when they try to access
-        //  Field Reports for which they're not authorized, and those errors
-        //  show up in the browser console. I'd like to find a way to avoid
-        //  bringing those errors into the console constantly.
-        // maintain page location if user is not on page 1
-        fieldReportsTable.ajax.reload(null, false);
-        ims.clearErrorMessage();
-    };
+        };
+    });
 }
 //
 // Initialize DataTables

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -179,48 +179,53 @@ async function initIncidentsTable() {
     else {
         ims.disableEditing();
     }
-    ims.requestEventSourceLock();
-    ims.newIncidentChannel().onmessage = async function (e) {
-        if (e.data.update_all) {
-            console.log("Reloading the whole table to be cautious, as an SSE was missed");
-            incidentsTable.ajax.reload();
-            ims.clearErrorMessage();
-            return;
-        }
-        const number = e.data.incident_number;
-        const event = e.data.event_name;
-        if (event !== ims.pathIds.eventID) {
-            return;
-        }
-        const { json, err } = await ims.fetchNoThrow(ims.urlReplace(url_incidentNumber).replace("<incident_number>", number.toString()), null);
-        if (err != null) {
-            const message = `Failed to update Incident ${number}: ${err}`;
-            console.error(message);
-            ims.setErrorMessage(message);
-            return;
-        }
-        // Now update/create the relevant row. This is a change from pre-2025, in that
-        // we no longer reload all incidents here on any single incident update.
-        let done = false;
-        incidentsTable.rows().every(function () {
-            // @ts-expect-error use of "this" for DataTables
-            const existingIncident = this.data();
-            if (existingIncident.number === number) {
-                console.log("Updating Incident " + number);
-                // @ts-expect-error use of "this" for DataTables
-                this.data(json);
-                done = true;
+    // Wait until the table is initialized before starting to listen for updates.
+    // https://github.com/burningmantech/ranger-ims-go/issues/399
+    incidentsTable.on("init", function () {
+        console.log("Table initialized. Requesting EventSource lock");
+        ims.requestEventSourceLock();
+        ims.newIncidentChannel().onmessage = async function (e) {
+            if (e.data.update_all) {
+                console.log("Reloading the whole table to be cautious, as an SSE was missed");
+                incidentsTable.ajax.reload();
+                ims.clearErrorMessage();
+                return;
             }
-        });
-        if (!done) {
-            console.log("Loading new Incident " + number);
-            incidentsTable.row.add(json);
-        }
-        ims.clearErrorMessage();
-        incidentsTable.processing(false);
-        // maintain page location if user is not on page 1
-        incidentsTable.draw("full-hold");
-    };
+            const number = e.data.incident_number;
+            const event = e.data.event_name;
+            if (event !== ims.pathIds.eventID) {
+                return;
+            }
+            const { json, err } = await ims.fetchNoThrow(ims.urlReplace(url_incidentNumber).replace("<incident_number>", number.toString()), null);
+            if (err != null) {
+                const message = `Failed to update Incident ${number}: ${err}`;
+                console.error(message);
+                ims.setErrorMessage(message);
+                return;
+            }
+            // Now update/create the relevant row. This is a change from pre-2025, in that
+            // we no longer reload all incidents here on any single incident update.
+            let done = false;
+            incidentsTable.rows().every(function () {
+                // @ts-expect-error use of "this" for DataTables
+                const existingIncident = this.data();
+                if (existingIncident.number === number) {
+                    console.log("Updating Incident " + number);
+                    // @ts-expect-error use of "this" for DataTables
+                    this.data(json);
+                    done = true;
+                }
+            });
+            if (!done) {
+                console.log("Loading new Incident " + number);
+                incidentsTable.row.add(json);
+            }
+            ims.clearErrorMessage();
+            incidentsTable.processing(false);
+            // maintain page location if user is not on page 1
+            incidentsTable.draw("full-hold");
+        };
+    });
 }
 //
 // Initialize DataTables

--- a/web/template/header_templ.go
+++ b/web/template/header_templ.go
@@ -66,7 +66,7 @@ func Header(deployment string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if strings.ToLower(deployment) != "production" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"nonprod-warning text-center\" title=\"This environment is designed for testing or training, and permissions are generally open to all Rangers. Don't add anything here about real participants or pertaining to sensitive Ranger operational details.\">Only use fake data here!<wbr> This is ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"nonprod-warning text-center\" title=\"This environment is designed for testing or training, and permissions are generally open to all Rangers. Don't add anything to this IMS instance about real participants or pertaining to sensitive Ranger operational details.\">Only use fake data here!<wbr> This is ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -1579,6 +1579,7 @@ interface DTAjax {
 type DTData = Record<number, object>;
 
 export interface DataTablesTable {
+    on(event: string, callback: (jqueryEvent: object, dtSettings: object, json: object) => void): unknown;
     row: any;
     rows: any;
     data(): DTData;


### PR DESCRIPTION
it appears that when the initial table load is still in progress when an SSE-induced table reload happens concurrently, DataTables ends up showing all the rows twice. This PR changes things so that the SSE listening doesn't start until after the first table load is complete.

fixes #399