### PR TITLE
add a docker-compose for a local development stack

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,52 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "air_tmp"
+
+[build]
+  args_bin = ["serve","--print-config=false"]
+  bin = "./ranger-ims-go"
+  cmd = "go run bin/build/build.go"
+  delay = 100
+  exclude_dir = ["playwright", "ims-attachments"]
+  exclude_file = ["web/template/*_templ.go", "web/static/*.js", "store/imsdb/*.go", "directory/clubhousedb/*.go"]
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go","tpl","tmpl","templ","html","css","scss","js","ts","sql","jpeg","jpg","gif","png","bmp","svg","webp","ico","env"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = true
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,7 @@ run: build
 ## run/live: run the application with reloading on file changes
 .PHONY: run/live
 run/live:
-	go tool air \
-		--build.cmd "make build" --build.bin "./${binary_name}" --build.args_bin "serve,--print-config=false" --build.delay "100" \
-		--build.include_ext "go,tpl,tmpl,templ,html,css,scss,js,ts,sql,jpeg,jpg,gif,png,bmp,svg,webp,ico,env" \
-		--build.exclude_file "web/template/*_templ.go,web/static/*.js,store/imsdb/*.go,directory/clubhousedb/*.go" \
-		--build.exclude_dir "playwright,ims-attachments" \
-		--misc.clean_on_exit "true" --tmp_dir=air_tmp
+	go tool air
 
 ## upgrade-deps: upgrade all Go deps
 .PHONY: upgrade-deps

--- a/README.md
+++ b/README.md
@@ -16,14 +16,17 @@ that occur in Black Rock City.
     go run bin/fetchbuilddeps/fetchbuilddeps.go
    ```
 
-## Run IMS locally with in-process volatile DBs
+## Run IMS locally with docker compose
 
-As a super quick development approach for playing with IMS, follow the "getting started" steps above,
-then run the following to build and run IMS. This doesn't require Docker, nor any external DB.
+The fastest way to get a local IMS server up-and-running is to use Docker Compose. This
+requires only that you install Docker in advance (you don't even need Go!). This approach
+uses a live code-reloading mechanism, so any changes to the source code will cause the
+server to rebuild and relaunch.
+
+There's good documentation in `docker-compose.dev.yml` that's worth a read.
 
 ```shell
-go run bin/build/build.go
-./ranger-ims-go serve
+docker compose -f docker-compose.dev.yml up
 ```
 
 ## Run IMS locally with MariaDB

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,89 @@
+# This docker-compose brings up a local live-reloading IMS server, IMS DB, and Clubhouse DB.
+#
+# `docker compose -f docker-compose.dev.yml up`
+#
+# Here's some helpful information:
+#
+# 1. The server will rebuild and restart on any code update, thanks to air.
+# 2. When the compose stack is first brought up, the IMS and Clubhouse databases
+#    will be created, DDLed to the latest schema, then seeded  with data for
+#    local development. Search for "docker-entrypoint-initdb.d" below for more info.
+# 3. If you ever want to delete one of those databases and start fresh, then you just
+#    need to delete ./.docker/mysql/data-clubhouse/ or ./.docker/mysql/data-ims/, and
+#    the stack will re-create and re-seed the databases when you next `docker compose up`.
+
+services:
+
+  ims-go:
+    # See https://github.com/air-verse/air
+    image: cosmtrek/air
+    container_name: "ranger-ims-go"
+
+    # Map the repo into a directory in the container.
+    working_dir: /src
+    volumes:
+      - ./:/src/
+
+    # IMS server configuration starts with
+    # 1. DefaultIMS in imsconfig.go, which is overridden by
+    # 2. ./.env file, if present, which is overridden by
+    # 3. The environment values here.
+    environment:
+      IMS_HOSTNAME: "0.0.0.0"
+      IMS_DB_HOST_NAME: "ims-db"
+      IMS_DB_PORT: "${IMS_DB_PORT:-3306}"
+      IMS_DB_USER_NAME: "${IMS_DB_USER_NAME:-ims}"
+      IMS_DB_PASSWORD: "${IMS_DB_PASSWORD:-ims}"
+      IMS_DMS_HOSTNAME: "ranger-clubhouse-db:3306"
+      IMS_DMS_DATABASE: "${IMS_DMS_DATABASE:-rangers}"
+      IMS_DMS_USERNAME: "${IMS_DMS_USERNAME:-clubhouseuser}"
+      IMS_DMS_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
+    ports:
+      - "127.0.0.1:${IMS_PORT:-8080}:8080"
+    depends_on:
+      ims-db:
+        condition: service_healthy
+      clubhouse-db:
+        condition: service_healthy
+
+  ims-db:
+    image: "mariadb:10.5.27"
+    container_name: "ranger-ims-db"
+    environment:
+      MARIADB_DATABASE: "${IMS_DB_DATABASE:-ims}"
+      MARIADB_USER: "${IMS_DB_USER_NAME:-ims}"
+      MARIADB_PASSWORD: "${IMS_DB_PASSWORD:-ims}"
+      MARIADB_RANDOM_ROOT_PASSWORD: "yes"
+    ports:
+      - "${IMS_DB_PORT:-3306}"
+    volumes:
+      - ./.docker/mysql/data-ims/:/var/lib/mysql
+      - ./store/schema/current.sql:/docker-entrypoint-initdb.d/1.schema.sql
+      - ./store/fakeimsdb/seed.sql:/docker-entrypoint-initdb.d/2.seed.sql
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+
+  # Be aware that this database isn't seeded with any data, so while the IMS server
+  # will successfully start up, there won't be any users with whom to log in.
+  clubhouse-db:
+    image: "mariadb:10.5.27"
+    container_name: "ranger-clubhouse-db"
+    environment:
+      MARIADB_DATABASE: "${IMS_DMS_DATABASE:-rangers}"
+      MARIADB_USER: "${IMS_DMS_USERNAME:-clubhouseuser}"
+      MARIADB_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
+      MARIADB_RANDOM_ROOT_PASSWORD: "yes"
+    ports:
+      - "3306"
+    volumes:
+      - ./.docker/mysql/data-clubhouse/:/var/lib/mysql
+      - ./directory/schema/current.sql:/docker-entrypoint-initdb.d/1.schema.sql
+      - ./directory/fakeclubhousedb/seed.sql:/docker-entrypoint-initdb.d/2.seed.sql
+    healthcheck:
+      test: [ "CMD", "healthcheck.sh", "--connect", "--innodb_initialized" ]
+      interval: 1s
+      timeout: 5s
+      retries: 10


### PR DESCRIPTION
this makes it trivially simple to bring up a local IMS server, without the need for installing MariaDB separately, or needing a Clubhouse DB dump.

https://github.com/burningmantech/ranger-ims-go/issues/425