### PR TITLE
enhance docker-compose use

### DIFF
--- a/bin/test_docker
+++ b/bin/test_docker
@@ -7,7 +7,7 @@
 
 set -o errexit -o nounset -o pipefail
 
-# cd to the repo root, where docker-compose.yml lives
+# cd to the repo root, where docker-compose.cicd.yml lives
 cd "$(git rev-parse --show-toplevel)"
 
 exit_code=0
@@ -22,10 +22,10 @@ else
 fi
 
 exit_code=0
-docker compose up --wait-timeout 30 --wait || exit_code=$?
+docker compose -f docker-compose.cicd.yml up --wait-timeout 30 --wait || exit_code=$?
 
 echo "Stopping and deleting those Docker containers"
-docker compose rm -fsv
+docker compose -f docker-compose.cicd.yml rm -fsv
 
 if [ "${exit_code}" -ne "0" ]; then
     echo '!!! App failed health check !!!'

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,0 @@
-target "ranger-ims-go" {
-  context = "."
-  dockerfile = "Dockerfile"
-  tags = ["ranger-ims-go"]
-}

--- a/docker-compose.cicd.yml
+++ b/docker-compose.cicd.yml
@@ -1,34 +1,34 @@
 services:
 
-  app:
-    build: .
+  ims-go:
+    build:
+      context: .
+      dockerfile: Dockerfile
     image: "ranger-ims-go:${IMAGE_TAG:-latest}"
-    container_name: "ranger-ims-go"
     environment:
-      IMS_DB_HOST_NAME: "ranger-ims-database"
+      IMS_DB_HOST_NAME: "ims-db"
       IMS_DB_PORT: "${IMS_DB_PORT:-3306}"
       IMS_DB_USER_NAME: "${IMS_DB_USER_NAME:-ims}"
       IMS_DB_PASSWORD: "${IMS_DB_PASSWORD:-ims}"
-      IMS_DMS_HOSTNAME: "ranger-clubhouse-database:3306"
+      IMS_DMS_HOSTNAME: "clubhouse-db:3306"
       IMS_DMS_DATABASE: "${IMS_DMS_DATABASE:-rangers}"
       IMS_DMS_USERNAME: "${IMS_DMS_USERNAME:-clubhouseuser}"
       IMS_DMS_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
     ports:
       - "${IMS_PORT:-8080}:80"
     depends_on:
-      database:
+      ims-db:
         condition: service_healthy
-      clubhouse-database:
+      clubhouse-db:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "/opt/ims/bin/ims", "healthcheck", "--server_url", "http://app:80" ]
+      test: [ "CMD", "/opt/ims/bin/ims", "healthcheck", "--server_url", "http://ims-go:80" ]
       interval: 1s
       timeout: 3s
       retries: 30
 
-  database:
+  ims-db:
     image: "mariadb:10.5.27"
-    container_name: "ranger-ims-database"
     environment:
       MARIADB_DATABASE: "${IMS_DB_DATABASE:-ims}"
       MARIADB_USER: "${IMS_DB_USER_NAME:-ims}"
@@ -46,9 +46,8 @@ services:
 
   # Be aware that this database isn't seeded with any data, so while the IMS server
   # will successfully start up, there won't be any users with whom to log in.
-  clubhouse-database:
+  clubhouse-db:
     image: "mariadb:10.5.27"
-    container_name: "ranger-clubhouse-database"
     environment:
       MARIADB_DATABASE: "${IMS_DMS_DATABASE:-rangers}"
       MARIADB_USER: "${IMS_DMS_USERNAME:-clubhouseuser}"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -15,9 +15,20 @@
 services:
 
   ims-go:
-    # See https://github.com/air-verse/air
-    image: cosmtrek/air
-    container_name: "ranger-ims-go-air"
+    # This uses a Go hot-reload program: https://github.com/air-verse/air
+    # If you want to rebuild this image (e.g. because you're updating
+    # the go version in go.mod), then run the following:
+    #  docker compose -f docker-compose.dev.yml build --no-cache
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM golang:alpine
+        RUN apk add --no-cache git
+        RUN go install github.com/air-verse/air@latest
+        WORKDIR /src
+        ENTRYPOINT ["air"]
+    image: "ims-go-air"
+    container_name: "ranger-ims-go"
 
     # Map the repo into a directory in the container.
     working_dir: /src

--- a/web/template/header.templ
+++ b/web/template/header.templ
@@ -22,7 +22,7 @@ templ Header(deployment string) {
 <header>
     if strings.ToLower(deployment) != "production" {
         <div class="nonprod-warning text-center" title="This environment is designed for testing or training, and permissions are generally open to all Rangers. Don't add anything to this IMS instance about real participants or pertaining to sensitive Ranger operational details.">
-        Only use fake data here!<wbr /> This is {strings.ToLower(deployment)}, not production.
+        This is a {strings.ToLower(deployment)} server. <wbr />Use fake data only!
         </div>
     }
 </header>

--- a/web/template/header_templ.go
+++ b/web/template/header_templ.go
@@ -66,20 +66,20 @@ func Header(deployment string) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		if strings.ToLower(deployment) != "production" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"nonprod-warning text-center\" title=\"This environment is designed for testing or training, and permissions are generally open to all Rangers. Don't add anything to this IMS instance about real participants or pertaining to sensitive Ranger operational details.\">Only use fake data here!<wbr> This is ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<div class=\"nonprod-warning text-center\" title=\"This environment is designed for testing or training, and permissions are generally open to all Rangers. Don't add anything to this IMS instance about real participants or pertaining to sensitive Ranger operational details.\">This is a ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var2 string
 			templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(strings.ToLower(deployment))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/header.templ`, Line: 25, Col: 76}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/header.templ`, Line: 25, Col: 46}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, ", not production.</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 3, " server. <wbr>Use fake data only!</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}


### PR DESCRIPTION
the main thing here is that we stop using the cosmtrek/air docker image, and rather make an image and install air directly. That's preferable because it solves the problem of cosmtrek/air never being up to date with the latest Go version (e.g. currently 1.25.2 is out, but comtrek hasn't released an image with that version yet, so we get blocked on upgrading to 1.25.2 as well).

This change also does some other cleanups on Docker code.