### PR TITLE
fix: drop support for sha1-hashed passwords

### DIFF
--- a/directory/fakeclubhousedb/seed.sql
+++ b/directory/fakeclubhousedb/seed.sql
@@ -11,13 +11,12 @@ alter table `person`
 insert into `person`
 (`id`,  `callsign`, `email`,                `password`,                     `status`,   `on_site`)
 values
--- This password is "Hardware"
-(600,   "Hardware", "hardware@example.com", "$argon2id$v=19$m=65536,t=3,p=4$ipVDinFcaxnDwt20s1YPZg$Y1XUdJBb4+VVy7hQ29ORNZvgsMu7ySbzLfdXgGMO6lo",  "active",   true),
-(601,   "Loosy",    "loosy@example.com",    concat(":", sha1("Loosy")),     "active",   true),
-(602,   "Doggy",    "doggy@example.com",    concat(":", sha1("Doggy")),     "active",   true),
-(603,   "Runner",   "runner@example.com",   concat(":", sha1("Runner")),    "active",   true),
--- The below password is "TheMan"
-(604,   "TheMan",   "theman@example.com",   "$argon2id$v=19$m=65536,t=1,p=12$YqQK04inaw4iIkQf5k0hyg$O1/TG6705h9w6R0C96qodP26JkN1pwM1vTod07yz3BM",    "active",   true)
+-- All of these users just have passwords equal to their case-sensitive callsigns
+(600,   "Hardware", "hardware@example.com", "$argon2id$v=19$m=8192,t=4,p=1$pGcXPQ1tP2Lz54c+R+8jgg$FZryn3Gttrxi7GoZXxyG/rGl/xNjOEjjDGeboEGMph8", "active",   true),
+(601,   "Loosy",    "loosy@example.com",    "$argon2id$v=19$m=8192,t=4,p=1$qGMBHtiPMl0MtCQncHhNdA$f1LbS0MIcIYjfiisvxAyEJC21lGVMBB11Yr9ctLP7aI", "active",   true),
+(602,   "Doggy",    "doggy@example.com",    "$argon2id$v=19$m=8192,t=4,p=1$L1EBUN9twap4arU4qurBdA$ML6fWDryXTmbyiAfzIQMFUoHYbJoOhwh58Oq3ffxeWA", "active",   true),
+(603,   "Runner",   "runner@example.com",   "$argon2id$v=19$m=8192,t=4,p=1$YY+aGB2MTKrnHFEQqdfdNg$Q9yByHhJ1GpOW+fUWePv+u76wE9fCGXSONkawTiyJEs", "active",   true),
+(604,   "TheMan",   "theman@example.com",   "$argon2id$v=19$m=8192,t=4,p=1$5zituz25m5nT7J2MgGAwfQ$EtaP17cnQCVOaVx3Ns8TZPPN1s3zY7bLvKW4QlwSR9Y", "active",   true)
 ;
 
 insert into `position`

--- a/lib/authn/password_test.go
+++ b/lib/authn/password_test.go
@@ -17,67 +17,14 @@
 package authn_test
 
 import (
+	"testing"
+
 	"github.com/burningmantech/ranger-ims-go/lib/authn"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"strings"
-	"testing"
-	"unicode/utf8"
 )
 
-func TestVerifyPassword_success(t *testing.T) {
-	t.Parallel()
-	pw, s := "Hardware", "my_little_salty"
-	hashed := "ee9a23000af19a22acd0d9a22dfe9558580771dc"
-	assert.Equal(t, hashed, authn.Hash(pw, s))
-
-	stored := "my_little_salty:" + hashed
-	vp, err := authn.Verify(pw, stored)
-	require.NoError(t, err)
-	assert.True(t, vp)
-
-	vp, err = authn.Verify("wrong password", stored)
-	require.NoError(t, err)
-	assert.False(t, vp)
-}
-
-func TestVerifyPassword_badStoredValue(t *testing.T) {
-	t.Parallel()
-	noColonInThisString := "abcdefg"
-	_, err := authn.Verify("some_password", noColonInThisString)
-	require.Error(t, err)
-	require.Contains(t, "invalid hashed password", err.Error())
-}
-
-func TestNewSalted(t *testing.T) {
-	t.Parallel()
-	pw := "this is my password"
-	saltedPw := authn.NewSaltedSha1(pw)
-	isValid, err := authn.Verify(pw, saltedPw)
-	require.NoError(t, err)
-	require.True(t, isValid)
-}
-
-func FuzzNewSaltedVerify(f *testing.F) {
-	f.Add("pass")
-	f.Add("")
-	f.Add("🔥")
-	f.Add(strings.Repeat("some text,", 1000))
-
-	f.Fuzz(func(t *testing.T, pw string) {
-		saltedHashed := authn.NewSaltedSha1(pw)
-		assert.True(t, utf8.ValidString(saltedHashed))
-		// the separator
-		assert.Contains(t, saltedHashed, ":")
-		// we use a base64-encoded salt that takes 22 bytes, then ":" is 1, and the hash is 40
-		assert.Len(t, saltedHashed, 63)
-		isValid, err := authn.Verify(pw, saltedHashed)
-		require.NoError(t, err)
-		assert.True(t, isValid)
-	})
-}
-
-func TestHashArgon2id(t *testing.T) {
+func TestVerify_success(t *testing.T) {
 	t.Parallel()
 	hash := authn.NewSaltedArgon2idDevOnly("my password 123")
 
@@ -88,6 +35,14 @@ func TestHashArgon2id(t *testing.T) {
 	isValid, err = authn.Verify("my password 123", hash)
 	require.NoError(t, err)
 	assert.True(t, isValid)
+}
+
+func TestVerify_failure(t *testing.T) {
+	t.Parallel()
+	isValid, err := authn.Verify("some password", "this is not an argon2id hash")
+	assert.False(t, isValid)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported non-argon2id stored password")
 }
 
 func BenchmarkHashArgon2id(b *testing.B) {


### PR DESCRIPTION
We switched to argon2id before the 2025 BRC event, and every active Ranger will have had their stored password updated by now.