### PR TITLE
use an external library to detect file content types

### DIFF
--- a/api/attachment_test.go
+++ b/api/attachment_test.go
@@ -29,22 +29,6 @@ import (
 	"testing"
 )
 
-func TestExtensionByType(t *testing.T) {
-	t.Parallel()
-	assert.Equal(t, ".bmp", extensionByType("image/bmp"))
-	assert.Equal(t, ".csv", extensionByType("text/csv"))
-	assert.Equal(t, ".gif", extensionByType("image/gif"))
-	assert.Equal(t, ".html", extensionByType("text/html"))
-	assert.Equal(t, ".jpg", extensionByType("image/jpeg"))
-	assert.Equal(t, ".mp4", extensionByType("video/mp4"))
-	assert.Equal(t, ".pdf", extensionByType("application/pdf"))
-	assert.Equal(t, ".png", extensionByType("image/png"))
-	assert.Equal(t, ".txt", extensionByType("text/plain"))
-	assert.Equal(t, ".zip", extensionByType("application/zip"))
-
-	assert.Empty(t, extensionByType("notta/mime"))
-}
-
 func TestSaveAndRetrieveS3File(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/api/reportentry.go
+++ b/api/reportentry.go
@@ -196,7 +196,7 @@ func reportEntryToJSON(re imsdb.ReportEntry, attachmentsEnabled bool) imsjson.Re
 	var attachment imsjson.Attachment
 	if attachmentsEnabled && re.AttachedFileOriginalName.Valid {
 		attachment.Name = re.AttachedFileOriginalName.String
-		attachment.Previewable = safeContentType(re.AttachedFileMediaType.String) != octetStream
+		attachment.Previewable = previewableContentType(re.AttachedFileMediaType.String)
 	}
 	return imsjson.ReportEntry{
 		ID:          re.ID,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.88.0
 	github.com/aws/smithy-go v1.23.0
 	github.com/dolthub/go-mysql-server v0.20.1-0.20250530192624-c17dd77cc53b
+	github.com/gabriel-vasile/mimetype v1.4.10
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/joho/godotenv v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHk
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/gabriel-vasile/mimetype v1.4.10 h1:zyueNbySn/z8mJZHLt6IPw0KoZsiQNszIpU+bX4+ZK0=
+github.com/gabriel-vasile/mimetype v1.4.10/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/getkin/kin-openapi v0.132.0 h1:3ISeLMsQzcb5v26yeJrBcdTCEQTag36ZjaGk7MIRUwk=
 github.com/getkin/kin-openapi v0.132.0/go.mod h1:3OlG51PCYNsPByuiMB0t4fjnNlIDnaEDsjiKUV8nL58=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=


### PR DESCRIPTION
this is too complex a task to do ourselves, and the Go standard library way is too incomplete (e.g. fails at .heic and .qt, picks weird file extensions).

I generally dislike bringing in external dependencies, but this one is mature, has no other dependencies, and performs a task that we can't easily do ourselves.

This is related to
https://github.com/burningmantech/ranger-ims-go/issues/413 because it makes Quicktime videos previewable...however there's still an annoying problem there with Chrome, because Chromium browsers won't actually preview video/quicktime files. The next step here will be spoofing video/quicktime downloads as video/mp4, because that's apparently all it takes to get Chrome to play those files.