### PR TITLE
prevent users from adding incidents/FRs to event groups

### DIFF
--- a/lib/authz/permission.go
+++ b/lib/authz/permission.go
@@ -102,6 +102,8 @@ func EventPermissions(
 ) (eventPermissions map[int32]EventPermissionMask, globalPermissions GlobalPermissionMask, err error) {
 	accessByEvent := make(map[int32][]imsdb.EventAccess)
 	if eventID != nil {
+		// If the eventID is the ID for an event group, this query returns no rows.
+		// This prevents users from adding entities under event groups, which we don't want.
 		accessRows, err := imsDBQ.EventAndParentAccess(ctx, imsDBQ, imsdb.EventAndParentAccessParams{EventID: *eventID})
 		if err != nil {
 			return nil, GlobalNoPermissions, fmt.Errorf("[EventAccess]: %w", err)

--- a/store/imsdb/querier.go
+++ b/store/imsdb/querier.go
@@ -32,6 +32,10 @@ type Querier interface {
 	DetachRangerHandleFromIncident(ctx context.Context, db DBTX, arg DetachRangerHandleFromIncidentParams) error
 	Event(ctx context.Context, db DBTX, id int32) (EventRow, error)
 	EventAccessAll(ctx context.Context, db DBTX) ([]EventAccessAllRow, error)
+	// This returns access for a target event, as well as for that event's
+	// parent group, if any. If the target event *is* a group, this query
+	// will return nothing. That's intentional, and it helps prevent people
+	// from adding incidents or FRs to event groups as though those were events.
 	EventAndParentAccess(ctx context.Context, db DBTX, arg EventAndParentAccessParams) ([]EventAndParentAccessRow, error)
 	Events(ctx context.Context, db DBTX) ([]EventsRow, error)
 	FieldReport(ctx context.Context, db DBTX, arg FieldReportParams) (FieldReportRow, error)

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -22,10 +22,17 @@ set
 where ID = ?
 ;
 
+-- This returns access for a target event, as well as for that event's
+-- parent group, if any. If the target event *is* a group, this query
+-- will return nothing. That's intentional, and it helps prevent people
+-- from adding incidents or FRs to event groups as though those were events.
 -- name: EventAndParentAccess :many
 select sqlc.embed(ea)
-from EVENT_ACCESS ea
-where ea.EVENT = sqlc.arg(event_id)
+from `EVENT` e
+    join EVENT_ACCESS ea
+        on e.ID = ea.EVENT
+where e.ID = sqlc.arg(event_id)
+    and not e.IS_GROUP
 union all
 select sqlc.embed(ea)
 from `EVENT` e


### PR DESCRIPTION
groups are intended as placeholders for use by permissions, so users shouldn't be able to add incidents/FRs onto the groups themselves.