### PR TITLE
feat: convert attach/detach ranger into separate API calls

### DIFF
--- a/api/integration/permissions_test.go
+++ b/api/integration/permissions_test.go
@@ -120,6 +120,8 @@ func TestEventEndpoints_ForNoEventPerms(t *testing.T) {
 	postIncident := MethodURL{http.MethodPost, eventPath + "/incidents/1"}
 	postIncidentAttachment := MethodURL{http.MethodPost, eventPath + "/incidents/1/attachments"}
 	postIncidentRE := MethodURL{http.MethodPost, eventPath + "/incidents/1/report_entries/2"}
+	postIncidentRanger := MethodURL{http.MethodPost, eventPath + "/incidents/1/rangers/some_name"}
+	deleteIncidentRanger := MethodURL{http.MethodDelete, eventPath + "/incidents/1/rangers/some_name"}
 	getFieldReports := MethodURL{http.MethodGet, eventPath + "/field_reports"}
 	getFieldReport := MethodURL{http.MethodGet, eventPath + "/field_reports/1"}
 	getFieldReportAttachment := MethodURL{http.MethodGet, eventPath + "/field_reports/1/attachments/1"}
@@ -135,6 +137,8 @@ func TestEventEndpoints_ForNoEventPerms(t *testing.T) {
 		postIncident,
 		postIncidentAttachment,
 		postIncidentRE,
+		postIncidentRanger,
+		deleteIncidentRanger,
 		getFieldReports,
 		getFieldReport,
 		getFieldReportAttachment,
@@ -306,6 +310,8 @@ func apiCall(t *testing.T, api MethodURL, user ApiHelper) (statusCode int) {
 	ctx := t.Context()
 	var httpResp *http.Response
 	switch api.Method {
+	case http.MethodDelete:
+		_, httpResp = user.imsDelete(ctx, user.serverURL.JoinPath(api.Path).String(), nil)
 	case http.MethodGet:
 		_, httpResp = user.imsGetBodyBytes(ctx, user.serverURL.JoinPath(api.Path).String())
 	case http.MethodPost:

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -948,8 +948,14 @@ async function editLocationDescription() {
 async function removeRanger(sender) {
     const parent = sender.parentElement;
     const rangerHandle = parent.dataset["rangerHandle"];
-    await sendEdits({
-        "rangers": (incident.rangers ?? []).filter(function (h) { return h.handle !== rangerHandle; }),
+    if (!rangerHandle) {
+        return;
+    }
+    const url = (ims.urlReplace(url_incidentRanger)
+        .replace("<incident_number>", ims.pathIds.incidentNumber.toString())
+        .replace("<ranger_name>", encodeURIComponent(rangerHandle)));
+    await ims.fetchNoThrow(url, {
+        method: "DELETE",
     });
 }
 async function removeIncidentType(sender) {
@@ -991,7 +997,12 @@ async function addRanger() {
     }
     rangers.push({ handle: handle });
     addRanger.disabled = true;
-    const { err } = await sendEdits({ "rangers": rangers });
+    const url = (ims.urlReplace(url_incidentRanger)
+        .replace("<incident_number>", ims.pathIds.incidentNumber.toString())
+        .replace("<ranger_name>", encodeURIComponent(handle)));
+    const { err } = await ims.fetchNoThrow(url, {
+        body: JSON.stringify({}),
+    });
     if (err !== null) {
         ims.controlHasError(addRanger);
         addRanger.value = "";

--- a/web/static/urls.js
+++ b/web/static/urls.js
@@ -37,6 +37,7 @@ const url_incidentNumber = "/ims/api/events/<event_id>/incidents/<incident_numbe
 const url_incident_reportEntries = "/ims/api/events/<event_id>/incidents/<incident_number>/report_entries";
 const url_incident_reportEntry = "/ims/api/events/<event_id>/incidents/<incident_number>/report_entries/<report_entry_id>";
 const url_incidentAttachments = "/ims/api/events/<event_id>/incidents/<incident_number>/attachments";
+const url_incidentRanger = "/ims/api/events/<event_id>/incidents/<incident_number>/rangers/<ranger_name>";
 const url_incidentAttachmentNumber = "/ims/api/events/<event_id>/incidents/<incident_number>/attachments/<attachment_number>";
 const url_fieldReports = "/ims/api/events/<event_id>/field_reports";
 const url_fieldReport = "/ims/api/events/<event_id>/field_reports/<field_report_number>";

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1194,14 +1194,18 @@ async function editLocationDescription(): Promise<void> {
 async function removeRanger(sender: HTMLElement): Promise<void> {
     const parent = sender.parentElement as HTMLElement;
     const rangerHandle = parent.dataset["rangerHandle"];
+    if (!rangerHandle) {
+        return;
+    }
 
-    await sendEdits(
-        {
-            "rangers": (incident!.rangers??[]).filter(
-                function(h: ims.IncidentRanger): boolean { return h.handle !== rangerHandle; }
-            ),
-        },
+    const url = (
+        ims.urlReplace(url_incidentRanger)
+            .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
+            .replace("<ranger_name>", encodeURIComponent(rangerHandle))
     );
+    await ims.fetchNoThrow(url, {
+        method: "DELETE",
+    });
 }
 
 
@@ -1253,7 +1257,15 @@ async function addRanger(): Promise<void> {
     rangers.push({handle: handle});
 
     addRanger.disabled = true;
-    const {err} = await sendEdits({"rangers": rangers});
+
+    const url = (
+        ims.urlReplace(url_incidentRanger)
+            .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
+            .replace("<ranger_name>", encodeURIComponent(handle))
+    );
+    const {err} = await ims.fetchNoThrow(url, {
+        body: JSON.stringify({}),
+    });
     if (err !== null) {
         ims.controlHasError(addRanger);
         addRanger.value = "";

--- a/web/typescript/urls.ts
+++ b/web/typescript/urls.ts
@@ -38,6 +38,7 @@ const url_incidentNumber = "/ims/api/events/<event_id>/incidents/<incident_numbe
 const url_incident_reportEntries = "/ims/api/events/<event_id>/incidents/<incident_number>/report_entries";
 const url_incident_reportEntry = "/ims/api/events/<event_id>/incidents/<incident_number>/report_entries/<report_entry_id>";
 const url_incidentAttachments = "/ims/api/events/<event_id>/incidents/<incident_number>/attachments";
+const url_incidentRanger = "/ims/api/events/<event_id>/incidents/<incident_number>/rangers/<ranger_name>";
 const url_incidentAttachmentNumber = "/ims/api/events/<event_id>/incidents/<incident_number>/attachments/<attachment_number>";
 const url_fieldReports = "/ims/api/events/<event_id>/field_reports";
 const url_fieldReport = "/ims/api/events/<event_id>/field_reports/<field_report_number>";


### PR DESCRIPTION
It's getting unreasonable to updates this list as part of editIncident, especially in light of having an additional field on an IncidentRanger. This approach scales better, doesn't introduce contention between different users, and is easier to process in the server.

https://github.com/burningmantech/ranger-ims-go/issues/451