### PR TITLE
add a "closed" time column to INCIDENT and backfill it

### DIFF
--- a/api/eventaccess.go
+++ b/api/eventaccess.go
@@ -98,16 +98,13 @@ func (action GetEventAccesses) getEventsAccess(ctx context.Context) (imsjson.Eve
 		}
 		for _, accessRow := range accessRowByEventID[e.ID] {
 			access := accessRow
-			var expires time.Time
-			expired := false
-			if access.Expires.Valid {
-				expires = conv.FloatToTime(access.Expires.Float64)
-				expired = expires.Before(time.Now())
-			}
+
+			expires := conv.NullFloatToTime(access.Expires)
+			expired := access.Expires.Valid && expires.Before(time.Now())
 			rule := imsjson.AccessRule{
 				Expression: access.Expression,
 				Validity:   string(access.Validity),
-				Expires:    expires,
+				Expires:    conv.NullFloatToTime(access.Expires),
 				Expired:    expired,
 			}
 

--- a/json/incident.go
+++ b/json/incident.go
@@ -47,6 +47,7 @@ type Incident struct {
 	LastModified    time.Time     `json:"last_modified,omitzero"`
 	State           string        `json:"state"`
 	Started         time.Time     `json:"started,omitzero"`
+	Closed          time.Time     `json:"closed,omitzero"`
 	Priority        int8          `json:"priority"`
 	Summary         *string       `json:"summary"`
 	Location        Location      `json:"location"`

--- a/lib/conv/convert.go
+++ b/lib/conv/convert.go
@@ -120,6 +120,23 @@ func TimeToFloat(t time.Time) float64 {
 	return decimalPart + float64(t.Unix())
 }
 
+func NullFloatToTime(f sql.NullFloat64) time.Time {
+	if !f.Valid {
+		return time.Time{}
+	}
+	return FloatToTime(f.Float64)
+}
+
+func TimeToNullFloat(t time.Time) sql.NullFloat64 {
+	if t.IsZero() {
+		return sql.NullFloat64{}
+	}
+	return sql.NullFloat64{
+		Valid:   true,
+		Float64: TimeToFloat(t),
+	}
+}
+
 func EmptyToNil(s string) *string {
 	if s == "" {
 		return nil

--- a/store/imsdb/models.go
+++ b/store/imsdb/models.go
@@ -253,6 +253,7 @@ type Incident struct {
 	Priority             int8
 	State                IncidentState
 	Started              float64
+	Closed               sql.NullFloat64
 	Summary              sql.NullString
 	LocationName         sql.NullString
 	LocationConcentric   sql.NullString

--- a/store/imsdb/queries.sql.go
+++ b/store/imsdb/queries.sql.go
@@ -765,7 +765,7 @@ func (q *Queries) FieldReports_ReportEntries(ctx context.Context, db DBTX, arg F
 
 const incident = `-- name: Incident :one
 select
-    i.event, i.number, i.created, i.priority, i.state, i.started, i.summary, i.location_name, i.location_concentric, i.location_radial_hour, i.location_radial_minute, i.location_description,
+    i.event, i.number, i.created, i.priority, i.state, i.started, i.closed, i.summary, i.location_name, i.location_concentric, i.location_radial_hour, i.location_radial_minute, i.location_description,
     (
         select coalesce(json_arrayagg(iit.INCIDENT_TYPE), "[]")
         from INCIDENT__INCIDENT_TYPE iit
@@ -811,6 +811,7 @@ func (q *Queries) Incident(ctx context.Context, db DBTX, arg IncidentParams) (In
 		&i.Incident.Priority,
 		&i.Incident.State,
 		&i.Incident.Started,
+		&i.Incident.Closed,
 		&i.Incident.Summary,
 		&i.Incident.LocationName,
 		&i.Incident.LocationConcentric,
@@ -942,7 +943,7 @@ func (q *Queries) Incident_ReportEntries(ctx context.Context, db DBTX, arg Incid
 
 const incidents = `-- name: Incidents :many
 select
-    i.event, i.number, i.created, i.priority, i.state, i.started, i.summary, i.location_name, i.location_concentric, i.location_radial_hour, i.location_radial_minute, i.location_description,
+    i.event, i.number, i.created, i.priority, i.state, i.started, i.closed, i.summary, i.location_name, i.location_concentric, i.location_radial_hour, i.location_radial_minute, i.location_description,
     (
         select coalesce(json_arrayagg(iit.INCIDENT_TYPE), "[]")
         from INCIDENT__INCIDENT_TYPE iit
@@ -992,6 +993,7 @@ func (q *Queries) Incidents(ctx context.Context, db DBTX, event int32) ([]Incide
 			&i.Incident.Priority,
 			&i.Incident.State,
 			&i.Incident.Started,
+			&i.Incident.Closed,
 			&i.Incident.Summary,
 			&i.Incident.LocationName,
 			&i.Incident.LocationConcentric,
@@ -1226,6 +1228,7 @@ update INCIDENT set
     PRIORITY = ?,
     STATE = ?,
     STARTED = ?,
+    CLOSED = ?,
     SUMMARY = ?,
     LOCATION_NAME = ?,
     LOCATION_CONCENTRIC = ?,
@@ -1241,6 +1244,7 @@ type UpdateIncidentParams struct {
 	Priority             int8
 	State                IncidentState
 	Started              float64
+	Closed               sql.NullFloat64
 	Summary              sql.NullString
 	LocationName         sql.NullString
 	LocationConcentric   sql.NullString
@@ -1256,6 +1260,7 @@ func (q *Queries) UpdateIncident(ctx context.Context, db DBTX, arg UpdateInciden
 		arg.Priority,
 		arg.State,
 		arg.Started,
+		arg.Closed,
 		arg.Summary,
 		arg.LocationName,
 		arg.LocationConcentric,

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -51,6 +51,7 @@ update INCIDENT set
     PRIORITY = ?,
     STATE = ?,
     STARTED = ?,
+    CLOSED = ?,
     SUMMARY = ?,
     LOCATION_NAME = ?,
     LOCATION_CONCENTRIC = ?,

--- a/store/schema/21-from-20.sql
+++ b/store/schema/21-from-20.sql
@@ -1,0 +1,32 @@
+alter table `INCIDENT`
+add column `CLOSED` double after `STARTED`;
+
+update
+    `INCIDENT`
+    join
+        (select
+             ire.INCIDENT_NUMBER AS `INCIDENT_NUMBER`
+              ,ire.EVENT AS `EVENT_ID`
+              ,max(re.created) as `CLOSE_TIME`
+         from INCIDENT__REPORT_ENTRY ire
+                  join REPORT_ENTRY re
+                       on ire.report_entry = re.id
+         where (
+            re.text like '%Changed state: closed%'
+            or re.text like '%Changed state to: closed%'
+            or re.text like '%State changed to: closed%'
+         )
+         group by 1,2
+        ) as `ENTRY`
+        on
+            INCIDENT.NUMBER = ENTRY.INCIDENT_NUMBER
+                and INCIDENT.EVENT = ENTRY.EVENT_ID
+set
+    `CLOSED` = ENTRY.CLOSE_TIME
+where
+    INCIDENT.STATE = 'closed'
+;
+
+update `SCHEMA_INFO`
+set `VERSION` = 21
+where true;

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -6,7 +6,7 @@ create table SCHEMA_INFO (
 -- This value must be updated when you make a new migration file.
 --
 
-insert into SCHEMA_INFO (VERSION) values (20);
+insert into SCHEMA_INFO (VERSION) values (21);
 
 
 create table `EVENT` (
@@ -69,6 +69,7 @@ create table INCIDENT (
     -- STARTED is the time the INCIDENT began. This field is mutable, and its initial
     -- value will usually be the same as CREATED.
     STARTED  double not null,
+    CLOSED   double,
 
     SUMMARY varchar(1024),
     LOCATION_NAME          varchar(1024),


### PR DESCRIPTION
many post-event analyses want to know when an incident was closed. We should track that as part of the data model. It's much easier and less error-prone than querying into REPORT_ENTRY every time.

fixes #385