### PR TITLE
fix: log incident type when removing it

### DIFF
--- a/api/incident.go
+++ b/api/incident.go
@@ -584,7 +584,7 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 			}
 		}
 		if len(sub) > 0 {
-			names := namesForIncidentTypes(allIncidentTypes, add)
+			names := namesForIncidentTypes(allIncidentTypes, sub)
 			logs = append(logs, fmt.Sprintf("Removed type: %v", names))
 			for _, rh := range sub {
 				err = imsDBQ.DetachIncidentTypeFromIncident(ctx, txn,


### PR DESCRIPTION
that was a silly oversight

https://github.com/burningmantech/ranger-ims-go/issues/542