### PR TITLE
fix: distinguish two types of JWT

### DIFF
--- a/lib/authz/accesstoken.go
+++ b/lib/authz/accesstoken.go
@@ -41,6 +41,7 @@ func (j JWTer) CreateAccessToken(
 			WithIssuedAt(time.Now()).
 			WithExpiration(expiration).
 			WithIssuer("ims").
+			WithTokenType(TokenTypeAccess).
 			WithRangerHandle(rangerName).
 			WithRangerOnSite(onsite).
 			WithRangerOnDutyPosition(onDutyPositionID).
@@ -50,9 +51,9 @@ func (j JWTer) CreateAccessToken(
 	)
 }
 
-// AuthenticateJWT gives JWT claims for a valid, authenticated JWT string, or
+// AuthenticateJWT gives JWT claims for a valid, authenticated access token, or
 // returns an error otherwise. A JWT may be invalid because it was signed by a
-// different key, because it has expired, etc.
+// different key, because it has expired, because it isn't an access token, etc.
 func (j JWTer) AuthenticateJWT(jwtStr string) (*IMSClaims, error) {
-	return j.authenticateJWT(jwtStr)
+	return j.authenticateJWT(jwtStr, TokenTypeAccess)
 }

--- a/lib/authz/claim.go
+++ b/lib/authz/claim.go
@@ -25,6 +25,13 @@ import (
 
 const compactIntBase = 62
 
+// TokenType values for the "tok" claim. These distinguish access tokens from
+// refresh tokens, so that one can never be used in place of the other.
+const (
+	TokenTypeAccess  = "access"
+	TokenTypeRefresh = "refresh"
+)
+
 type IMSClaims struct {
 	jwt.RegisteredClaims
 
@@ -33,6 +40,7 @@ type IMSClaims struct {
 	Teams          string `json:"tea"`
 	Onsite         bool   `json:"ons"`
 	OnDutyPosition *int64 `json:"dut,omitempty"`
+	TokenType      string `json:"tok,omitempty"`
 }
 
 func unmarshalBigInt(s string) *big.Int {
@@ -114,6 +122,11 @@ func (c IMSClaims) WithRangerTeams(teams ...int64) IMSClaims {
 
 func (c IMSClaims) WithRangerOnDutyPosition(pos *int64) IMSClaims {
 	c.OnDutyPosition = pos
+	return c
+}
+
+func (c IMSClaims) WithTokenType(tokenType string) IMSClaims {
+	c.TokenType = tokenType
 	return c
 }
 

--- a/lib/authz/jwt.go
+++ b/lib/authz/jwt.go
@@ -35,7 +35,7 @@ func (j JWTer) createJWT(claims IMSClaims) (string, error) {
 	return token, nil
 }
 
-func (j JWTer) authenticateJWT(jwtStr string) (*IMSClaims, error) {
+func (j JWTer) authenticateJWT(jwtStr, wantTokenType string) (*IMSClaims, error) {
 	if jwtStr == "" {
 		return nil, errors.New("no JWT string provided")
 	}
@@ -54,6 +54,12 @@ func (j JWTer) authenticateJWT(jwtStr string) (*IMSClaims, error) {
 	}
 	if claims.RangerHandle() == "" {
 		return nil, errors.New("ranger handle is required")
+	}
+	// Access and refresh tokens are both JWTs signed by the same key, so this
+	// check is what stops a refresh token from being used as a bearer access
+	// token (or an access token from being used to mint new access tokens).
+	if claims.TokenType != wantTokenType {
+		return nil, fmt.Errorf("token type %q is not valid here", claims.TokenType)
 	}
 	return &claims, nil
 }

--- a/lib/authz/jwt_test.go
+++ b/lib/authz/jwt_test.go
@@ -99,3 +99,37 @@ func TestCreateAndGetInvalidJWTs(t *testing.T) {
 		require.Contains(t, err.Error(), "ranger handle is required")
 	}
 }
+
+func TestTokenTypesAreNotInterchangeable(t *testing.T) {
+	t.Parallel()
+	jwter := authz.JWTer{SecretKey: "some-secret"}
+
+	accessToken, err := jwter.CreateAccessToken(
+		"Hardware",
+		12345,
+		nil,
+		nil,
+		true,
+		new(int64(20)),
+		time.Now().Add(1*time.Hour),
+	)
+	require.NoError(t, err)
+	refreshToken, err := jwter.CreateRefreshToken("Hardware", 12345, time.Now().Add(1*time.Hour))
+	require.NoError(t, err)
+
+	// Each token works for its intended purpose
+	_, err = jwter.AuthenticateJWT(accessToken)
+	require.NoError(t, err)
+	_, err = jwter.AuthenticateRefreshToken(refreshToken)
+	require.NoError(t, err)
+
+	// A refresh token must not be usable as an access token
+	_, err = jwter.AuthenticateJWT(refreshToken)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token type")
+
+	// An access token must not be usable as a refresh token
+	_, err = jwter.AuthenticateRefreshToken(accessToken)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "token type")
+}

--- a/lib/authz/refreshtoken.go
+++ b/lib/authz/refreshtoken.go
@@ -30,8 +30,9 @@ import (
 const RefreshTokenCookieName = "refresh_token"
 
 // CreateRefreshToken creates a refresh token, which the client can use to request new access tokens,
-// based on any updated claims from the UserStore. It's an implementation detail that this uses an
-// access token-style JWT. Ideally a refresh token is supposed to be persisted, so that it can be
+// based on any updated claims from the UserStore. It's an implementation detail that this is a JWT;
+// its "tok" claim marks it as a refresh token, so it cannot be used as an access token.
+// Ideally a refresh token is supposed to be persisted, so that it can be
 // invalidated from the server side. As a stopgap before we have such a per-user persistence component,
 // we instead rely on the security of JWT signing.
 func (j JWTer) CreateRefreshToken(rangerName string, clubhouseID int64, expiration time.Time) (string, error) {
@@ -40,15 +41,17 @@ func (j JWTer) CreateRefreshToken(rangerName string, clubhouseID int64, expirati
 			WithIssuedAt(time.Now()).
 			WithExpiration(expiration).
 			WithIssuer("ims").
+			WithTokenType(TokenTypeRefresh).
 			WithRangerHandle(rangerName).
 			WithSubject(strconv.FormatInt(clubhouseID, 10)),
 	)
 }
 
 // AuthenticateRefreshToken is like AuthenticateJWT, in that it validates that the
-// supplied token is valid (was signed by the same secret key and hasn't expired).
-// It's an implementation detail that refresh tokens are also JWTs. Clients of IMS
-// should treat them as simply opaque strings.
+// supplied token is valid (was signed by the same secret key, hasn't expired, and
+// is a refresh token rather than an access token). It's an implementation detail
+// that refresh tokens are also JWTs. Clients of IMS should treat them as simply
+// opaque strings.
 func (j JWTer) AuthenticateRefreshToken(refreshToken string) (*IMSClaims, error) {
-	return j.authenticateJWT(refreshToken)
+	return j.authenticateJWT(refreshToken, TokenTypeRefresh)
 }


### PR DESCRIPTION
This was a suggested fix from a Claude review. Here's how it laid out the problem, which is real, but IMO not a huge deal.

  2. Access tokens and refresh tokens are interchangeable

  lib/authz/jwt.go:38-59, lib/authz/accesstoken.go:56-58, lib/authz/refreshtoken.go:52-54 — both token types are HS256 JWTs signed with the same key, carrying the same claim
  set (refresh tokens just omit positions/teams), and AuthenticateJWT and AuthenticateRefreshToken are literally the same function. There is no token-type claim. Consequences:

  - A leaked 15-minute access token grants indefinite access. Put an access token in the refresh_token cookie and POST to /ims/api/auth/refresh (api/auth.go:294-343): it validates, and you get a fresh access token, which can refresh itself again before it expires — forever. The short access-token lifetime provides no security boundary.
  - The 7-day refresh token works directly as a bearer access token in the Authorization header. It lacks position/team claims, but person: access rules and IMS_ADMINS checks key off the handle alone, so for most users (and all admins) it's full access.

  Fix direction: add a typ/audience claim distinguishing the two and validate it in each authenticate function.