### PR TITLE
docs: update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ This page accounts for changes up until:
 https://github.com/burningmantech/ranger-ims-go/pull/528
 -->
 
+## 2026-02
+
 ## 2026-01
 
 ### Added


### PR DESCRIPTION
this is really just a poke to get CICD to run on merge. It didn't run at all after https://github.com/burningmantech/ranger-ims-go/pull/556, for some unknown reason