### PR TITLE
trigger search on input rather than keyup

### DIFF
--- a/web/static/field_reports.js
+++ b/web/static/field_reports.js
@@ -298,11 +298,7 @@ function frInitSearchField() {
         searchInput.value = queryString;
         searchAndDraw();
     }
-    searchInput.addEventListener("keyup", function (e) {
-        // No action on Enter key
-        if (e.key === "Enter") {
-            return;
-        }
+    searchInput.addEventListener("input", function (_) {
         // Delay the search in case the user is still typing.
         // This reduces perceived lag, since searching can be
         // very slow, and it's super annoying for a user when

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -470,11 +470,7 @@ function initSearchField() {
         searchInput.value = queryString;
         searchAndDraw();
     }
-    searchInput.addEventListener("keyup", function (e) {
-        // No action on Enter key
-        if (e.key === "Enter") {
-            return;
-        }
+    searchInput.addEventListener("input", function (_) {
         // Delay the search in case the user is still typing.
         // This reduces perceived lag, since searching can be
         // very slow, and it's super annoying for a user when

--- a/web/typescript/field_reports.ts
+++ b/web/typescript/field_reports.ts
@@ -357,12 +357,8 @@ function frInitSearchField(): void {
         searchAndDraw();
     }
 
-    searchInput.addEventListener("keyup",
-        function (e: KeyboardEvent): void {
-            // No action on Enter key
-            if (e.key === "Enter") {
-                return;
-            }
+    searchInput.addEventListener("input",
+        function (_: Event): void {
             // Delay the search in case the user is still typing.
             // This reduces perceived lag, since searching can be
             // very slow, and it's super annoying for a user when

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -554,12 +554,8 @@ function initSearchField() {
         searchAndDraw();
     }
 
-    searchInput.addEventListener("keyup",
-        function (e: KeyboardEvent): void {
-            // No action on Enter key
-            if (e.key === "Enter") {
-                return;
-            }
+    searchInput.addEventListener("input",
+        function (_: Event): void {
             // Delay the search in case the user is still typing.
             // This reduces perceived lag, since searching can be
             // very slow, and it's super annoying for a user when


### PR DESCRIPTION
prior to this, nothing would happen when the search field was cleared via browser clear button, because no keyboard event was involved. input seems to be better for this use case