### PR TITLE
feat: change incident API to use a struct for Incident Rangers

### DIFF
--- a/api/integration/incident_test.go
+++ b/api/integration/incident_test.go
@@ -17,13 +17,14 @@
 package integration_test
 
 import (
-	imsjson "github.com/burningmantech/ranger-ims-go/json"
-	"github.com/burningmantech/ranger-ims-go/lib/rand"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	imsjson "github.com/burningmantech/ranger-ims-go/json"
+	"github.com/burningmantech/ranger-ims-go/lib/rand"
+	"github.com/stretchr/testify/require"
 )
 
 func sampleIncident1(eventName string) imsjson.Incident {
@@ -41,7 +42,7 @@ func sampleIncident1(eventName string) imsjson.Incident {
 		},
 		IncidentTypeIDs: &[]int32{1, 2},
 		FieldReports:    &[]int32{},
-		RangerHandles:   &[]string{"SomeOne", "SomeTwo"},
+		Rangers:         &[]imsjson.IncidentRanger{{Handle: "SomeOne"}, {Handle: "SomeTwo"}},
 		ReportEntries: []imsjson.ReportEntry{
 			{Text: "This is some report text lol"},
 			{Text: ""},
@@ -251,7 +252,7 @@ func TestCreateAndUpdateIncident(t *testing.T) {
 		},
 		IncidentTypeIDs: &[]int32{},
 		FieldReports:    &[]int32{},
-		RangerHandles:   &[]string{},
+		Rangers:         &[]imsjson.IncidentRanger{},
 		ReportEntries:   []imsjson.ReportEntry{},
 	}
 	resp = apisNonAdmin.updateIncident(ctx, eventName, num, updates)
@@ -270,7 +271,7 @@ func TestCreateAndUpdateIncident(t *testing.T) {
 		Location:        imsjson.Location{},
 		IncidentTypeIDs: &[]int32{},
 		FieldReports:    &[]int32{},
-		RangerHandles:   &[]string{},
+		Rangers:         &[]imsjson.IncidentRanger{},
 		LinkedIncidents: &[]imsjson.LinkedIncident{},
 	}
 	requireEqualIncident(t, expected, retrievedIncidentAfterUpdate)
@@ -426,7 +427,7 @@ func requireEqualIncident(t *testing.T, before, after imsjson.Incident) {
 	require.Equal(t, before.Summary, after.Summary)
 	require.Equal(t, before.Location, after.Location)
 	require.Equal(t, before.IncidentTypeIDs, after.IncidentTypeIDs)
-	require.Equal(t, before.RangerHandles, after.RangerHandles)
+	require.Equal(t, before.Rangers, after.Rangers)
 	require.Equal(t, before.FieldReports, after.FieldReports)
 	require.Equal(t, before.LinkedIncidents, after.LinkedIncidents)
 	// these will always be different. Check them separately of this function

--- a/json/incident.go
+++ b/json/incident.go
@@ -54,9 +54,14 @@ type Incident struct {
 	Location        Location          `json:"location"`
 	IncidentTypeIDs *[]int32          `json:"incident_type_ids"`
 	FieldReports    *[]int32          `json:"field_reports"`
-	RangerHandles   *[]string         `json:"ranger_handles"`
+	Rangers         *[]IncidentRanger `json:"rangers"`
 	LinkedIncidents *[]LinkedIncident `json:"linked_incidents,omitzero"`
 	ReportEntries   []ReportEntry     `json:"report_entries"`
+}
+
+type IncidentRanger struct {
+	Handle string `json:"handle,omitempty"`
+	// Role   *string `json:"role,omitempty"`
 }
 
 type LinkedIncident struct {

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -719,6 +719,12 @@ export function renderLocation(data, type, _incident) {
     }
     return undefined;
 }
+export function renderRangerHandles(data, _type, _incident) {
+    if (data?.handle == null) {
+        return undefined;
+    }
+    return DataTable.render.text().display(data.handle);
+}
 //
 // Populate report entry text
 //

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -505,7 +505,7 @@ function drawIncidentSummary() {
 // Populate Rangers list
 //
 function drawRangers() {
-    const handles = incident.ranger_handles ?? [];
+    const handles = (incident.rangers ?? []).map(r => r.handle ?? "");
     handles.sort((a, b) => a.localeCompare(b));
     const rangerItemTemplate = document.getElementById("incident_rangers_li_template");
     const rangersElement = document.getElementById("incident_rangers_list");
@@ -949,7 +949,7 @@ async function removeRanger(sender) {
     const parent = sender.parentElement;
     const rangerHandle = parent.dataset["rangerHandle"];
     await sendEdits({
-        "ranger_handles": (incident.ranger_handles ?? []).filter(function (h) { return h !== rangerHandle; }),
+        "rangers": (incident.rangers ?? []).filter(function (h) { return h.handle !== rangerHandle; }),
     });
 }
 async function removeIncidentType(sender) {
@@ -965,8 +965,9 @@ function normalize(str) {
 async function addRanger() {
     const addRanger = document.getElementById("ranger_add");
     let handle = addRanger.value;
-    // make a copy of the handles
-    const handles = (incident.ranger_handles ?? []).slice();
+    // make a copy of the rangers
+    const rangers = (incident.rangers ?? []).slice();
+    const handles = rangers.map(r => r.handle).filter(handle => handle != null);
     // fuzzy-match on handle, to allow case insensitivity and
     // leading/trailing whitespace.
     if (!(handle in (personnel ?? []))) {
@@ -988,9 +989,9 @@ async function addRanger() {
         addRanger.value = "";
         return;
     }
-    handles.push(handle);
+    rangers.push({ handle: handle });
     addRanger.disabled = true;
-    const { err } = await sendEdits({ "ranger_handles": handles });
+    const { err } = await sendEdits({ "rangers": rangers });
     if (err !== null) {
         ims.controlHasError(addRanger);
         addRanger.value = "";

--- a/web/static/incidents.js
+++ b/web/static/incidents.js
@@ -348,9 +348,9 @@ function initDataTables(tablePrereqs) {
             {
                 "name": "incident_ranger_handles",
                 "className": "incident_ranger_handles",
-                "data": "ranger_handles",
+                "data": "rangers",
                 "defaultContent": "",
-                "render": ims.renderSafeSorted,
+                "render": ims.renderRangerHandles,
                 "responsivePriority": 6,
             },
             {

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -839,6 +839,13 @@ export function renderLocation(data: EventLocation|null, type: string, _incident
     return undefined;
 }
 
+export function renderRangerHandles(data: IncidentRanger|null, _type: string, _incident: Incident): string|undefined {
+    if (data?.handle == null) {
+        return undefined;
+    }
+    return DataTable.render.text().display(data.handle);
+}
+
 //
 // Populate report entry text
 //
@@ -1534,6 +1541,11 @@ export type LinkedIncident = {
     summary?: string|null;
 }
 
+export type IncidentRanger = {
+    handle?: string|null;
+    // role?: string|null;
+}
+
 export type Incident = {
     number?: number|null;
     event?: string|null;
@@ -1543,7 +1555,7 @@ export type Incident = {
     created?: string|null;
     started?: string|null;
     last_modified?: string|null;
-    ranger_handles?: string[]|null;
+    rangers?: IncidentRanger[]|null;
     incident_type_ids?: number[]|null;
     location?: EventLocation|null;
     report_entries?: ReportEntry[]|null;

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -645,7 +645,7 @@ function drawIncidentSummary(): void {
 //
 
 function drawRangers() {
-    const handles: string[] = incident!.ranger_handles??[];
+    const handles: string[] = (incident!.rangers??[]).map(r=>r.handle??"");
     handles.sort((a, b) => a.localeCompare(b));
 
     const rangerItemTemplate = document.getElementById("incident_rangers_li_template") as HTMLTemplateElement;
@@ -1197,8 +1197,8 @@ async function removeRanger(sender: HTMLElement): Promise<void> {
 
     await sendEdits(
         {
-            "ranger_handles": (incident!.ranger_handles??[]).filter(
-                function(h: string): boolean { return h !== rangerHandle; }
+            "rangers": (incident!.rangers??[]).filter(
+                function(h: ims.IncidentRanger): boolean { return h.handle !== rangerHandle; }
             ),
         },
     );
@@ -1223,8 +1223,9 @@ async function addRanger(): Promise<void> {
     const addRanger = document.getElementById("ranger_add") as HTMLInputElement;
     let handle: string = addRanger.value;
 
-    // make a copy of the handles
-    const handles = (incident!.ranger_handles??[]).slice();
+    // make a copy of the rangers
+    const rangers = (incident!.rangers??[]).slice();
+    const handles = rangers.map(r=>r.handle).filter(handle => handle != null);
 
     // fuzzy-match on handle, to allow case insensitivity and
     // leading/trailing whitespace.
@@ -1249,10 +1250,10 @@ async function addRanger(): Promise<void> {
         return;
     }
 
-    handles.push(handle);
+    rangers.push({handle: handle});
 
     addRanger.disabled = true;
-    const {err} = await sendEdits({"ranger_handles": handles});
+    const {err} = await sendEdits({"rangers": rangers});
     if (err !== null) {
         ims.controlHasError(addRanger);
         addRanger.value = "";

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -410,9 +410,9 @@ function initDataTables(tablePrereqs: Promise<void>): void {
             {   // 6
                 "name": "incident_ranger_handles",
                 "className": "incident_ranger_handles",
-                "data": "ranger_handles",
+                "data": "rangers",
                 "defaultContent": "",
-                "render": ims.renderSafeSorted,
+                "render": ims.renderRangerHandles,
                 "responsivePriority": 6,
             },
             {   // 7


### PR DESCRIPTION
this is a breaking API change, and it's necessary for us to start recording Rangers' "roles" with respect to incidents.

https://github.com/burningmantech/ranger-ims-go/issues/451