### PR TITLE
support video/quicktime videos in Chromium browsers

### DIFF
--- a/api/attachment.go
+++ b/api/attachment.go
@@ -147,7 +147,6 @@ var safeToPreviewMediaTypes = []string{
 	"image/webp",
 	"text/plain",
 	"video/mp4",
-	"video/quicktime",
 	"video/x-msvideo",
 }
 
@@ -166,6 +165,12 @@ func safeToPreviewContentType(contentType string) string {
 	}
 	if slices.Contains(safeToPreviewMediaTypes, mediaType) {
 		return contentType
+	}
+	// Any Chromium browser won't play videos with video/quicktime media type (https://crbug.com/40714674),
+	// but it will play those same videos if you use video/mp4 as the media type. This is technically incorrect,
+	// but it works for Chromium browsers, and is also not a problem for Firefox or Safari.
+	if mediaType == "video/quicktime" {
+		return mime.FormatMediaType("video/mp4", nil)
 	}
 	if strings.HasPrefix(mediaType, "text/") {
 		return mime.FormatMediaType("text/plain", params)

--- a/conf/imsconfig.go
+++ b/conf/imsconfig.go
@@ -25,6 +25,9 @@ import (
 	"time"
 )
 
+// mib is the number of bytes in 1 MiB.
+const mib = 1 << 20
+
 // DefaultIMS is the base configuration used for the IMS server.
 // It gets overridden by values in .env, if present, then the result
 // of that gets overridden by environment variables. See mustApplyEnvConfig
@@ -41,7 +44,7 @@ func DefaultIMS() *IMSConfig {
 			RefreshTokenLifetime: 8 * time.Hour,
 			CacheControlShort:    20 * time.Minute,
 			CacheControlLong:     2 * time.Hour,
-			MaxRequestBytes:      20 * 1024 * 1024,
+			MaxRequestBytes:      100 * mib,
 			ActionLogEnabled:     true,
 		},
 		Store: DBStore{


### PR DESCRIPTION
also boost attachment size limit to 100 MiB

fixes #413