### PR TITLE
fix: use cache-busting to prevent browsers caching our JavaScript

### DIFF
--- a/web/mux.go
+++ b/web/mux.go
@@ -18,16 +18,17 @@ package web
 
 import (
 	"fmt"
-	"github.com/a-h/templ"
-	"github.com/burningmantech/ranger-ims-go/conf"
-	"github.com/burningmantech/ranger-ims-go/lib/authz"
-	"github.com/burningmantech/ranger-ims-go/lib/herr"
-	"github.com/burningmantech/ranger-ims-go/web/template"
 	"log/slog"
 	"net/http"
 	"runtime/debug"
 	"strings"
 	"time"
+
+	"github.com/a-h/templ"
+	"github.com/burningmantech/ranger-ims-go/conf"
+	"github.com/burningmantech/ranger-ims-go/lib/authz"
+	"github.com/burningmantech/ranger-ims-go/lib/herr"
+	"github.com/burningmantech/ranger-ims-go/web/template"
 )
 
 func AddToMux(mux *http.ServeMux, cfg *conf.IMSConfig) *http.ServeMux {
@@ -35,7 +36,10 @@ func AddToMux(mux *http.ServeMux, cfg *conf.IMSConfig) *http.ServeMux {
 		mux = http.NewServeMux()
 	}
 
-	var versionName, versionRef string
+	// Supply a default versionName and fake ref, in case BuildInfo is unavailable.
+	// This version name is just the current UTC time, all smushed together.
+	versionName := time.Now().UTC().Format("20060102150405")
+	versionRef := "deadbeef"
 	bi, _ := debug.ReadBuildInfo()
 	if bi != nil {
 		// e.g. "20250629122355-7254ff315bc4"

--- a/web/template/adminactionlogs.templ
+++ b/web/template/adminactionlogs.templ
@@ -19,7 +19,7 @@ package template
 templ AdminActionLogs(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Action Logs", "admin_action_logs.js", true)
+@Head("Action Logs", "admin_action_logs.js", true, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/adminactionlogs_templ.go
+++ b/web/template/adminactionlogs_templ.go
@@ -63,7 +63,7 @@ func AdminActionLogs(deployment, versionName, versionRef string) templ.Component
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Action Logs", "admin_action_logs.js", true).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Action Logs", "admin_action_logs.js", true, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/admindebug.templ
+++ b/web/template/admindebug.templ
@@ -19,7 +19,7 @@ package template
 templ AdminDebug(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Debugging Details", "admin_debug.js", false)
+@Head("Debugging Details", "admin_debug.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/admindebug_templ.go
+++ b/web/template/admindebug_templ.go
@@ -63,7 +63,7 @@ func AdminDebug(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Debugging Details", "admin_debug.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Debugging Details", "admin_debug.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/admindestinations.templ
+++ b/web/template/admindestinations.templ
@@ -19,7 +19,7 @@ package template
 templ AdminDestinations(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Destinations", "admin_destinations.js", false)
+@Head("Destinations", "admin_destinations.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/admindestinations_templ.go
+++ b/web/template/admindestinations_templ.go
@@ -63,7 +63,7 @@ func AdminDestinations(deployment, versionName, versionRef string) templ.Compone
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Destinations", "admin_destinations.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Destinations", "admin_destinations.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/adminevents.templ
+++ b/web/template/adminevents.templ
@@ -19,7 +19,7 @@ package template
 templ AdminEvents(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Edit Events", "admin_events.js", false)
+@Head("Edit Events", "admin_events.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/adminevents_templ.go
+++ b/web/template/adminevents_templ.go
@@ -63,7 +63,7 @@ func AdminEvents(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Edit Events", "admin_events.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Edit Events", "admin_events.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/adminroot.templ
+++ b/web/template/adminroot.templ
@@ -19,7 +19,7 @@ package template
 templ AdminRoot(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Administration Tools", "admin_root.js", false)
+@Head("Administration Tools", "admin_root.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/adminroot_templ.go
+++ b/web/template/adminroot_templ.go
@@ -63,7 +63,7 @@ func AdminRoot(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Administration Tools", "admin_root.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Administration Tools", "admin_root.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/adminstreets.templ
+++ b/web/template/adminstreets.templ
@@ -19,7 +19,7 @@ package template
 templ AdminStreets(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Edit Streets", "admin_streets.js", false)
+@Head("Edit Streets", "admin_streets.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/adminstreets_templ.go
+++ b/web/template/adminstreets_templ.go
@@ -63,7 +63,7 @@ func AdminStreets(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Edit Streets", "admin_streets.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Edit Streets", "admin_streets.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/admintypes.templ
+++ b/web/template/admintypes.templ
@@ -19,7 +19,7 @@ package template
 templ AdminTypes(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Edit Incident Types", "admin_types.js", false)
+@Head("Edit Incident Types", "admin_types.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/admintypes_templ.go
+++ b/web/template/admintypes_templ.go
@@ -63,7 +63,7 @@ func AdminTypes(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Edit Incident Types", "admin_types.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Edit Incident Types", "admin_types.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/destinations.templ
+++ b/web/template/destinations.templ
@@ -19,7 +19,7 @@ package template
 templ Destinations(deployment, versionName, versionRef, eventName string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Destinations | " + eventName, "destinations.js", true)
+@Head("Destinations | " + eventName, "destinations.js", true, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/destinations_templ.go
+++ b/web/template/destinations_templ.go
@@ -63,7 +63,7 @@ func Destinations(deployment, versionName, versionRef, eventName string) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Destinations | "+eventName, "destinations.js", true).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Destinations | "+eventName, "destinations.js", true, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/field_report.templ
+++ b/web/template/field_report.templ
@@ -19,7 +19,7 @@ package template
 templ FieldReport(deployment, versionName, versionRef, eventName string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Field Report Details | " + eventName, "field_report.js", false)
+@Head("Field Report Details | " + eventName, "field_report.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/field_report_templ.go
+++ b/web/template/field_report_templ.go
@@ -63,7 +63,7 @@ func FieldReport(deployment, versionName, versionRef, eventName string) templ.Co
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Field Report Details | "+eventName, "field_report.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Field Report Details | "+eventName, "field_report.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/field_reports.templ
+++ b/web/template/field_reports.templ
@@ -19,7 +19,7 @@ package template
 templ FieldReports(deployment, versionName, versionRef, eventName string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Field Reports | " + eventName, "field_reports.js", true)
+@Head("Field Reports | " + eventName, "field_reports.js", true, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/field_reports_templ.go
+++ b/web/template/field_reports_templ.go
@@ -63,7 +63,7 @@ func FieldReports(deployment, versionName, versionRef, eventName string) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Field Reports | "+eventName, "field_reports.js", true).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Field Reports | "+eventName, "field_reports.js", true, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/head.templ
+++ b/web/template/head.templ
@@ -16,12 +16,19 @@
 
 package template
 
-templ Head(title string, module string, usesDataTables bool) {
+templ Head(title string, module string, usesDataTables bool, cacheVersion string) {
+{{
+    v := cacheVersion[:8]
+    var esImports = map[string]any{
+        "imports": map[string]string{
+            "/ims/static/ims.js": "/ims/static/ims.js?v=" + v,
+        },
+    }
+}}
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="modulepreload" href={"/ims/static/" + module} />
-    <link rel="modulepreload" href="/ims/static/ims.js" />
+    @templ.JSONScript("importmap", esImports).WithType("importmap")
     <link rel="apple-touch-icon" sizes="180x180" href="/ims/static/logos/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/ims/static/logos/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/ims/static/logos/favicon-16x16.png">
@@ -36,14 +43,14 @@ templ Head(title string, module string, usesDataTables bool) {
     <script src="/ims/static/ext/jquery.min.js" defer></script>
     <script src="/ims/static/ext/bootstrap.bundle.min.js" defer></script>
     <script src="/ims/static/ext/flatpickr.min.js" defer></script>
-    <script src="/ims/static/urls.js" defer></script>
+    <script src={"/ims/static/urls.js?v=" + v} defer></script>
     if usesDataTables {
     <script src="/ims/static/ext/dataTables.min.js" defer></script>
     <script src="/ims/static/ext/dataTables.bootstrap5.min.js" defer></script>
     }
-    <script src={"/ims/static/" + module} type="module"></script>
+    <script src={"/ims/static/" + module + "?v=" + v} type="module"></script>
     <!-- theme.js should not be deferred, so add it last. -->
-    <!-- We run it synchronously to avoid a light flicker on page load for dark mode users. -->
-    <script src="/ims/static/theme.js"></script>
+    <!-- We run it synchronously to avoid a flicker on page load for dark mode users. -->
+    <script src={"/ims/static/theme.js?v=" + v}></script>
 </head>
 }

--- a/web/template/head_templ.go
+++ b/web/template/head_templ.go
@@ -38,7 +38,7 @@ package template
 import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
-func Head(title string, module string, usesDataTables bool) templ.Component {
+func Head(title string, module string, usesDataTables bool, cacheVersion string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -59,20 +59,21 @@ func Head(title string, module string, usesDataTables bool) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><link rel=\"modulepreload\" href=\"")
+		v := cacheVersion[:8]
+		var esImports = map[string]any{
+			"imports": map[string]string{
+				"/ims/static/ims.js": "/ims/static/ims.js?v=" + v,
+			},
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var2 templ.SafeURL
-		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinURLErrs("/ims/static/" + module)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 23, Col: 59}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+		templ_7745c5c3_Err = templ.JSONScript("importmap", esImports).WithType("importmap").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "\"><link rel=\"modulepreload\" href=\"/ims/static/ims.js\"><link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ims/static/logos/apple-touch-icon.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/ims/static/logos/favicon-32x32.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/ims/static/logos/favicon-16x16.png\"><link rel=\"manifest\" href=\"/ims/static/logos/site.webmanifest\"><link rel=\"stylesheet\" href=\"/ims/static/ext/bootstrap.min.css\" type=\"text/css\"><link rel=\"stylesheet\" href=\"/ims/static/ext/flatpickr.min.css\" type=\"text/css\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 2, "<link rel=\"apple-touch-icon\" sizes=\"180x180\" href=\"/ims/static/logos/apple-touch-icon.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"32x32\" href=\"/ims/static/logos/favicon-32x32.png\"><link rel=\"icon\" type=\"image/png\" sizes=\"16x16\" href=\"/ims/static/logos/favicon-16x16.png\"><link rel=\"manifest\" href=\"/ims/static/logos/site.webmanifest\"><link rel=\"stylesheet\" href=\"/ims/static/ext/bootstrap.min.css\" type=\"text/css\"><link rel=\"stylesheet\" href=\"/ims/static/ext/flatpickr.min.css\" type=\"text/css\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -86,39 +87,65 @@ func Head(title string, module string, usesDataTables bool) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var3 string
-		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(title)
+		var templ_7745c5c3_Var2 string
+		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 35, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 42, Col: 17}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</title><script src=\"/ims/static/ext/jquery.min.js\" defer></script><script src=\"/ims/static/ext/bootstrap.bundle.min.js\" defer></script><script src=\"/ims/static/ext/flatpickr.min.js\" defer></script><script src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var3 string
+		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs("/ims/static/urls.js?v=" + v)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 46, Col: 45}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "</title><script src=\"/ims/static/ext/jquery.min.js\" defer></script><script src=\"/ims/static/ext/bootstrap.bundle.min.js\" defer></script><script src=\"/ims/static/ext/flatpickr.min.js\" defer></script><script src=\"/ims/static/urls.js\" defer></script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" defer></script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if usesDataTables {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<script src=\"/ims/static/ext/dataTables.min.js\" defer></script> <script src=\"/ims/static/ext/dataTables.bootstrap5.min.js\" defer></script>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<script src=\"/ims/static/ext/dataTables.min.js\" defer></script> <script src=\"/ims/static/ext/dataTables.bootstrap5.min.js\" defer></script>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<script src=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<script src=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var4 string
-		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("/ims/static/" + module)
+		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs("/ims/static/" + module + "?v=" + v)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 44, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 51, Col: 52}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\" type=\"module\"></script><!-- theme.js should not be deferred, so add it last. --><!-- We run it synchronously to avoid a light flicker on page load for dark mode users. --><script src=\"/ims/static/theme.js\"></script></head>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "\" type=\"module\"></script><!-- theme.js should not be deferred, so add it last. --><!-- We run it synchronously to avoid a flicker on page load for dark mode users. --><script src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var5 string
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs("/ims/static/theme.js?v=" + v)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `web/template/head.templ`, Line: 54, Col: 46}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"></script></head>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/incident.templ
+++ b/web/template/incident.templ
@@ -19,7 +19,7 @@ package template
 templ Incident(deployment, versionName, versionRef, eventName string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Incident Details | " + eventName, "incident.js", true)
+@Head("Incident Details | " + eventName, "incident.js", true, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/incident_templ.go
+++ b/web/template/incident_templ.go
@@ -63,7 +63,7 @@ func Incident(deployment, versionName, versionRef, eventName string) templ.Compo
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Incident Details | "+eventName, "incident.js", true).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Incident Details | "+eventName, "incident.js", true, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/incidents.templ
+++ b/web/template/incidents.templ
@@ -21,7 +21,7 @@ import "strings"
 templ Incidents(deployment, versionName, versionRef, eventName string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Incidents | " + eventName, "incidents.js", true)
+@Head("Incidents | " + eventName, "incidents.js", true, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/incidents_templ.go
+++ b/web/template/incidents_templ.go
@@ -65,7 +65,7 @@ func Incidents(deployment, versionName, versionRef, eventName string) templ.Comp
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Incidents | "+eventName, "incidents.js", true).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Incidents | "+eventName, "incidents.js", true, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/login.templ
+++ b/web/template/login.templ
@@ -19,7 +19,7 @@ package template
 templ Login(deployment, passwordResetURL, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Log In | IMS", "login.js", false)
+@Head("Log In | IMS", "login.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/login_templ.go
+++ b/web/template/login_templ.go
@@ -63,7 +63,7 @@ func Login(deployment, passwordResetURL, versionName, versionRef string) templ.C
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Log In | IMS", "login.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Log In | IMS", "login.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/root.templ
+++ b/web/template/root.templ
@@ -19,7 +19,7 @@ package template
 templ Root(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Home | IMS", "root.js", false)
+@Head("Home | IMS", "root.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/root_templ.go
+++ b/web/template/root_templ.go
@@ -63,7 +63,7 @@ func Root(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Home | IMS", "root.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Home | IMS", "root.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/web/template/settings.templ
+++ b/web/template/settings.templ
@@ -19,7 +19,7 @@ package template
 templ Settings(deployment, versionName, versionRef string) {
 <!DOCTYPE html>
 <html lang="en">
-@Head("Settings", "settings.js", false)
+@Head("Settings", "settings.js", false, versionRef)
 
 <body>
 <div class="container-fluid">

--- a/web/template/settings_templ.go
+++ b/web/template/settings_templ.go
@@ -63,7 +63,7 @@ func Settings(deployment, versionName, versionRef string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = Head("Settings", "settings.js", false).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = Head("Settings", "settings.js", false, versionRef).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
My iPhone's Safari browser cached ims.js a couple months ago, and it refuses to fetch a new version. I've had problems like this before as well. This solution really forces browsers to get new versions of scripts, because it changes the URI for each IMS script with each new release of the app.