### PR TITLE
feat: add versioning of Incidents, Field Reports, and Visits

### DIFF
--- a/api/eventaccess.go
+++ b/api/eventaccess.go
@@ -311,6 +311,13 @@ func (action PostEventAccess) maybeSetAccess(
 	// This function is very prone to transaction deadlock, because it does
 	// multiple transactional deletes and inserts. Add a timeout in here too,
 	// just to be safe that we don't end up holding the lock forever.
+	//
+	// Event-access writes are deliberately last-write-wins, with no
+	// optimistic-concurrency VERSION/ETag like incidents have: two admins
+	// editing the same event and mode concurrently can overwrite each other.
+	// That's acceptable because writes are admin-only and rare, this mutex
+	// serializes them, and the result is immediately visible (and fixable)
+	// on the admin page.
 	eventAccessWriteMu.Lock()
 	defer eventAccessWriteMu.Unlock()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)

--- a/api/fieldreport.go
+++ b/api/fieldreport.go
@@ -150,6 +150,7 @@ func (action GetFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		errHTTP.From("[getFieldReport]").WriteResponse(w)
 		return
 	}
+	setETag(w, resp.Version)
 	mustWriteJSON(w, req, resp)
 }
 
@@ -198,6 +199,7 @@ func fieldReportToJSON(
 		Event:         event.Name,
 		Number:        fr.Number,
 		Created:       conv.FloatToTime(fr.Created),
+		Version:       fr.Version,
 		Summary:       conv.SqlToString(fr.Summary),
 		Incident:      conv.SqlToInt32(fr.IncidentNumber),
 		ReportEntries: entries,
@@ -242,20 +244,21 @@ type EditFieldReport struct {
 }
 
 func (action EditFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := action.editFieldReport(req)
+	version, errHTTP := action.editFieldReport(req)
 	if errHTTP != nil {
 		errHTTP.From("[editFieldReport]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
-func (action EditFieldReport) editFieldReport(req *http.Request) *herr.HTTPError {
+func (action EditFieldReport) editFieldReport(req *http.Request) (int32, *herr.HTTPError) {
 	event, jwt, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return errHTTP.From("[getEventPermissions]")
+		return 0, errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&(authz.EventWriteAllFieldReports|authz.EventWriteOwnFieldReports) == 0 {
-		return herr.Forbidden("The requestor does not have permission to edit Field Reports on this Event", nil)
+		return 0, herr.Forbidden("The requestor does not have permission to edit Field Reports on this Event", nil)
 	}
 	// i.e. they have EventWriteOwnFieldReports, but not EventWriteAllFieldReports
 	limitedAccess := eventPermissions&authz.EventWriteAllFieldReports == 0
@@ -263,20 +266,24 @@ func (action EditFieldReport) editFieldReport(req *http.Request) *herr.HTTPError
 	ctx := req.Context()
 	err := req.ParseForm()
 	if err != nil {
-		return herr.BadRequest("Failed to parse form data", err).From("[ParseForm]")
+		return 0, herr.BadRequest("Failed to parse form data", err).From("[ParseForm]")
 	}
 	fieldReportNumber, err := conv.ParseInt32(req.PathValue("fieldReportNumber"))
 	if err != nil {
-		return herr.BadRequest("Invalid field report number", err).From("[ParseInt32]")
+		return 0, herr.BadRequest("Invalid field report number", err).From("[ParseInt32]")
+	}
+	ifMatch, errHTTP := parseIfMatch(req)
+	if errHTTP != nil {
+		return 0, errHTTP.From("[parseIfMatch]")
 	}
 	author := jwt.Claims.RangerHandle()
 	if limitedAccess {
 		isPrevAuthor, errHTTP := action.isPreviousAuthor(req, event.ID, fieldReportNumber, author)
 		if errHTTP != nil {
-			return errHTTP.From("[isPreviousAuthor]")
+			return 0, errHTTP.From("[isPreviousAuthor]")
 		}
 		if !isPrevAuthor {
-			return herr.Forbidden("The requestor does not have permission to edit this Field Report", nil)
+			return 0, herr.Forbidden("The requestor does not have permission to edit this Field Report", nil)
 		}
 	}
 
@@ -287,34 +294,109 @@ func (action EditFieldReport) editFieldReport(req *http.Request) *herr.HTTPError
 		},
 	)
 	if err != nil {
-		return herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, herr.NotFound("Field Report does not exist", err).From("[FieldReport]")
+		}
+		return 0, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
 	}
 	storedFR := frr.FieldReport
+	version := storedFR.Version
 
 	// If there's an "action" in the form, we're either linking or unlinking this FR from an Incident.
 	if queryAction := req.FormValue("action"); queryAction != "" {
 		targetIncidentVal := req.FormValue("incident")
 
+		// The link bumps this Field Report's version, so If-Match is verified
+		// here, against the version read above. The guarded update below then
+		// re-reads, so that this request's own bump doesn't read as a conflict.
+		if ifMatch != nil && *ifMatch != version {
+			return 0, herr.PreconditionFailed(
+				"This field report was changed by someone else while you were editing it", nil,
+			).SetExpectedError()
+		}
+		ifMatch = nil
+
 		// TODO: get rid of this "action" framework, and just allow a standard POST, as with visit's incident field.
 		errHTTP = action.handleLinkToIncident(ctx, storedFR, event, queryAction, targetIncidentVal, author)
 		if errHTTP != nil {
-			return errHTTP.From("[handleLinkToIncident]")
+			return 0, errHTTP.From("[handleLinkToIncident]")
+		}
+		version, err = action.imsDBQ.FieldReportVersion(ctx, action.imsDBQ, imsdb.FieldReportVersionParams{
+			Event:  event.ID,
+			Number: fieldReportNumber,
+		})
+		if err != nil {
+			return 0, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReportVersion]")
 		}
 	}
 
 	requestFR, errHTTP := readBodyAs[imsjson.FieldReport](req)
 	if errHTTP != nil {
-		return errHTTP.From("[readBodyAs]")
+		return 0, errHTTP.From("[readBodyAs]")
 	}
 	// This is fine, as it may be that only a link/unlink was requested
 	if requestFR.Number == 0 {
 		slog.Debug("No field report number provided")
-		return nil
+		return version, nil
+	}
+
+	version, errHTTP = action.updateFieldReport(ctx, event, fieldReportNumber, requestFR, author, ifMatch)
+	if errHTTP != nil {
+		return 0, errHTTP.From("[updateFieldReport]")
+	}
+	return version, nil
+}
+
+func (action EditFieldReport) updateFieldReport(
+	ctx context.Context, event imsdb.Event, fieldReportNumber int32,
+	requestFR imsjson.FieldReport, author string, ifMatch *int32,
+) (newVersion int32, errHTTP *herr.HTTPError) {
+	attempts := maxCASAttempts
+	if ifMatch != nil {
+		attempts = 1
+	}
+	for range attempts {
+		version, conflict, errHTTP := action.updateFieldReportAttempt(ctx, event, fieldReportNumber, requestFR, author, ifMatch)
+		if errHTTP != nil {
+			return 0, errHTTP.From("[updateFieldReportAttempt]")
+		}
+		if !conflict {
+			return version, nil
+		}
+		if ifMatch != nil {
+			return 0, herr.PreconditionFailed(
+				"This field report was changed by someone else while you were editing it", nil,
+			).SetExpectedError()
+		}
+	}
+	return 0, herr.Conflict("The field report is being modified concurrently. Please try again.", nil)
+}
+
+func (action EditFieldReport) updateFieldReportAttempt(
+	ctx context.Context, event imsdb.Event, fieldReportNumber int32,
+	requestFR imsjson.FieldReport, author string, ifMatch *int32,
+) (newVersion int32, conflict bool, errHTTP *herr.HTTPError) {
+	frr, err := action.imsDBQ.FieldReport(ctx, action.imsDBQ,
+		imsdb.FieldReportParams{
+			Event:  event.ID,
+			Number: fieldReportNumber,
+		},
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, herr.NotFound("Field Report does not exist", err).From("[FieldReport]")
+		}
+		return 0, false, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
+	}
+	storedFR := frr.FieldReport
+	expectedVersion := storedFR.Version
+	if ifMatch != nil && *ifMatch != expectedVersion {
+		return 0, true, nil
 	}
 
 	txn, err := action.imsDBQ.Begin()
 	if err != nil {
-		return herr.InternalServerError("Failed to begin transaction", err).From("[Begin]")
+		return 0, false, herr.InternalServerError("Failed to begin transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
@@ -323,30 +405,52 @@ func (action EditFieldReport) editFieldReport(req *http.Request) *herr.HTTPError
 		storedFR.Summary = conv.StringToSql(requestFR.Summary, 0)
 		logs = append(logs, "Changed summary to: "+*requestFR.Summary)
 	}
-	err = action.imsDBQ.UpdateFieldReport(ctx, txn,
-		imsdb.UpdateFieldReportParams{
-			Event:          storedFR.Event,
-			Number:         storedFR.Number,
-			Summary:        storedFR.Summary,
-			IncidentNumber: storedFR.IncidentNumber,
-		},
-	)
-	if err != nil {
-		return herr.InternalServerError("Failed to update Field Report", err).From("[UpdateFieldReport]")
+	// A request that only appends report entries is applied without the
+	// guarded update below; see updateIncidentAttempt.
+	newVersion = expectedVersion
+	if len(logs) > 0 {
+		// The version-guarded update is the concurrency gate; see updateIncidentAttempt.
+		rows, err := action.imsDBQ.UpdateFieldReport(ctx, txn,
+			imsdb.UpdateFieldReportParams{
+				Event:          storedFR.Event,
+				Number:         storedFR.Number,
+				Version:        expectedVersion,
+				Summary:        storedFR.Summary,
+				IncidentNumber: storedFR.IncidentNumber,
+			},
+		)
+		if err != nil {
+			return 0, false, herr.InternalServerError("Failed to update Field Report", err).From("[UpdateFieldReport]")
+		}
+		if rows == 0 {
+			// Stale version or vanished row; re-read to tell which.
+			_, err = action.imsDBQ.FieldReportVersion(ctx, action.imsDBQ, imsdb.FieldReportVersionParams{
+				Event:  event.ID,
+				Number: fieldReportNumber,
+			})
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return 0, false, herr.NotFound("Field Report does not exist", err).From("[FieldReportVersion]")
+				}
+				return 0, false, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReportVersion]")
+			}
+			return 0, true, nil
+		}
+		newVersion = expectedVersion + 1
 	}
 	errHTTP = addChangeReportEntries(ctx, action.imsDBQ, txn, event.ID, storedFR.Number, author,
 		logs, requestFR.ReportEntries, addFRReportEntry)
 	if errHTTP != nil {
-		return errHTTP.From("[addChangeReportEntries]")
+		return 0, false, errHTTP.From("[addChangeReportEntries]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return 0, false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
-	defer action.eventSource.notifyFieldReportUpdate(event.ID, storedFR.Number)
-	return nil
+	action.eventSource.notifyFieldReportUpdate(event.ID, storedFR.Number)
+	return newVersion, false, nil
 }
 
 func (action EditFieldReport) handleLinkToIncident(
@@ -390,6 +494,20 @@ func (action EditFieldReport) handleLinkToIncident(
 			return herr.NotFound("No such Incident", err).From("[AttachFieldReportToIncident]")
 		}
 		return herr.InternalServerError("Failed to attach Field Report to incident", err).From("[AttachFieldReportToIncident]")
+	}
+	// The affected incidents' field-report lists changed, so their versions
+	// must move for clients holding their ETags to notice.
+	for _, incidentNumber := range []sql.NullInt32{previousIncident, newIncident} {
+		if !incidentNumber.Valid {
+			continue
+		}
+		err = action.imsDBQ.BumpIncidentVersion(ctx, action.imsDBQ, imsdb.BumpIncidentVersionParams{
+			Event:  event.ID,
+			Number: incidentNumber.Int32,
+		})
+		if err != nil {
+			return herr.InternalServerError("Failed to update incident", err).From("[BumpIncidentVersion]")
+		}
 	}
 	_, errHTTP := addFRReportEntry(ctx, action.imsDBQ, action.imsDBQ, event.ID, fieldReportNumber, newReportEntry{
 		author:    actor,
@@ -452,6 +570,9 @@ func (action NewFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Request)
 
 	w.Header().Set("IMS-Field-Report-Number", strconv.Itoa(int(number)))
 	w.Header().Set("Location", location)
+	// A new Field Report is created directly (not via the guarded update path),
+	// so its version is the column default.
+	setETag(w, 1)
 	herr.WriteCreatedResponse(w, http.StatusText(http.StatusCreated))
 }
 

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/burningmantech/ranger-ims-go/directory"
 	"github.com/burningmantech/ranger-ims-go/lib/authz"
@@ -57,6 +59,33 @@ func readBodyAs[T any](req *http.Request) (T, *herr.HTTPError) {
 		return empty, herr.BadRequest("Failed to unmarshal request body", err).From("[Unmarshal]")
 	}
 	return t, nil
+}
+
+// parseIfMatch returns the record version from a request's If-Match header, or
+// nil if the header is absent or "*" (which matches any current version).
+// IMS ETags are strong and hold a single integer version, e.g. `"7"`.
+func parseIfMatch(req *http.Request) (*int32, *herr.HTTPError) {
+	raw := strings.TrimSpace(req.Header.Get("If-Match"))
+	if raw == "" || raw == "*" {
+		return nil, nil
+	}
+	if strings.Contains(raw, ",") {
+		return nil, herr.BadRequest("If-Match with multiple ETags is not supported", nil)
+	}
+	if strings.HasPrefix(raw, "W/") {
+		return nil, herr.BadRequest("Weak ETags are not valid in If-Match", nil)
+	}
+	version, err := conv.ParseInt32(strings.Trim(raw, `"`))
+	if err != nil {
+		return nil, herr.BadRequest("Invalid If-Match header", err)
+	}
+	return &version, nil
+}
+
+// setETag sets a strong ETag response header from a record version, e.g. `"7"`.
+// It must be called before the response status is written.
+func setETag(w http.ResponseWriter, version int32) {
+	w.Header().Set("ETag", `"`+strconv.FormatInt(int64(version), 10)+`"`)
 }
 
 func eventFromFormValue(req *http.Request, imsDBQ *store.DBQ) (imsdb.Event, *herr.HTTPError) {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -70,6 +70,62 @@ func TestReadBodyAsErrors(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, errHTTP.Code)
 }
 
+func TestParseIfMatch(t *testing.T) {
+	t.Parallel()
+
+	requestWithIfMatch := func(value string) *http.Request {
+		req := &http.Request{Header: http.Header{}}
+		if value != "" {
+			req.Header.Set("If-Match", value)
+		}
+		return req
+	}
+
+	// absent header means no version check
+	version, errHTTP := parseIfMatch(requestWithIfMatch(""))
+	require.Nil(t, errHTTP)
+	assert.Nil(t, version)
+
+	// "*" matches any current version, so it also means no version check
+	version, errHTTP = parseIfMatch(requestWithIfMatch("*"))
+	require.Nil(t, errHTTP)
+	assert.Nil(t, version)
+
+	// a quoted ETag is the normal case
+	version, errHTTP = parseIfMatch(requestWithIfMatch(`"7"`))
+	require.Nil(t, errHTTP)
+	require.NotNil(t, version)
+	assert.Equal(t, int32(7), *version)
+
+	// an unquoted value is tolerated too
+	version, errHTTP = parseIfMatch(requestWithIfMatch("12"))
+	require.Nil(t, errHTTP)
+	require.NotNil(t, version)
+	assert.Equal(t, int32(12), *version)
+
+	// weak ETags aren't valid in If-Match
+	_, errHTTP = parseIfMatch(requestWithIfMatch(`W/"7"`))
+	require.NotNil(t, errHTTP)
+	assert.Equal(t, http.StatusBadRequest, errHTTP.Code)
+
+	// multiple ETags aren't supported
+	_, errHTTP = parseIfMatch(requestWithIfMatch(`"7", "8"`))
+	require.NotNil(t, errHTTP)
+	assert.Equal(t, http.StatusBadRequest, errHTTP.Code)
+
+	// garbage isn't a version
+	_, errHTTP = parseIfMatch(requestWithIfMatch(`"unversioned"`))
+	require.NotNil(t, errHTTP)
+	assert.Equal(t, http.StatusBadRequest, errHTTP.Code)
+}
+
+func TestSetETag(t *testing.T) {
+	t.Parallel()
+	rec := httptest.NewRecorder()
+	setETag(rec, 42)
+	assert.Equal(t, `"42"`, rec.Header().Get("ETag"))
+}
+
 func TestEventFromFormValue(t *testing.T) {
 	t.Parallel()
 

--- a/api/incident.go
+++ b/api/incident.go
@@ -154,6 +154,7 @@ func (action GetIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		errHTTP.From("[getIncident]").WriteResponse(w)
 		return
 	}
+	setETag(w, resp.Version)
 	mustWriteJSON(w, req, resp)
 }
 
@@ -261,6 +262,7 @@ func incidentToJSON(storedRow imsdb.IncidentRow, incidentRangers []imsdb.Inciden
 		Number:       storedRow.Incident.Number,
 		Created:      conv.FloatToTime(storedRow.Incident.Created),
 		LastModified: lastModified,
+		Version:      storedRow.Incident.Version,
 		State:        string(storedRow.Incident.State),
 		Started:      conv.FloatToTime(storedRow.Incident.Started),
 		Closed:       conv.NullFloatToTime(storedRow.Incident.Closed),
@@ -321,7 +323,7 @@ type NewIncident struct {
 }
 
 func (action NewIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	number, location, errHTTP := action.newIncident(req)
+	number, version, location, errHTTP := action.newIncident(req)
 	if errHTTP != nil {
 		errHTTP.From("[newIncident]").WriteResponse(w)
 		return
@@ -329,20 +331,21 @@ func (action NewIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("IMS-Incident-Number", strconv.Itoa(int(number)))
 	w.Header().Set("Location", location)
+	setETag(w, version)
 	herr.WriteCreatedResponse(w, http.StatusText(http.StatusCreated))
 }
-func (action NewIncident) newIncident(req *http.Request) (incidentNumber int32, location string, errHTTP *herr.HTTPError) {
+func (action NewIncident) newIncident(req *http.Request) (incidentNumber, version int32, location string, errHTTP *herr.HTTPError) {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[getEventPermissions]")
+		return 0, 0, "", errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteIncidents == 0 {
-		return 0, "", herr.Forbidden("The requestor does not have EventWriteIncidents permission on this Event", nil)
+		return 0, 0, "", herr.Forbidden("The requestor does not have EventWriteIncidents permission on this Event", nil)
 	}
 	ctx := req.Context()
 	newIncident, errHTTP := readBodyAs[imsjson.Incident](req)
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[readBodyAs]")
+		return 0, 0, "", errHTTP.From("[readBodyAs]")
 	}
 
 	author := jwtCtx.Claims.RangerHandle()
@@ -350,7 +353,7 @@ func (action NewIncident) newIncident(req *http.Request) (incidentNumber int32, 
 	// First create the incident, to lock in the incident number reservation
 	newIncidentNumber, err := action.imsDBQ.NextIncidentNumber(ctx, action.imsDBQ, event.ID)
 	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to find next Incident number", err).From("[NextIncidentNumber]")
+		return 0, 0, "", herr.InternalServerError("Failed to find next Incident number", err).From("[NextIncidentNumber]")
 	}
 	newIncident.EventID = event.ID
 	newIncident.Event = event.Name
@@ -366,15 +369,15 @@ func (action NewIncident) newIncident(req *http.Request) (incidentNumber int32, 
 	}
 	_, err = action.imsDBQ.CreateIncident(ctx, action.imsDBQ, createTheIncident)
 	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to create incident", err).From("[CreateIncident]")
+		return 0, 0, "", herr.InternalServerError("Failed to create incident", err).From("[CreateIncident]")
 	}
 
-	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author)
+	version, errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author, nil)
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[updateIncident]")
+		return 0, 0, "", errHTTP.From("[updateIncident]")
 	}
 
-	return newIncident.Number, fmt.Sprintf("/ims/api/events/%v/incidents/%d", event.Name, newIncident.Number), nil
+	return newIncident.Number, version, fmt.Sprintf("/ims/api/events/%v/incidents/%d", event.Name, newIncident.Number), nil
 }
 
 func unmarshalByteSlice[T any](isByteSlice any) (T, error) {
@@ -406,8 +409,38 @@ func readExtraIncidentRowFields(row imsdb.IncidentRow) (incidentTypeIDs, fieldRe
 	return incidentTypeIDs, fieldReportNumbers, visitNumbers, nil
 }
 
+// maxCASAttempts bounds the read-merge-write retries for edits that don't
+// carry an If-Match header. Edits that do carry one get a single attempt,
+// since a version mismatch must be reported back to the client as a 412.
+const maxCASAttempts = 3
+
 func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
-) *herr.HTTPError {
+	ifMatch *int32,
+) (newVersion int32, errHTTP *herr.HTTPError) {
+	attempts := maxCASAttempts
+	if ifMatch != nil {
+		attempts = 1
+	}
+	for range attempts {
+		version, conflict, errHTTP := updateIncidentAttempt(ctx, imsDBQ, es, newIncident, author, ifMatch)
+		if errHTTP != nil {
+			return 0, errHTTP.From("[updateIncidentAttempt]")
+		}
+		if !conflict {
+			return version, nil
+		}
+		if ifMatch != nil {
+			return 0, herr.PreconditionFailed(
+				"This incident was changed by someone else while you were editing it", nil,
+			).SetExpectedError()
+		}
+	}
+	return 0, herr.Conflict("The incident is being modified concurrently. Please try again.", nil)
+}
+
+func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
+	ifMatch *int32,
+) (newVersion int32, conflict bool, errHTTP *herr.HTTPError) {
 	storedIncidentRow, err := imsDBQ.Incident(ctx, imsDBQ,
 		imsdb.IncidentParams{
 			Event:  newIncident.EventID,
@@ -415,13 +448,20 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 		},
 	)
 	if err != nil {
-		return herr.InternalServerError("Failed to fetch incident", err).From("[Incident]")
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, herr.NotFound("Incident not found", err).From("[Incident]")
+		}
+		return 0, false, herr.InternalServerError("Failed to fetch incident", err).From("[Incident]")
 	}
 	storedIncident := storedIncidentRow.Incident
+	expectedVersion := storedIncident.Version
+	if ifMatch != nil && *ifMatch != expectedVersion {
+		return 0, true, nil
+	}
 
 	allEvents, err := imsDBQ.Events(ctx, imsDBQ)
 	if err != nil {
-		return herr.InternalServerError("Failed to fetch events", err).From("[Events]")
+		return 0, false, herr.InternalServerError("Failed to fetch events", err).From("[Events]")
 	}
 	eventNameById := make(map[int32]string)
 	for _, event := range allEvents {
@@ -433,7 +473,7 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 	if newIncident.IncidentTypeIDs != nil {
 		allIncidentTypes, err = imsDBQ.IncidentTypes(ctx, imsDBQ)
 		if err != nil {
-			return herr.InternalServerError("Failed to get incident types", err).From("[IncidentTypes]")
+			return 0, false, herr.InternalServerError("Failed to get incident types", err).From("[IncidentTypes]")
 		}
 	}
 
@@ -442,59 +482,93 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 		IncidentNumber1: storedIncident.Number,
 	})
 	if err != nil {
-		return herr.InternalServerError("Failed to fetch linked incidents", err)
+		return 0, false, herr.InternalServerError("Failed to fetch linked incidents", err)
 	}
 
 	incidentTypeIDs, fieldReportNumbers, visitNumbers, err := readExtraIncidentRowFields(storedIncidentRow)
 	if err != nil {
-		return herr.InternalServerError("Failed to read incident details", err).From("[readExtraIncidentRowFields]")
+		return 0, false, herr.InternalServerError("Failed to read incident details", err).From("[readExtraIncidentRowFields]")
 	}
 
 	txn, err := imsDBQ.Begin()
 	if err != nil {
-		return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		return 0, false, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
 	update, logs := buildIncidentUpdate(storedIncident, newIncident)
-	err = imsDBQ.UpdateIncident(ctx, txn, update)
-	if err != nil {
-		return herr.InternalServerError("Failed to update incident", err).From("[UpdateIncident]")
+
+	// A request that only appends report entries is applied without the
+	// guarded update below: appends can't lose data, so they must neither
+	// conflict with concurrent field edits nor move the version and thereby
+	// invalidate other clients' ETags.
+	changesIncident := len(logs) > 0 ||
+		newIncident.IncidentTypeIDs != nil ||
+		newIncident.FieldReports != nil ||
+		newIncident.Visits != nil ||
+		newIncident.LinkedIncidents != nil
+	newVersion = expectedVersion
+	if changesIncident {
+		// The version-guarded update is the concurrency gate for everything in
+		// this transaction: if another writer committed since the read above,
+		// it affects zero rows and the whole edit is retried (or rejected with
+		// a 412) rather than clobbering the other writer's changes. Once it
+		// succeeds, the row lock it takes serializes any competing writers
+		// until commit.
+		rows, err := imsDBQ.UpdateIncident(ctx, txn, update)
+		if err != nil {
+			return 0, false, herr.InternalServerError("Failed to update incident", err).From("[UpdateIncident]")
+		}
+		if rows == 0 {
+			// Stale version or vanished row; re-read to tell which.
+			_, err = imsDBQ.IncidentVersion(ctx, imsDBQ, imsdb.IncidentVersionParams{
+				Event:  newIncident.EventID,
+				Number: newIncident.Number,
+			})
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return 0, false, herr.NotFound("Incident not found", err).From("[IncidentVersion]")
+				}
+				return 0, false, herr.InternalServerError("Failed to fetch incident", err).From("[IncidentVersion]")
+			}
+			return 0, true, nil
+		}
+		newVersion = expectedVersion + 1
 	}
 
 	typeLogs, errHTTP := applyIncidentTypeChanges(ctx, imsDBQ, txn, newIncident, incidentTypeIDs, allIncidentTypes)
 	if errHTTP != nil {
-		return errHTTP.From("[applyIncidentTypeChanges]")
+		return 0, false, errHTTP.From("[applyIncidentTypeChanges]")
 	}
 	logs = append(logs, typeLogs...)
 
 	frLogs, updatedFieldReports, errHTTP := applyIncidentFieldReportChanges(ctx, imsDBQ, txn, newIncident, fieldReportNumbers)
 	if errHTTP != nil {
-		return errHTTP.From("[applyIncidentFieldReportChanges]")
+		return 0, false, errHTTP.From("[applyIncidentFieldReportChanges]")
 	}
 	logs = append(logs, frLogs...)
 
 	visitLogs, updatedVisits, errHTTP := applyIncidentVisitChanges(ctx, imsDBQ, txn, newIncident, visitNumbers)
 	if errHTTP != nil {
-		return errHTTP.From("[applyIncidentVisitChanges]")
+		return 0, false, errHTTP.From("[applyIncidentVisitChanges]")
 	}
 	logs = append(logs, visitLogs...)
 
 	linkLogs, updatedLinkedIncidents, errHTTP := applyLinkedIncidentChanges(ctx, imsDBQ, txn, newIncident, linkedIncidents, eventNameById, author)
 	if errHTTP != nil {
-		return errHTTP.From("[applyLinkedIncidentChanges]")
+		return 0, false, errHTTP.From("[applyLinkedIncidentChanges]")
 	}
 	logs = append(logs, linkLogs...)
 
 	errHTTP = addChangeReportEntries(ctx, imsDBQ, txn, newIncident.EventID, newIncident.Number, author,
 		logs, newIncident.ReportEntries, addIncidentReportEntry)
 	if errHTTP != nil {
-		return errHTTP.From("[addChangeReportEntries]")
+		return 0, false, errHTTP.From("[addChangeReportEntries]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return 0, false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	es.notifyIncidentUpdate(newIncident.EventID, newIncident.Number)
@@ -508,7 +582,7 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 		es.notifyVisitUpdate(newIncident.EventID, s)
 	}
 
-	return nil
+	return newVersion, false, nil
 }
 
 // buildIncidentUpdate merges the client-provided fields of newIncident over the
@@ -518,6 +592,7 @@ func buildIncidentUpdate(stored imsdb.Incident, newIncident imsjson.Incident) (i
 	update := imsdb.UpdateIncidentParams{
 		Event:               stored.Event,
 		Number:              stored.Number,
+		Version:             stored.Version,
 		Priority:            stored.Priority,
 		State:               stored.State,
 		Started:             stored.Started,
@@ -752,6 +827,15 @@ func applyLinkedIncidentChanges(
 			if err != nil {
 				return nil, nil, herr.InternalServerError("Failed to link Incident", err).From("[LinkIncidents]")
 			}
+			// The other incident's representation changed too, so its version
+			// must move for clients holding its ETag to notice.
+			err = imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
+				Event:  otherIncident.EventID,
+				Number: otherIncident.Number,
+			})
+			if err != nil {
+				return nil, nil, herr.InternalServerError("Failed to update linked Incident", err).From("[BumpIncidentVersion]")
+			}
 			_, errHTTP := addIncidentReportEntry(
 				ctx, imsDBQ, dbtx, otherIncident.EventID, otherIncident.Number,
 				newReportEntry{
@@ -790,6 +874,13 @@ func applyLinkedIncidentChanges(
 			)
 			if err != nil {
 				return nil, nil, herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
+			}
+			err = imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
+				Event:  otherIncident.EventID,
+				Number: otherIncident.Number,
+			})
+			if err != nil {
+				return nil, nil, herr.InternalServerError("Failed to update unlinked Incident", err).From("[BumpIncidentVersion]")
 			}
 			_, errHTTP := addIncidentReportEntry(
 				ctx, imsDBQ, dbtx, otherIncident.EventID, otherIncident.Number,
@@ -843,31 +934,36 @@ type EditIncident struct {
 }
 
 func (action EditIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := action.editIncident(req)
+	version, errHTTP := action.editIncident(req)
 	if errHTTP != nil {
 		errHTTP.From("[editIncident]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
-func (action EditIncident) editIncident(req *http.Request) *herr.HTTPError {
+func (action EditIncident) editIncident(req *http.Request) (int32, *herr.HTTPError) {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return errHTTP.From("[getEventPermissions]")
+		return 0, errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteIncidents == 0 {
-		return herr.Forbidden("The requestor does not have EventWriteIncidents permission for this Event", nil)
+		return 0, herr.Forbidden("The requestor does not have EventWriteIncidents permission for this Event", nil)
 	}
 	ctx := req.Context()
 
 	incidentNumber, err := conv.ParseInt32(req.PathValue("incidentNumber"))
 	if err != nil {
-		return herr.BadRequest("Invalid Incident Number", err).From("[ParseInt32]")
+		return 0, herr.BadRequest("Invalid Incident Number", err).From("[ParseInt32]")
+	}
+	ifMatch, errHTTP := parseIfMatch(req)
+	if errHTTP != nil {
+		return 0, errHTTP.From("[parseIfMatch]")
 	}
 	newIncident, errHTTP := readBodyAs[imsjson.Incident](req)
 	if errHTTP != nil {
-		return errHTTP.From("[readBodyAs]")
+		return 0, errHTTP.From("[readBodyAs]")
 	}
 	newIncident.Event = event.Name
 	newIncident.EventID = event.ID
@@ -875,10 +971,10 @@ func (action EditIncident) editIncident(req *http.Request) *herr.HTTPError {
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author)
+	version, errHTTP := updateIncident(ctx, action.imsDBQ, action.es, newIncident, author, ifMatch)
 	if errHTTP != nil {
-		return errHTTP.From("[updateIncident]")
+		return 0, errHTTP.From("[updateIncident]")
 	}
 
-	return nil
+	return version, nil
 }

--- a/api/integration/directory_test.go
+++ b/api/integration/directory_test.go
@@ -22,6 +22,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/burningmantech/ranger-ims-go/api"
@@ -43,6 +45,14 @@ const (
 	dirAdminPassword = "dir-admin-password"
 )
 
+// dirAdminOnce guards the DIRECTORY_PERSON admin bootstrap: the IMS DB (and
+// its DIRECTORY_* tables) is shared by every test in this package, and the
+// admin's handle is unique-constrained, so only the first caller may insert it.
+var (
+	dirAdminOnce sync.Once
+	dirAdminErr  error //nolint:errname // This isn't a sentinel error
+)
+
 // newIMSDirectoryServer starts a second IMS server, one that uses the
 // IMS-native directory (backed by the shared IMS DB container) rather than
 // the Clubhouse directory. It also bootstraps an admin user in the
@@ -54,16 +64,18 @@ func newIMSDirectoryServer(t *testing.T, ctx context.Context) *url.URL {
 	cfg.Directory.Directory = conf.DirectoryTypeIMS
 	cfg.Core.Admins = []string{dirAdminHandle}
 
-	hashed := argon2id.CreateHash(dirAdminPassword, argon2id.DevelopmentParams)
-	_, err := shared.imsDBQ.DirectoryCreatePerson(ctx, shared.imsDBQ,
-		imsdb.DirectoryCreatePersonParams{
-			Handle:   dirAdminHandle,
-			Email:    sql.NullString{String: dirAdminEmail, Valid: true},
-			Password: hashed,
-			Active:   true,
-			Onsite:   true,
-		})
-	require.NoError(t, err)
+	dirAdminOnce.Do(func() {
+		hashed := argon2id.CreateHash(dirAdminPassword, argon2id.DevelopmentParams)
+		_, dirAdminErr = shared.imsDBQ.DirectoryCreatePerson(ctx, shared.imsDBQ,
+			imsdb.DirectoryCreatePersonParams{
+				Handle:   dirAdminHandle,
+				Email:    sql.NullString{String: dirAdminEmail, Valid: true},
+				Password: hashed,
+				Active:   true,
+				Onsite:   true,
+			})
+	})
+	require.NoError(t, dirAdminErr)
 
 	userStore := directory.NewUserStore(
 		directory.NewIMSSource(shared.imsDBQ),
@@ -76,6 +88,39 @@ func newIMSDirectoryServer(t *testing.T, ctx context.Context) *url.URL {
 	serverURL, err := url.Parse(server.URL)
 	require.NoError(t, err)
 	return serverURL
+}
+
+// dirAdminJWT logs in as the bootstrapped IMS-native directory admin.
+func dirAdminJWT(t *testing.T, ctx context.Context, serverURL *url.URL) string {
+	t.Helper()
+	unauthed := ApiHelper{t: t, serverURL: serverURL, jwt: ""}
+	statusCode, _, jwt := unauthed.postAuth(ctx, api.PostAuthRequest{
+		Identification: dirAdminHandle,
+		Password:       dirAdminPassword,
+	})
+	require.Equal(t, http.StatusOK, statusCode)
+	return jwt
+}
+
+// The DIRECTORY_* tables are shared by all tests in this package, so lookups
+// must find rows by ID rather than assuming counts or indexes.
+
+func findDirectoryPerson(dir imsjson.Directory, id int64) *imsjson.DirectoryPerson {
+	for _, p := range dir.Persons {
+		if p.ID == id {
+			return &p
+		}
+	}
+	return nil
+}
+
+func findDirectoryGroup(groups []imsjson.DirectoryGroup, id int64) *imsjson.DirectoryGroup {
+	for _, g := range groups {
+		if g.ID == id {
+			return &g
+		}
+	}
+	return nil
 }
 
 func TestIMSNativeDirectory(t *testing.T) {
@@ -94,14 +139,22 @@ func TestIMSNativeDirectory(t *testing.T) {
 	apisAdmin := ApiHelper{t: t, serverURL: serverURL, jwt: adminJWT}
 
 	// The admin can read the directory, which contains the admin itself.
+	// (Other parallel tests may have added more persons to the shared
+	// DIRECTORY_* tables, so find the admin by handle.)
 	dir, resp := apisAdmin.getDirectory(ctx)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-	require.Len(t, dir.Persons, 1)
-	require.Equal(t, dirAdminHandle, *dir.Persons[0].Handle)
-	require.Equal(t, dirAdminEmail, *dir.Persons[0].Email)
-	require.True(t, *dir.Persons[0].Active)
-	require.True(t, *dir.Persons[0].Onsite)
+	var admin *imsjson.DirectoryPerson
+	for _, p := range dir.Persons {
+		if *p.Handle == dirAdminHandle {
+			admin = &p
+			break
+		}
+	}
+	require.NotNil(t, admin)
+	require.Equal(t, dirAdminEmail, *admin.Email)
+	require.True(t, *admin.Active)
+	require.True(t, *admin.Onsite)
 
 	// Create a team and a position.
 	teamID, resp := apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
@@ -161,12 +214,13 @@ func TestIMSNativeDirectory(t *testing.T) {
 	personnel, resp := apisFrodo.getPersonnel(ctx)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-	require.Len(t, personnel, 2)
-	handles := []string{personnel[0].Handle, personnel[1].Handle}
-	require.ElementsMatch(t, []string{dirAdminHandle, frodoHandle}, handles)
+	handles := make([]string, 0, len(personnel))
 	for _, p := range personnel {
+		handles = append(handles, p.Handle)
 		require.Equal(t, "active", p.Status)
 	}
+	require.Contains(t, handles, dirAdminHandle)
+	require.Contains(t, handles, frodoHandle)
 
 	// Team-based access rules work with IMS-native directory teams:
 	// grant write access on a new event to the Night Shift team, and
@@ -243,6 +297,453 @@ func TestDirectoryAPIDisabledOnClubhouseDeployments(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 }
 
+func TestDirectoryPersonValidation(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	serverURL := newIMSDirectoryServer(t, ctx)
+	apisAdmin := ApiHelper{t: t, serverURL: serverURL, jwt: dirAdminJWT(t, ctx, serverURL)}
+
+	// An unauthenticated request is rejected outright.
+	unauthed := ApiHelper{t: t, serverURL: serverURL, jwt: ""}
+	_, resp := unauthed.getDirectory(ctx)
+	require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A new person must have a handle.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Email: new("nohandle@example.com"),
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A handle must not be empty.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{Handle: new("")})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A handle must not be too long.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Handle: new(strings.Repeat("h", 129)),
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// An email must not be too long.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Handle: new("LongEmail-" + rand.NonCryptoText()),
+		Email:  new(strings.Repeat("e", 257)),
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Create a valid person to test uniqueness against.
+	handle := "Unique-" + rand.NonCryptoText()
+	email := handle + "@example.com"
+	personID, resp := apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Handle: &handle,
+		Email:  &email,
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, personID)
+
+	// Handles must be unique.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{Handle: &handle})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Emails must be unique.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Handle: new("OtherHandle-" + rand.NonCryptoText()),
+		Email:  &email,
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Updating a person that doesn't exist is a 404.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:     999999999,
+		Handle: new("Ghost"),
+	})
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Memberships must reference a team that exists.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:      *personID,
+		TeamIDs: &[]int64{999999999},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// ...and a position that exists.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:          *personID,
+		PositionIDs: &[]int64{999999999},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A non-numeric person ID in the path is a 400, for delete and
+	// for password-setting.
+	_, resp = apisAdmin.imsDelete(ctx, serverURL.JoinPath("/ims/api/directory/persons/pippin").String(), nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = apisAdmin.imsPost(ctx, imsjson.DirectoryPersonPassword{Password: "irrelevant"},
+		serverURL.JoinPath("/ims/api/directory/persons/pippin/password").String())
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Deleting a person that doesn't exist succeeds (the delete is idempotent).
+	resp = apisAdmin.deleteDirectoryPerson(ctx, 999999999)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestDirectoryPersonPartialUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	serverURL := newIMSDirectoryServer(t, ctx)
+	apisAdmin := ApiHelper{t: t, serverURL: serverURL, jwt: dirAdminJWT(t, ctx, serverURL)}
+
+	teamA, resp := apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		Title: new("TeamA-" + rand.NonCryptoText()),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	teamB, resp := apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		Title: new("TeamB-" + rand.NonCryptoText()),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	position, resp := apisAdmin.editDirectoryGroup(ctx, "positions", imsjson.DirectoryGroup{
+		Title: new("Position-" + rand.NonCryptoText()),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	handle := "Partial-" + rand.NonCryptoText()
+	email := handle + "@example.com"
+	personID, resp := apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Handle:      &handle,
+		Email:       &email,
+		Onsite:      new(true),
+		TeamIDs:     &[]int64{*teamA},
+		PositionIDs: &[]int64{*position},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, personID)
+
+	// The person comes back from the directory with all fields set,
+	// active by default.
+	dir, resp := apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	person := findDirectoryPerson(dir, *personID)
+	require.NotNil(t, person)
+	require.Equal(t, handle, *person.Handle)
+	require.Equal(t, email, *person.Email)
+	require.True(t, *person.Active)
+	require.True(t, *person.Onsite)
+	require.Equal(t, []int64{*teamA}, *person.TeamIDs)
+	require.Equal(t, []int64{*position}, *person.PositionIDs)
+
+	// Updating only "active" leaves every other field untouched,
+	// including memberships (nil membership lists mean "no change").
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:     *personID,
+		Active: new(false),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp = apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	person = findDirectoryPerson(dir, *personID)
+	require.NotNil(t, person)
+	require.Equal(t, handle, *person.Handle)
+	require.Equal(t, email, *person.Email)
+	require.False(t, *person.Active)
+	require.True(t, *person.Onsite)
+	require.Equal(t, []int64{*teamA}, *person.TeamIDs)
+	require.Equal(t, []int64{*position}, *person.PositionIDs)
+
+	// Handle and email can be changed, again without touching memberships.
+	handle2 := "Partial2-" + rand.NonCryptoText()
+	email2 := handle2 + "@example.com"
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:     *personID,
+		Handle: &handle2,
+		Email:  &email2,
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp = apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	person = findDirectoryPerson(dir, *personID)
+	require.NotNil(t, person)
+	require.Equal(t, handle2, *person.Handle)
+	require.Equal(t, email2, *person.Email)
+	require.Equal(t, []int64{*teamA}, *person.TeamIDs)
+
+	// A non-nil team list replaces the memberships wholesale.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:      *personID,
+		TeamIDs: &[]int64{*teamB},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp = apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	person = findDirectoryPerson(dir, *personID)
+	require.NotNil(t, person)
+	require.Equal(t, []int64{*teamB}, *person.TeamIDs)
+	require.Equal(t, []int64{*position}, *person.PositionIDs)
+
+	// Empty (but non-nil) lists clear the memberships.
+	_, resp = apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		ID:          *personID,
+		TeamIDs:     &[]int64{},
+		PositionIDs: &[]int64{},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp = apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	person = findDirectoryPerson(dir, *personID)
+	require.NotNil(t, person)
+	require.Empty(t, *person.TeamIDs)
+	require.Empty(t, *person.PositionIDs)
+}
+
+func TestDirectoryPersonPassword(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	serverURL := newIMSDirectoryServer(t, ctx)
+	apisAdmin := ApiHelper{t: t, serverURL: serverURL, jwt: dirAdminJWT(t, ctx, serverURL)}
+	unauthed := ApiHelper{t: t, serverURL: serverURL, jwt: ""}
+
+	handle := "PwPerson-" + rand.NonCryptoText()
+	personID, resp := apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{Handle: &handle})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, personID)
+
+	// A password must not be empty.
+	resp = apisAdmin.setDirectoryPersonPassword(ctx, *personID, "")
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A password must not be too long.
+	resp = apisAdmin.setDirectoryPersonPassword(ctx, *personID, strings.Repeat("p", 257))
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Setting a password for a nonexistent person is a 404.
+	resp = apisAdmin.setDirectoryPersonPassword(ctx, 999999999, "a fine password")
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Set a first password and log in with it.
+	password1 := "pw1-" + rand.NonCryptoText()
+	resp = apisAdmin.setDirectoryPersonPassword(ctx, *personID, password1)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	statusCode, _, _ := unauthed.postAuth(ctx, api.PostAuthRequest{
+		Identification: handle,
+		Password:       password1,
+	})
+	require.Equal(t, http.StatusOK, statusCode)
+
+	// Change the password: the old one stops working and the new one works.
+	password2 := "pw2-" + rand.NonCryptoText()
+	resp = apisAdmin.setDirectoryPersonPassword(ctx, *personID, password2)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	statusCode, _, _ = unauthed.postAuth(ctx, api.PostAuthRequest{
+		Identification: handle,
+		Password:       password1,
+	})
+	require.Equal(t, http.StatusUnauthorized, statusCode)
+	statusCode, _, _ = unauthed.postAuth(ctx, api.PostAuthRequest{
+		Identification: handle,
+		Password:       password2,
+	})
+	require.Equal(t, http.StatusOK, statusCode)
+}
+
+func TestDirectoryGroupValidationAndUpdate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	serverURL := newIMSDirectoryServer(t, ctx)
+	apisAdmin := ApiHelper{t: t, serverURL: serverURL, jwt: dirAdminJWT(t, ctx, serverURL)}
+
+	// A new team must have a title.
+	_, resp := apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A title must not be empty.
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{Title: new("")})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A title must not be too long.
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		Title: new(strings.Repeat("t", 129)),
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Team titles must be unique.
+	teamTitle := "Team-" + rand.NonCryptoText()
+	teamID, resp := apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{Title: &teamTitle})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, teamID)
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{Title: &teamTitle})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Updating a nonexistent team or position is a 404.
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		ID:    999999999,
+		Title: new("Ghost Team"),
+	})
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "positions", imsjson.DirectoryGroup{
+		ID:    999999999,
+		Title: new("Ghost Position"),
+	})
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Updating only the title leaves "active" untouched...
+	teamTitle2 := "Team2-" + rand.NonCryptoText()
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		ID:    *teamID,
+		Title: &teamTitle2,
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp := apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	team := findDirectoryGroup(dir.Teams, *teamID)
+	require.NotNil(t, team)
+	require.Equal(t, teamTitle2, *team.Title)
+	require.True(t, *team.Active)
+
+	// ...and updating only "active" leaves the title untouched.
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		ID:     *teamID,
+		Active: new(false),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp = apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	team = findDirectoryGroup(dir.Teams, *teamID)
+	require.NotNil(t, team)
+	require.Equal(t, teamTitle2, *team.Title)
+	require.False(t, *team.Active)
+
+	// Positions update the same way.
+	positionTitle := "Position-" + rand.NonCryptoText()
+	positionID, resp := apisAdmin.editDirectoryGroup(ctx, "positions", imsjson.DirectoryGroup{Title: &positionTitle})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, positionID)
+	positionTitle2 := "Position2-" + rand.NonCryptoText()
+	_, resp = apisAdmin.editDirectoryGroup(ctx, "positions", imsjson.DirectoryGroup{
+		ID:    *positionID,
+		Title: &positionTitle2,
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	dir, resp = apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	position := findDirectoryGroup(dir.Positions, *positionID)
+	require.NotNil(t, position)
+	require.Equal(t, positionTitle2, *position.Title)
+	require.True(t, *position.Active)
+}
+
+func TestDirectoryGroupDelete(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	serverURL := newIMSDirectoryServer(t, ctx)
+	apisAdmin := ApiHelper{t: t, serverURL: serverURL, jwt: dirAdminJWT(t, ctx, serverURL)}
+
+	teamID, resp := apisAdmin.editDirectoryGroup(ctx, "teams", imsjson.DirectoryGroup{
+		Title: new("DoomedTeam-" + rand.NonCryptoText()),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, teamID)
+	positionID, resp := apisAdmin.editDirectoryGroup(ctx, "positions", imsjson.DirectoryGroup{
+		Title: new("DoomedPosition-" + rand.NonCryptoText()),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, positionID)
+
+	// A person belongs to the doomed team and position.
+	handle := "Member-" + rand.NonCryptoText()
+	personID, resp := apisAdmin.editDirectoryPerson(ctx, imsjson.DirectoryPerson{
+		Handle:      &handle,
+		TeamIDs:     &[]int64{*teamID},
+		PositionIDs: &[]int64{*positionID},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, personID)
+
+	// Delete the team and the position.
+	resp = apisAdmin.deleteDirectoryTeam(ctx, *teamID)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = apisAdmin.deleteDirectoryPosition(ctx, *positionID)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// They're gone from the directory, and the person's memberships in
+	// them were removed too.
+	dir, resp := apisAdmin.getDirectory(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Nil(t, findDirectoryGroup(dir.Teams, *teamID))
+	require.Nil(t, findDirectoryGroup(dir.Positions, *positionID))
+	person := findDirectoryPerson(dir, *personID)
+	require.NotNil(t, person)
+	require.Empty(t, *person.TeamIDs)
+	require.Empty(t, *person.PositionIDs)
+
+	// A non-numeric team or position ID in the path is a 400.
+	_, resp = apisAdmin.imsDelete(ctx, serverURL.JoinPath("/ims/api/directory/teams/legolas").String(), nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	_, resp = apisAdmin.imsDelete(ctx, serverURL.JoinPath("/ims/api/directory/positions/gimli").String(), nil)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Deleting a team or position that doesn't exist succeeds
+	// (the delete is idempotent).
+	resp = apisAdmin.deleteDirectoryTeam(ctx, 999999999)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = apisAdmin.deleteDirectoryPosition(ctx, 999999999)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
 func (a ApiHelper) getDirectory(ctx context.Context) (imsjson.Directory, *http.Response) {
 	a.t.Helper()
 	bod, resp := a.imsGet(ctx, a.serverURL.JoinPath("/ims/api/directory").String(), &imsjson.Directory{})
@@ -294,5 +795,17 @@ func (a ApiHelper) setDirectoryPersonPassword(ctx context.Context, personID int6
 func (a ApiHelper) deleteDirectoryPerson(ctx context.Context, personID int64) *http.Response {
 	a.t.Helper()
 	_, resp := a.imsDelete(ctx, a.serverURL.JoinPath("/ims/api/directory/persons/", conv.FormatInt(personID)).String(), nil)
+	return resp
+}
+
+func (a ApiHelper) deleteDirectoryTeam(ctx context.Context, teamID int64) *http.Response {
+	a.t.Helper()
+	_, resp := a.imsDelete(ctx, a.serverURL.JoinPath("/ims/api/directory/teams/", conv.FormatInt(teamID)).String(), nil)
+	return resp
+}
+
+func (a ApiHelper) deleteDirectoryPosition(ctx context.Context, positionID int64) *http.Response {
+	a.t.Helper()
+	_, resp := a.imsDelete(ctx, a.serverURL.JoinPath("/ims/api/directory/positions/", conv.FormatInt(positionID)).String(), nil)
 	return resp
 }

--- a/api/integration/etag_test.go
+++ b/api/integration/etag_test.go
@@ -1,0 +1,860 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package integration_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	"github.com/burningmantech/ranger-ims-go/api"
+	imsjson "github.com/burningmantech/ranger-ims-go/json"
+	"github.com/burningmantech/ranger-ims-go/lib/conv"
+	"github.com/burningmantech/ranger-ims-go/lib/rand"
+	"github.com/burningmantech/ranger-ims-go/store"
+	"github.com/burningmantech/ranger-ims-go/store/imsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newEventWithWriter makes a fresh event and gives Alice the Writer role on it.
+func newEventWithWriter(t *testing.T, apisAdmin ApiHelper) (eventName string) {
+	t.Helper()
+	ctx := t.Context()
+	eventName = rand.NonCryptoText()
+	_, resp := apisAdmin.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = apisAdmin.addWriter(ctx, eventName, userAliceHandle)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	return eventName
+}
+
+func TestIncidentETagLifecycle(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	// Creation goes through the guarded update path, so a new incident's
+	// version is 2 (insert at 1, then one bump), and the 201 carries its ETag.
+	resp := apis.newIncident(ctx, sampleIncident1(eventName))
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
+	numStr := resp.Header.Get("IMS-Incident-Number")
+	require.NoError(t, resp.Body.Close())
+	num := parseInt32Required(t, numStr)
+
+	// A single GET returns the same ETag, and the version in the body.
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
+	require.Equal(t, int32(2), retrieved.Version)
+
+	// An edit carrying the current ETag succeeds, and the 204 carries the new ETag.
+	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("an updated summary"),
+	}, `"2"`)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, `"3"`, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+
+	retrieved, resp = apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(3), retrieved.Version)
+	require.Equal(t, "an updated summary", *retrieved.Summary)
+}
+
+func TestIncidentEditWithStaleIfMatchIsRejected(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	// Two dispatchers read the incident at the same version...
+	_, resp := apis.getIncident(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag)
+
+	// ...the first one's edit lands...
+	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("the first edit wins"),
+	}, etag)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// ...and the second one's edit, still carrying the now-stale ETag, is
+	// rejected with a 412 problem response instead of clobbering the first.
+	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("the second edit must not clobber the first"),
+	}, etag)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "the first edit wins", *retrieved.Summary)
+}
+
+func TestIncidentEditWithoutIfMatchStillSucceeds(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	// A client that predates If-Match keeps working: the server does its own
+	// compare-and-swap internally instead of requiring the header.
+	resp := apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("edited without an If-Match header"),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NotEmpty(t, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "edited without an If-Match header", *retrieved.Summary)
+}
+
+func TestIncidentEditIfMatchOnMissingIncidentIs404(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	// A version check against a nonexistent incident is a 404, not a 412.
+	resp := apis.updateIncidentIfMatch(ctx, eventName, 12345, imsjson.Incident{
+		Event:   eventName,
+		Number:  12345,
+		Summary: new("does not exist"),
+	}, `"1"`)
+	require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestReportEntryAppendDoesNotBumpIncidentETag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	_, resp := apis.getIncident(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	etagBefore := resp.Header.Get("ETag")
+	require.NotEmpty(t, etagBefore)
+
+	// Appending a note can't lose data, so it must not move the version and
+	// thereby make other clients' edits spuriously conflict.
+	resp = apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:         eventName,
+		Number:        num,
+		ReportEntries: []imsjson.ReportEntry{{Text: "just a note", ID: -1}},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, etagBefore, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, etagBefore, resp.Header.Get("ETag"))
+	lastEntry := retrieved.ReportEntries[len(retrieved.ReportEntries)-1]
+	require.Equal(t, "just a note", lastEntry.Text)
+
+	// A field edit carrying the pre-note ETag still succeeds, because the note
+	// didn't change the version.
+	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("edited after the note"),
+	}, etagBefore)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestRangerAttachBumpsIncidentETag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	_, resp := apis.getIncident(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	etagBefore := resp.Header.Get("ETag")
+	require.NotEmpty(t, etagBefore)
+
+	// A roster change moves the incident's version, and the response carries
+	// the new ETag so the client can keep its cached value fresh.
+	resp = apis.attachRangerToIncident(ctx, eventName, num, "Some Dude")
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	etagAfterAttach := resp.Header.Get("ETag")
+	require.NotEmpty(t, etagAfterAttach)
+	require.NotEqual(t, etagBefore, etagAfterAttach)
+	require.NoError(t, resp.Body.Close())
+
+	// An edit still carrying the pre-attach ETag is rejected.
+	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("stale after roster change"),
+	}, etagBefore)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Detaching moves it again.
+	resp = apis.detachRangerFromIncident(ctx, eventName, num, "Some Dude")
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	etagAfterDetach := resp.Header.Get("ETag")
+	require.NotEmpty(t, etagAfterDetach)
+	require.NotEqual(t, etagAfterAttach, etagAfterDetach)
+	require.NoError(t, resp.Body.Close())
+}
+
+func TestFieldReportETagAndLinkBumpsBothVersions(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	// A field report is created directly, so it starts at version 1.
+	resp := apis.newFieldReport(ctx, imsjson.FieldReport{Event: eventName, Summary: new("an FR")})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Equal(t, `"1"`, resp.Header.Get("ETag"))
+	frNum := parseInt32Required(t, resp.Header.Get("IMS-Field-Report-Number"))
+	require.NoError(t, resp.Body.Close())
+
+	fr, resp := apis.getFieldReport(ctx, eventName, frNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, `"1"`, resp.Header.Get("ETag"))
+	require.Equal(t, int32(1), fr.Version)
+
+	// A stale If-Match on a field report edit is rejected.
+	resp = apis.updateFieldReportIfMatch(ctx, eventName, frNum, imsjson.FieldReport{
+		Event:   eventName,
+		Number:  frNum,
+		Summary: new("edited summary"),
+	}, `"1"`)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+	resp = apis.updateFieldReportIfMatch(ctx, eventName, frNum, imsjson.FieldReport{
+		Event:   eventName,
+		Number:  frNum,
+		Summary: new("stale edit"),
+	}, `"1"`)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Attaching the field report to an incident bumps both records' versions.
+	incidentNum := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+	incidentBefore, resp := apis.getIncident(ctx, eventName, incidentNum)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.attachFieldReportToIncident(ctx, eventName, frNum, incidentNum)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	frAfter, resp := apis.getFieldReport(ctx, eventName, frNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Greater(t, frAfter.Version, fr.Version)
+
+	incidentAfter, resp := apis.getIncident(ctx, eventName, incidentNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Greater(t, incidentAfter.Version, incidentBefore.Version)
+}
+
+func TestVisitETagAndReassignmentBumpsIncidents(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	resp := apisAdmin.addVisitWriter(ctx, eventName, userAliceHandle)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = apisAdmin.addWriter(ctx, eventName, userAdminHandle)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Creation goes through the guarded update path, so a new visit's version
+	// is 2, matching incidents.
+	resp = apis.newVisit(ctx, imsjson.Visit{
+		Event:              eventName,
+		GuestPreferredName: new("A. Guest"),
+	})
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
+	visitNum := parseInt32Required(t, resp.Header.Get("IMS-Visit-Number"))
+	require.NoError(t, resp.Body.Close())
+
+	// An edit with the current ETag succeeds; repeating it with the stale one fails.
+	resp = apis.updateVisitIfMatch(ctx, eventName, visitNum, imsjson.Visit{
+		Event:            eventName,
+		Number:           visitNum,
+		GuestDescription: new("wearing a big hat"),
+	}, `"2"`)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, `"3"`, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+	resp = apis.updateVisitIfMatch(ctx, eventName, visitNum, imsjson.Visit{
+		Event:            eventName,
+		Number:           visitNum,
+		GuestDescription: new("stale edit"),
+	}, `"2"`)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// Assigning the visit to an incident bumps the incident's version too.
+	// Incident operations use the admin here: granting Alice VisitWriter above
+	// replaced her person-expression access rules, including her Writer role.
+	incidentNum := apisAdmin.newIncidentSuccess(ctx, sampleIncident1(eventName))
+	incidentBefore, resp := apisAdmin.getIncident(ctx, eventName, incidentNum)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.updateVisit(ctx, eventName, visitNum, imsjson.Visit{
+		Event:    eventName,
+		Number:   visitNum,
+		Incident: &incidentNum,
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	incidentAfter, resp := apisAdmin.getIncident(ctx, eventName, incidentNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Greater(t, incidentAfter.Version, incidentBefore.Version)
+}
+
+// casInterceptor wraps the sqlc Querier so a test can act in the window
+// between an edit's read of the stored record and its version-guarded UPDATE —
+// the interleaving where a concurrent writer causes a CAS conflict. A nil hook
+// leaves the corresponding query untouched.
+type casInterceptor struct {
+	imsdb.Querier
+
+	beforeUpdateIncident    func(ctx context.Context, arg imsdb.UpdateIncidentParams)
+	beforeUpdateFieldReport func(ctx context.Context, arg imsdb.UpdateFieldReportParams)
+	beforeUpdateVisit       func(ctx context.Context, arg imsdb.UpdateVisitParams)
+}
+
+func (q casInterceptor) UpdateIncident(ctx context.Context, db imsdb.DBTX, arg imsdb.UpdateIncidentParams) (int64, error) {
+	if q.beforeUpdateIncident != nil {
+		q.beforeUpdateIncident(ctx, arg)
+	}
+	return q.Querier.UpdateIncident(ctx, db, arg)
+}
+
+func (q casInterceptor) UpdateFieldReport(ctx context.Context, db imsdb.DBTX, arg imsdb.UpdateFieldReportParams) (int64, error) {
+	if q.beforeUpdateFieldReport != nil {
+		q.beforeUpdateFieldReport(ctx, arg)
+	}
+	return q.Querier.UpdateFieldReport(ctx, db, arg)
+}
+
+func (q casInterceptor) UpdateVisit(ctx context.Context, db imsdb.DBTX, arg imsdb.UpdateVisitParams) (int64, error) {
+	if q.beforeUpdateVisit != nil {
+		q.beforeUpdateVisit(ctx, arg)
+	}
+	return q.Querier.UpdateVisit(ctx, db, arg)
+}
+
+// interceptedServer starts a second in-process IMS server on the shared
+// database, identical to the shared one except for the interceptor's hooks.
+func interceptedServer(t *testing.T, interceptor casInterceptor) *url.URL {
+	t.Helper()
+	interceptor.Querier = imsdb.New()
+	dbq := store.NewDBQ(shared.imsDBQ.DB, interceptor)
+	server := httptest.NewServer(
+		api.AddToMux(nil, shared.es, shared.cfg, dbq, shared.userStore, nil, shared.actionLogger),
+	)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	return serverURL
+}
+
+// The bump helpers below commit a version bump for the record being updated,
+// simulating another writer's edit landing first. They assert rather than
+// require, since they run on the server's request goroutine.
+
+func bumpIncidentVersion(ctx context.Context, t *testing.T, event, number int32) {
+	t.Helper()
+	err := shared.imsDBQ.BumpIncidentVersion(ctx, shared.imsDBQ, imsdb.BumpIncidentVersionParams{
+		Event:  event,
+		Number: number,
+	})
+	assert.NoError(t, err)
+}
+
+func bumpFieldReportVersion(ctx context.Context, t *testing.T, event, number int32) {
+	t.Helper()
+	// No production code path needs a bare field report bump, so there's no
+	// sqlc query for it; do the competing write directly.
+	_, err := shared.imsDBQ.ExecContext(ctx,
+		"update FIELD_REPORT set VERSION = VERSION + 1 where EVENT = ? and NUMBER = ?", event, number)
+	assert.NoError(t, err)
+}
+
+func bumpVisitVersion(ctx context.Context, t *testing.T, event, number int32) {
+	t.Helper()
+	err := shared.imsDBQ.BumpVisitVersion(ctx, shared.imsDBQ, imsdb.BumpVisitVersionParams{
+		Event:  event,
+		Number: number,
+	})
+	assert.NoError(t, err)
+}
+
+func TestIncidentEditRetriesPastConcurrentWrite(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	// Another writer's edit commits after this edit has read the incident, but
+	// before its guarded UPDATE runs, so the first attempt is a CAS conflict.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateIncident: func(ctx context.Context, arg imsdb.UpdateIncidentParams) {
+			if updateAttempts.Add(1) == 1 {
+				bumpIncidentVersion(ctx, t, arg.Event, arg.Number)
+			}
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	// Without an If-Match header, the server retries internally and the edit
+	// still lands, on the second attempt.
+	resp := hookedApis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("landed on the retry"),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	// Version 2 at creation, 3 after the competing write, 4 after this edit.
+	require.Equal(t, `"4"`, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(2), updateAttempts.Load())
+
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "landed on the retry", *retrieved.Summary)
+	require.Equal(t, int32(4), retrieved.Version)
+}
+
+func TestIncidentEditGivesUpAfterRepeatedConcurrentWrites(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	// A competing write lands inside the race window on every attempt.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateIncident: func(ctx context.Context, arg imsdb.UpdateIncidentParams) {
+			updateAttempts.Add(1)
+			bumpIncidentVersion(ctx, t, arg.Event, arg.Number)
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	resp := hookedApis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("this edit must not land"),
+	})
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+	// The server exhausts its CAS retry budget, then gives up.
+	require.Equal(t, int32(3), updateAttempts.Load())
+
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, *sampleIncident1(eventName).Summary, *retrieved.Summary)
+}
+
+func TestIncidentEditIfMatchLosingRaceIs412(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+
+	_, resp := apis.getIncident(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag)
+
+	// The If-Match precondition passes against the version this edit read, but
+	// a competing write commits before the guarded UPDATE runs.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateIncident: func(ctx context.Context, arg imsdb.UpdateIncidentParams) {
+			if updateAttempts.Add(1) == 1 {
+				bumpIncidentVersion(ctx, t, arg.Event, arg.Number)
+			}
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	// An edit carrying If-Match gets no retries: the conflict must be reported
+	// back as a 412 so the client can re-fetch and re-apply its change.
+	resp = hookedApis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("this edit must not land"),
+	}, etag)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(1), updateAttempts.Load())
+
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, *sampleIncident1(eventName).Summary, *retrieved.Summary)
+}
+
+func TestFieldReportEditRetriesPastConcurrentWrite(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apis.newFieldReportSuccess(ctx, imsjson.FieldReport{Event: eventName, Summary: new("original summary")})
+
+	// Another writer's edit commits after this edit has read the field report,
+	// but before its guarded UPDATE runs, so the first attempt is a CAS conflict.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateFieldReport: func(ctx context.Context, arg imsdb.UpdateFieldReportParams) {
+			if updateAttempts.Add(1) == 1 {
+				bumpFieldReportVersion(ctx, t, arg.Event, arg.Number)
+			}
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	// Without an If-Match header, the server retries internally and the edit
+	// still lands, on the second attempt.
+	resp := hookedApis.updateFieldReport(ctx, eventName, num, imsjson.FieldReport{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("landed on the retry"),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	// Version 1 at creation, 2 after the competing write, 3 after this edit.
+	require.Equal(t, `"3"`, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(2), updateAttempts.Load())
+
+	retrieved, resp := apis.getFieldReport(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "landed on the retry", *retrieved.Summary)
+	require.Equal(t, int32(3), retrieved.Version)
+}
+
+func TestFieldReportEditGivesUpAfterRepeatedConcurrentWrites(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apis.newFieldReportSuccess(ctx, imsjson.FieldReport{Event: eventName, Summary: new("original summary")})
+
+	// A competing write lands inside the race window on every attempt.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateFieldReport: func(ctx context.Context, arg imsdb.UpdateFieldReportParams) {
+			updateAttempts.Add(1)
+			bumpFieldReportVersion(ctx, t, arg.Event, arg.Number)
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	resp := hookedApis.updateFieldReport(ctx, eventName, num, imsjson.FieldReport{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("this edit must not land"),
+	})
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+	// The server exhausts its CAS retry budget, then gives up.
+	require.Equal(t, int32(3), updateAttempts.Load())
+
+	retrieved, resp := apis.getFieldReport(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "original summary", *retrieved.Summary)
+}
+
+func TestFieldReportEditIfMatchLosingRaceIs412(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apis.newFieldReportSuccess(ctx, imsjson.FieldReport{Event: eventName, Summary: new("original summary")})
+
+	_, resp := apis.getFieldReport(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag)
+
+	// The If-Match precondition passes against the version this edit read, but
+	// a competing write commits before the guarded UPDATE runs.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateFieldReport: func(ctx context.Context, arg imsdb.UpdateFieldReportParams) {
+			if updateAttempts.Add(1) == 1 {
+				bumpFieldReportVersion(ctx, t, arg.Event, arg.Number)
+			}
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	// An edit carrying If-Match gets no retries: the conflict must be reported
+	// back as a 412 so the client can re-fetch and re-apply its change.
+	resp = hookedApis.updateFieldReportIfMatch(ctx, eventName, num, imsjson.FieldReport{
+		Event:   eventName,
+		Number:  num,
+		Summary: new("this edit must not land"),
+	}, etag)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(1), updateAttempts.Load())
+
+	retrieved, resp := apis.getFieldReport(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "original summary", *retrieved.Summary)
+}
+
+// newEventWithVisitWriter makes a fresh event and gives Alice the VisitWriter
+// role on it. That role is granted instead of Writer, not in addition: setting
+// it replaces Alice's person-expression access rules for the event.
+func newEventWithVisitWriter(t *testing.T, apisAdmin ApiHelper) (eventName string) {
+	t.Helper()
+	ctx := t.Context()
+	eventName = rand.NonCryptoText()
+	_, resp := apisAdmin.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	resp = apisAdmin.addVisitWriter(ctx, eventName, userAliceHandle)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	return eventName
+}
+
+func TestVisitEditRetriesPastConcurrentWrite(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithVisitWriter(t, apisAdmin)
+	num := apis.newVisitSuccess(ctx, imsjson.Visit{
+		Event:            eventName,
+		GuestDescription: new("original description"),
+	})
+
+	// Another writer's edit commits after this edit has read the visit, but
+	// before its guarded UPDATE runs, so the first attempt is a CAS conflict.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateVisit: func(ctx context.Context, arg imsdb.UpdateVisitParams) {
+			if updateAttempts.Add(1) == 1 {
+				bumpVisitVersion(ctx, t, arg.Event, arg.Number)
+			}
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	// Without an If-Match header, the server retries internally and the edit
+	// still lands, on the second attempt.
+	resp := hookedApis.updateVisit(ctx, eventName, num, imsjson.Visit{
+		Event:            eventName,
+		Number:           num,
+		GuestDescription: new("landed on the retry"),
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	// Version 2 at creation, 3 after the competing write, 4 after this edit.
+	require.Equal(t, `"4"`, resp.Header.Get("ETag"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(2), updateAttempts.Load())
+
+	retrieved, resp := apis.getVisit(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "landed on the retry", *retrieved.GuestDescription)
+	require.Equal(t, int32(4), retrieved.Version)
+}
+
+func TestVisitEditGivesUpAfterRepeatedConcurrentWrites(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithVisitWriter(t, apisAdmin)
+	num := apis.newVisitSuccess(ctx, imsjson.Visit{
+		Event:            eventName,
+		GuestDescription: new("original description"),
+	})
+
+	// A competing write lands inside the race window on every attempt.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateVisit: func(ctx context.Context, arg imsdb.UpdateVisitParams) {
+			updateAttempts.Add(1)
+			bumpVisitVersion(ctx, t, arg.Event, arg.Number)
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	resp := hookedApis.updateVisit(ctx, eventName, num, imsjson.Visit{
+		Event:            eventName,
+		Number:           num,
+		GuestDescription: new("this edit must not land"),
+	})
+	require.Equal(t, http.StatusConflict, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+	// The server exhausts its CAS retry budget, then gives up.
+	require.Equal(t, int32(3), updateAttempts.Load())
+
+	retrieved, resp := apis.getVisit(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "original description", *retrieved.GuestDescription)
+}
+
+func TestVisitEditIfMatchLosingRaceIs412(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithVisitWriter(t, apisAdmin)
+	num := apis.newVisitSuccess(ctx, imsjson.Visit{
+		Event:            eventName,
+		GuestDescription: new("original description"),
+	})
+
+	_, resp := apis.getVisit(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	etag := resp.Header.Get("ETag")
+	require.NotEmpty(t, etag)
+
+	// The If-Match precondition passes against the version this edit read, but
+	// a competing write commits before the guarded UPDATE runs.
+	var updateAttempts atomic.Int32
+	hookedURL := interceptedServer(t, casInterceptor{
+		beforeUpdateVisit: func(ctx context.Context, arg imsdb.UpdateVisitParams) {
+			if updateAttempts.Add(1) == 1 {
+				bumpVisitVersion(ctx, t, arg.Event, arg.Number)
+			}
+		},
+	})
+	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
+
+	// An edit carrying If-Match gets no retries: the conflict must be reported
+	// back as a 412 so the client can re-fetch and re-apply its change.
+	resp = hookedApis.updateVisitIfMatch(ctx, eventName, num, imsjson.Visit{
+		Event:            eventName,
+		Number:           num,
+		GuestDescription: new("this edit must not land"),
+	}, etag)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(1), updateAttempts.Load())
+
+	retrieved, resp := apis.getVisit(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, "original description", *retrieved.GuestDescription)
+}
+
+func parseInt32Required(t *testing.T, s string) int32 {
+	t.Helper()
+	require.NotEmpty(t, s)
+	num, err := conv.ParseInt32(s)
+	require.NoError(t, err)
+	require.Positive(t, num)
+	return num
+}

--- a/api/integration/fieldreport_test.go
+++ b/api/integration/fieldreport_test.go
@@ -289,6 +289,7 @@ func requireEqualFieldReport(t *testing.T, before, after imsjson.FieldReport) {
 		require.WithinDuration(t, time.Now(), after.Created, 20*time.Minute)
 	}
 	before.Created, after.Created = time.Time{}, time.Time{}
+	before.Version, after.Version = 0, 0
 
 	require.Equal(t, before, after)
 }

--- a/api/integration/helpers_test.go
+++ b/api/integration/helpers_test.go
@@ -511,6 +511,11 @@ func (a ApiHelper) getFieldReportAttachment(ctx context.Context, eventName strin
 
 func (a ApiHelper) imsPost(ctx context.Context, body any, path string) *http.Response {
 	a.t.Helper()
+	return a.imsPostIfMatch(ctx, body, path, "")
+}
+
+func (a ApiHelper) imsPostIfMatch(ctx context.Context, body any, path, ifMatch string) *http.Response {
+	a.t.Helper()
 	postBody, err := json.Marshal(body)
 	require.NoError(a.t, err)
 	httpPost, err := http.NewRequestWithContext(ctx, http.MethodPost, path, bytes.NewReader(postBody))
@@ -521,6 +526,9 @@ func (a ApiHelper) imsPost(ctx context.Context, body any, path string) *http.Res
 	if a.referrer != "" {
 		httpPost.Header.Set("Referer", a.referrer)
 	}
+	if ifMatch != "" {
+		httpPost.Header.Set("If-Match", ifMatch)
+	}
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}
@@ -528,6 +536,21 @@ func (a ApiHelper) imsPost(ctx context.Context, body any, path string) *http.Res
 	resp, err := client.Do(httpPost)
 	require.NoError(a.t, err)
 	return resp
+}
+
+func (a ApiHelper) updateIncidentIfMatch(ctx context.Context, eventName string, incident int32, req imsjson.Incident, ifMatch string) *http.Response {
+	a.t.Helper()
+	return a.imsPostIfMatch(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/incidents/", strconv.Itoa(int(incident))).String(), ifMatch)
+}
+
+func (a ApiHelper) updateFieldReportIfMatch(ctx context.Context, eventName string, fieldReport int32, req imsjson.FieldReport, ifMatch string) *http.Response {
+	a.t.Helper()
+	return a.imsPostIfMatch(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/field_reports/", conv.FormatInt(fieldReport)).String(), ifMatch)
+}
+
+func (a ApiHelper) updateVisitIfMatch(ctx context.Context, eventName string, visit int32, req imsjson.Visit, ifMatch string) *http.Response {
+	a.t.Helper()
+	return a.imsPostIfMatch(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/visits/", strconv.Itoa(int(visit))).String(), ifMatch)
 }
 
 func (a ApiHelper) imsGetBodyBytes(ctx context.Context, path string) ([]byte, *http.Response) {

--- a/api/integration/incident_test.go
+++ b/api/integration/incident_test.go
@@ -451,6 +451,7 @@ func requireEqualIncident(t *testing.T, before, after imsjson.Incident) {
 	before.Started, after.Started = time.Time{}, time.Time{}
 	before.Closed, after.Closed = time.Time{}, time.Time{}
 	before.LastModified, after.LastModified = time.Time{}, time.Time{}
+	before.Version, after.Version = 0, 0
 	before.ReportEntries, after.ReportEntries = nil, nil
 
 	require.Equal(t, before, after)

--- a/api/integration/visit_test.go
+++ b/api/integration/visit_test.go
@@ -412,6 +412,7 @@ func requireEqualVisit(t *testing.T, before, after imsjson.Visit) {
 	before.EventID, after.EventID = 0, 0
 	before.Created, after.Created = time.Time{}, time.Time{}
 	before.LastModified, after.LastModified = time.Time{}, time.Time{}
+	before.Version, after.Version = 0, 0
 	before.ArrivalTime, after.ArrivalTime = &time.Time{}, &time.Time{}
 	before.DepartureTime, after.DepartureTime = &time.Time{}, &time.Time{}
 	before.ReportEntries, after.ReportEntries = nil, nil

--- a/api/ranger.go
+++ b/api/ranger.go
@@ -42,7 +42,12 @@ type rangerRoster struct {
 	detach         func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, rangerHandle string) error
 	attach         func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, rangerHandle string, role sql.NullString) error
 	addReportEntry func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, entry newReportEntry) (int32, *herr.HTTPError)
-	notifyUpdate   func(eventID, number int32)
+	// bumpVersion moves the parent record's optimistic-concurrency version, so
+	// that clients holding its ETag notice the roster change. getVersion reads
+	// the resulting version for the response's ETag header.
+	bumpVersion  func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) error
+	getVersion   func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) (int32, error)
+	notifyUpdate func(eventID, number int32)
 }
 
 func incidentRangerRoster(imsDBQ *store.DBQ, es *EventSourcerer) rangerRoster {
@@ -68,6 +73,18 @@ func incidentRangerRoster(imsDBQ *store.DBQ, es *EventSourcerer) rangerRoster {
 		},
 		addReportEntry: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, entry newReportEntry) (int32, *herr.HTTPError) {
 			return addIncidentReportEntry(ctx, imsDBQ, dbtx, eventID, number, entry)
+		},
+		bumpVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) error {
+			return imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
+				Event:  eventID,
+				Number: number,
+			})
+		},
+		getVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) (int32, error) {
+			return imsDBQ.IncidentVersion(ctx, dbtx, imsdb.IncidentVersionParams{
+				Event:  eventID,
+				Number: number,
+			})
 		},
 		notifyUpdate: es.notifyIncidentUpdate,
 	}
@@ -96,6 +113,18 @@ func visitRangerRoster(imsDBQ *store.DBQ, es *EventSourcerer) rangerRoster {
 		},
 		addReportEntry: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, entry newReportEntry) (int32, *herr.HTTPError) {
 			return addVisitReportEntry(ctx, imsDBQ, dbtx, eventID, number, entry)
+		},
+		bumpVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) error {
+			return imsDBQ.BumpVisitVersion(ctx, dbtx, imsdb.BumpVisitVersionParams{
+				Event:  eventID,
+				Number: number,
+			})
+		},
+		getVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) (int32, error) {
+			return imsDBQ.VisitVersion(ctx, dbtx, imsdb.VisitVersionParams{
+				Event:  eventID,
+				Number: number,
+			})
 		},
 		notifyUpdate: es.notifyVisitUpdate,
 	}
@@ -152,20 +181,20 @@ type rangerRosterBody struct {
 func attachRanger(
 	req *http.Request, roster rangerRoster,
 	imsDBQ *store.DBQ, userStore *directory.UserStore, imsAdmins []string,
-) *herr.HTTPError {
+) (int32, *herr.HTTPError) {
 	rosterReq, errHTTP := parseRangerRosterRequest(req, roster, imsDBQ, userStore, imsAdmins)
 	if errHTTP != nil {
-		return errHTTP.From("[parseRangerRosterRequest]")
+		return 0, errHTTP.From("[parseRangerRosterRequest]")
 	}
 	body, errHTTP := readBodyAs[rangerRosterBody](req)
 	if errHTTP != nil {
-		return errHTTP.From("[readBodyAs]")
+		return 0, errHTTP.From("[readBodyAs]")
 	}
 	ctx := req.Context()
 
 	txn, err := imsDBQ.Begin()
 	if err != nil {
-		return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		return 0, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
@@ -173,12 +202,17 @@ func attachRanger(
 	// updates their role rather than failing.
 	err = roster.detach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName)
 	if err != nil {
-		return herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
+		return 0, herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
 	}
 
 	err = roster.attach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName, conv.StringToSql(body.Role, 128))
 	if err != nil {
-		return herr.InternalServerError(fmt.Sprintf("Failed to attach Ranger to %v", roster.noun), err).From("[attach]")
+		return 0, herr.InternalServerError(fmt.Sprintf("Failed to attach Ranger to %v", roster.noun), err).From("[attach]")
+	}
+
+	version, errHTTP := bumpRosterVersion(ctx, txn, roster, rosterReq)
+	if errHTTP != nil {
+		return 0, errHTTP.From("[bumpRosterVersion]")
 	}
 
 	_, errHTTP = roster.addReportEntry(ctx, txn, rosterReq.event.ID, rosterReq.number, newReportEntry{
@@ -187,37 +221,58 @@ func attachRanger(
 		generated: true,
 	})
 	if errHTTP != nil {
-		return errHTTP.From("[addReportEntry]")
+		return 0, errHTTP.From("[addReportEntry]")
 	}
 	err = txn.Commit()
 	if err != nil {
-		return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return 0, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	roster.notifyUpdate(rosterReq.event.ID, rosterReq.number)
 
-	return nil
+	return version, nil
+}
+
+// bumpRosterVersion moves the parent record's version within the roster
+// transaction and returns the new version for the response's ETag.
+func bumpRosterVersion(
+	ctx context.Context, txn *sql.Tx, roster rangerRoster, rosterReq rangerRosterRequest,
+) (int32, *herr.HTTPError) {
+	err := roster.bumpVersion(ctx, txn, rosterReq.event.ID, rosterReq.number)
+	if err != nil {
+		return 0, herr.InternalServerError(fmt.Sprintf("Failed to update %v", roster.noun), err).From("[bumpVersion]")
+	}
+	version, err := roster.getVersion(ctx, txn, rosterReq.event.ID, rosterReq.number)
+	if err != nil {
+		return 0, herr.InternalServerError(fmt.Sprintf("Failed to fetch %v", roster.noun), err).From("[getVersion]")
+	}
+	return version, nil
 }
 
 func detachRanger(
 	req *http.Request, roster rangerRoster,
 	imsDBQ *store.DBQ, userStore *directory.UserStore, imsAdmins []string,
-) *herr.HTTPError {
+) (int32, *herr.HTTPError) {
 	rosterReq, errHTTP := parseRangerRosterRequest(req, roster, imsDBQ, userStore, imsAdmins)
 	if errHTTP != nil {
-		return errHTTP.From("[parseRangerRosterRequest]")
+		return 0, errHTTP.From("[parseRangerRosterRequest]")
 	}
 	ctx := req.Context()
 
 	txn, err := imsDBQ.Begin()
 	if err != nil {
-		return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		return 0, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
 	err = roster.detach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName)
 	if err != nil {
-		return herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
+		return 0, herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
+	}
+
+	version, errHTTP := bumpRosterVersion(ctx, txn, roster, rosterReq)
+	if errHTTP != nil {
+		return 0, errHTTP.From("[bumpRosterVersion]")
 	}
 
 	_, errHTTP = roster.addReportEntry(ctx, txn, rosterReq.event.ID, rosterReq.number, newReportEntry{
@@ -226,17 +281,17 @@ func detachRanger(
 		generated: true,
 	})
 	if errHTTP != nil {
-		return errHTTP.From("[addReportEntry]")
+		return 0, errHTTP.From("[addReportEntry]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return 0, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	roster.notifyUpdate(rosterReq.event.ID, rosterReq.number)
 
-	return nil
+	return version, nil
 }
 
 type AttachRangerToIncident struct {
@@ -247,11 +302,12 @@ type AttachRangerToIncident struct {
 }
 
 func (action AttachRangerToIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := attachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	version, errHTTP := attachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[attachRanger]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -263,11 +319,12 @@ type DetachRangerFromIncident struct {
 }
 
 func (action DetachRangerFromIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := detachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	version, errHTTP := detachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[detachRanger]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -279,11 +336,12 @@ type AttachRangerToVisit struct {
 }
 
 func (action AttachRangerToVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := attachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	version, errHTTP := attachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[attachRanger]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -295,10 +353,11 @@ type DetachRangerFromVisit struct {
 }
 
 func (action DetachRangerFromVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := detachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	version, errHTTP := detachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[detachRanger]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }

--- a/api/reportentry.go
+++ b/api/reportentry.go
@@ -160,6 +160,11 @@ func addChangeReportEntries(
 	return nil
 }
 
+// The strike/unstrike handlers below deliberately do not bump the parent
+// record's VERSION/ETag: like appends, strikes cannot silently lose data,
+// so they are exempt from optimistic concurrency (see the VERSION column
+// comment in store/schema/current.sql).
+
 type EditFieldReportReportEntry struct {
 	imsDBQ      *store.DBQ
 	userStore   *directory.UserStore

--- a/api/visit.go
+++ b/api/visit.go
@@ -148,6 +148,7 @@ func (action GetVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		errHTTP.From("[getVisit]").WriteResponse(w)
 		return
 	}
+	setETag(w, resp.Version)
 	mustWriteJSON(w, req, resp)
 }
 
@@ -253,6 +254,7 @@ func visitToJSON(storedRow imsdb.VisitRow, visitRangers []imsdb.VisitRanger,
 		Number:       storedRow.Visit.Number,
 		Created:      conv.FloatToTime(storedRow.Visit.Created),
 		LastModified: lastModified,
+		Version:      storedRow.Visit.Version,
 		Incident:     conv.SqlToInt32(storedRow.Visit.IncidentNumber),
 
 		GuestPreferredName:   conv.SqlToString(storedRow.Visit.GuestPreferredName),
@@ -296,7 +298,7 @@ type NewVisit struct {
 }
 
 func (action NewVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	number, location, errHTTP := action.newVisit(req)
+	number, version, location, errHTTP := action.newVisit(req)
 	if errHTTP != nil {
 		errHTTP.From("[newVisit]").WriteResponse(w)
 		return
@@ -304,20 +306,21 @@ func (action NewVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("IMS-Visit-Number", strconv.Itoa(int(number)))
 	w.Header().Set("Location", location)
+	setETag(w, version)
 	herr.WriteCreatedResponse(w, http.StatusText(http.StatusCreated))
 }
-func (action NewVisit) newVisit(req *http.Request) (visitNumber int32, location string, errHTTP *herr.HTTPError) {
+func (action NewVisit) newVisit(req *http.Request) (visitNumber, version int32, location string, errHTTP *herr.HTTPError) {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[getEventPermissions]")
+		return 0, 0, "", errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteVisits == 0 {
-		return 0, "", herr.Forbidden("The requestor does not have EventWriteVisits permission on this Event", nil)
+		return 0, 0, "", herr.Forbidden("The requestor does not have EventWriteVisits permission on this Event", nil)
 	}
 	ctx := req.Context()
 	newVisit, errHTTP := readBodyAs[imsjson.Visit](req)
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[readBodyAs]")
+		return 0, 0, "", errHTTP.From("[readBodyAs]")
 	}
 
 	author := jwtCtx.Claims.RangerHandle()
@@ -325,7 +328,7 @@ func (action NewVisit) newVisit(req *http.Request) (visitNumber int32, location 
 	// First create the visit, to lock in the visit number reservation
 	newVisitNumber, err := action.imsDBQ.NextVisitNumber(ctx, action.imsDBQ, event.ID)
 	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to find next Visit number", err).From("[NextVisitNumber]")
+		return 0, 0, "", herr.InternalServerError("Failed to find next Visit number", err).From("[NextVisitNumber]")
 	}
 	newVisit.EventID = event.ID
 	newVisit.Event = event.Name
@@ -338,19 +341,44 @@ func (action NewVisit) newVisit(req *http.Request) (visitNumber int32, location 
 	}
 	_, err = action.imsDBQ.CreateVisit(ctx, action.imsDBQ, createTheVisit)
 	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to create visit", err).From("[CreateVisit]")
+		return 0, 0, "", herr.InternalServerError("Failed to create visit", err).From("[CreateVisit]")
 	}
 
-	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author)
+	version, errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author, nil)
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[updateVisit]")
+		return 0, 0, "", errHTTP.From("[updateVisit]")
 	}
 
-	return newVisit.Number, fmt.Sprintf("/ims/api/events/%v/visits/%d", event.Name, newVisit.Number), nil
+	return newVisit.Number, version, fmt.Sprintf("/ims/api/events/%v/visits/%d", event.Name, newVisit.Number), nil
 }
 
 func updateVisit(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newVisit imsjson.Visit, author string,
-) *herr.HTTPError {
+	ifMatch *int32,
+) (newVersion int32, errHTTP *herr.HTTPError) {
+	attempts := maxCASAttempts
+	if ifMatch != nil {
+		attempts = 1
+	}
+	for range attempts {
+		version, conflict, errHTTP := updateVisitAttempt(ctx, imsDBQ, es, newVisit, author, ifMatch)
+		if errHTTP != nil {
+			return 0, errHTTP.From("[updateVisitAttempt]")
+		}
+		if !conflict {
+			return version, nil
+		}
+		if ifMatch != nil {
+			return 0, herr.PreconditionFailed(
+				"This visit was changed by someone else while you were editing it", nil,
+			).SetExpectedError()
+		}
+	}
+	return 0, herr.Conflict("The visit is being modified concurrently. Please try again.", nil)
+}
+
+func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newVisit imsjson.Visit, author string,
+	ifMatch *int32,
+) (newVersion int32, conflict bool, errHTTP *herr.HTTPError) {
 	storedVisitRow, err := imsDBQ.Visit(ctx, imsDBQ,
 		imsdb.VisitParams{
 			Event:  newVisit.EventID,
@@ -358,48 +386,94 @@ func updateVisit(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, new
 		},
 	)
 	if err != nil {
-		return herr.InternalServerError("Failed to fetch visit", err).From("[Visit]")
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, false, herr.NotFound("Visit not found", err).From("[Visit]")
+		}
+		return 0, false, herr.InternalServerError("Failed to fetch visit", err).From("[Visit]")
 	}
 	storedVisit := storedVisitRow.Visit
+	expectedVersion := storedVisit.Version
+	if ifMatch != nil && *ifMatch != expectedVersion {
+		return 0, true, nil
+	}
 
 	txn, err := imsDBQ.Begin()
 	if err != nil {
-		return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		return 0, false, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
 	update, logs, errHTTP := buildVisitUpdate(storedVisit, newVisit)
 	if errHTTP != nil {
-		return errHTTP.From("[buildVisitUpdate]")
+		return 0, false, errHTTP.From("[buildVisitUpdate]")
 	}
 
-	err = imsDBQ.UpdateVisit(ctx, txn, update)
-	if err != nil {
-		const mySQLErNoReferencedRow2 = 1452
-		mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
-		if ok && mysqlErr.Number == mySQLErNoReferencedRow2 {
-			// This is probably the source of the error, because there are no other foreign
-			// keys updates within this function.
-			return herr.NotFound("No such Incident", err).From("[UpdateVisit]")
+	// A request that only appends report entries is applied without the
+	// guarded update below; see updateIncidentAttempt.
+	changesVisit := len(logs) > 0
+	newVersion = expectedVersion
+	if changesVisit {
+		// The version-guarded update is the concurrency gate; see updateIncidentAttempt.
+		rows, err := imsDBQ.UpdateVisit(ctx, txn, update)
+		if err != nil {
+			const mySQLErNoReferencedRow2 = 1452
+			mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
+			if ok && mysqlErr.Number == mySQLErNoReferencedRow2 {
+				// This is probably the source of the error, because there are no other foreign
+				// keys updates within this function.
+				return 0, false, herr.NotFound("No such Incident", err).From("[UpdateVisit]")
+			}
+			return 0, false, herr.InternalServerError("Failed to update visit", err).From("[UpdateVisit]")
 		}
-		return herr.InternalServerError("Failed to update visit", err).From("[UpdateVisit]")
+		if rows == 0 {
+			// Stale version or vanished row; re-read to tell which.
+			_, err = imsDBQ.VisitVersion(ctx, imsDBQ, imsdb.VisitVersionParams{
+				Event:  newVisit.EventID,
+				Number: newVisit.Number,
+			})
+			if err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return 0, false, herr.NotFound("Visit not found", err).From("[VisitVersion]")
+				}
+				return 0, false, herr.InternalServerError("Failed to fetch visit", err).From("[VisitVersion]")
+			}
+			return 0, true, nil
+		}
+		newVersion = expectedVersion + 1
+
+		// If the visit was reassigned, the affected incidents' visit lists
+		// changed, so their versions must move too.
+		if storedVisit.IncidentNumber != update.IncidentNumber {
+			for _, incidentNumber := range []sql.NullInt32{storedVisit.IncidentNumber, update.IncidentNumber} {
+				if !incidentNumber.Valid {
+					continue
+				}
+				err = imsDBQ.BumpIncidentVersion(ctx, txn, imsdb.BumpIncidentVersionParams{
+					Event:  newVisit.EventID,
+					Number: incidentNumber.Int32,
+				})
+				if err != nil {
+					return 0, false, herr.InternalServerError("Failed to update incident", err).From("[BumpIncidentVersion]")
+				}
+			}
+		}
 	}
 
 	errHTTP = addChangeReportEntries(ctx, imsDBQ, txn, newVisit.EventID, newVisit.Number, author,
 		logs, newVisit.ReportEntries, addVisitReportEntry)
 	if errHTTP != nil {
-		return errHTTP.From("[addChangeReportEntries]")
+		return 0, false, errHTTP.From("[addChangeReportEntries]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return 0, false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	es.notifyVisitUpdate(storedVisit.Event, storedVisit.Number)
 	es.notifyIncidentUpdates(storedVisit.Event, storedVisit.IncidentNumber.Int32, update.IncidentNumber.Int32)
 
-	return nil
+	return newVersion, false, nil
 }
 
 // buildVisitUpdate merges the client-provided fields of newVisit over the
@@ -410,6 +484,7 @@ func buildVisitUpdate(stored imsdb.Visit, newVisit imsjson.Visit) (imsdb.UpdateV
 	update := imsdb.UpdateVisitParams{
 		Event:                stored.Event,
 		Number:               stored.Number,
+		Version:              stored.Version,
 		IncidentNumber:       stored.IncidentNumber,
 		GuestPreferredName:   stored.GuestPreferredName,
 		GuestLegalName:       stored.GuestLegalName,
@@ -502,31 +577,36 @@ type EditVisit struct {
 }
 
 func (action EditVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	errHTTP := action.editVisit(req)
+	version, errHTTP := action.editVisit(req)
 	if errHTTP != nil {
 		errHTTP.From("[editVisit]").WriteResponse(w)
 		return
 	}
+	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
-func (action EditVisit) editVisit(req *http.Request) *herr.HTTPError {
+func (action EditVisit) editVisit(req *http.Request) (int32, *herr.HTTPError) {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return errHTTP.From("[getEventPermissions]")
+		return 0, errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteVisits == 0 {
-		return herr.Forbidden("The requestor does not have EventWriteVisits permission for this Event", nil)
+		return 0, herr.Forbidden("The requestor does not have EventWriteVisits permission for this Event", nil)
 	}
 	ctx := req.Context()
 
 	visitNumber, err := conv.ParseInt32(req.PathValue("visitNumber"))
 	if err != nil {
-		return herr.BadRequest("Invalid Visit Number", err).From("[ParseInt32]")
+		return 0, herr.BadRequest("Invalid Visit Number", err).From("[ParseInt32]")
+	}
+	ifMatch, errHTTP := parseIfMatch(req)
+	if errHTTP != nil {
+		return 0, errHTTP.From("[parseIfMatch]")
 	}
 	newVisit, errHTTP := readBodyAs[imsjson.Visit](req)
 	if errHTTP != nil {
-		return errHTTP.From("[readBodyAs]")
+		return 0, errHTTP.From("[readBodyAs]")
 	}
 	newVisit.Event = event.Name
 	newVisit.EventID = event.ID
@@ -534,10 +614,10 @@ func (action EditVisit) editVisit(req *http.Request) *herr.HTTPError {
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author)
+	version, errHTTP := updateVisit(ctx, action.imsDBQ, action.es, newVisit, author, ifMatch)
 	if errHTTP != nil {
-		return errHTTP.From("[updateVisit]")
+		return 0, errHTTP.From("[updateVisit]")
 	}
 
-	return nil
+	return version, nil
 }

--- a/json/fieldreport.go
+++ b/json/fieldreport.go
@@ -20,9 +20,11 @@ import "time"
 
 type FieldReports []FieldReport
 type FieldReport struct {
-	Event         string        `json:"event"`
-	Number        int32         `json:"number"`
-	Created       time.Time     `json:"created,omitzero"`
+	Event   string    `json:"event"`
+	Number  int32     `json:"number"`
+	Created time.Time `json:"created,omitzero"`
+	// Version is the optimistic-concurrency counter; see Incident.Version.
+	Version       int32         `json:"version,omitzero"`
 	Summary       *string       `json:"summary"`
 	Incident      *int32        `json:"incident,omitzero"`
 	ReportEntries []ReportEntry `json:"report_entries"`

--- a/json/incident.go
+++ b/json/incident.go
@@ -38,11 +38,15 @@ const (
 )
 
 type Incident struct {
-	Event           string            `json:"event"`
-	EventID         int32             `json:"event_id"`
-	Number          int32             `json:"number"`
-	Created         time.Time         `json:"created,omitzero"`
-	LastModified    time.Time         `json:"last_modified,omitzero"`
+	Event        string    `json:"event"`
+	EventID      int32     `json:"event_id"`
+	Number       int32     `json:"number"`
+	Created      time.Time `json:"created,omitzero"`
+	LastModified time.Time `json:"last_modified,omitzero"`
+	// Version is the optimistic-concurrency counter, surfaced as an ETag on
+	// single-Incident endpoints. Stored versions start at 1, so omitzero only
+	// elides it from client-sent edit bodies, never from server responses.
+	Version         int32             `json:"version,omitzero"`
 	State           string            `json:"state"`
 	Started         time.Time         `json:"started,omitzero"`
 	Closed          time.Time         `json:"closed,omitzero"`

--- a/json/visit.go
+++ b/json/visit.go
@@ -26,7 +26,9 @@ type Visit struct {
 	Number       int32     `json:"number"`
 	Created      time.Time `json:"created,omitzero"`
 	LastModified time.Time `json:"last_modified,omitzero"`
-	Incident     *int32    `json:"incident,omitzero"`
+	// Version is the optimistic-concurrency counter; see Incident.Version.
+	Version  int32  `json:"version,omitzero"`
+	Incident *int32 `json:"incident,omitzero"`
 
 	GuestPreferredName   *string `json:"guest_preferred_name,omitzero"`
 	GuestLegalName       *string `json:"guest_legal_name,omitzero"`

--- a/lib/herr/httperror.go
+++ b/lib/herr/httperror.go
@@ -85,6 +85,16 @@ func NotFound(userMessage string, err error) *HTTPError {
 	return New(http.StatusNotFound, userMessage, err)
 }
 
+// Conflict returns an http.StatusConflict HTTPError.
+func Conflict(userMessage string, err error) *HTTPError {
+	return New(http.StatusConflict, userMessage, err)
+}
+
+// PreconditionFailed returns an http.StatusPreconditionFailed HTTPError.
+func PreconditionFailed(userMessage string, err error) *HTTPError {
+	return New(http.StatusPreconditionFailed, userMessage, err)
+}
+
 // From wraps the InternalErr using fmt.Sprintf. This should be used to specify
 // the name of a function that returned an error. See httperror_test.go for
 // examples of wrapping.

--- a/lib/herr/httperror_test.go
+++ b/lib/herr/httperror_test.go
@@ -65,6 +65,27 @@ func TestSrcWrap(t *testing.T) {
 	assert.ErrorIs(t, err, errInternal)
 }
 
+func TestConflict(t *testing.T) {
+	t.Parallel()
+	err := Conflict("try again", errors.New("contention"))
+	assert.Equal(t, http.StatusConflict, err.Code)
+	assert.Equal(t, "try again", err.ResponseMessage)
+	assert.Equal(t, "contention", err.InternalErr.Error())
+	assert.False(t, err.ExpectedError)
+}
+
+func TestPreconditionFailed(t *testing.T) {
+	t.Parallel()
+	err := PreconditionFailed("someone else edited this", nil)
+	assert.Equal(t, http.StatusPreconditionFailed, err.Code)
+	assert.Equal(t, "someone else edited this", err.ResponseMessage)
+	assert.False(t, err.ExpectedError)
+
+	// A 412 is normal operation, so callers mark it expected to skip logging.
+	err = err.SetExpectedError()
+	assert.True(t, err.ExpectedError)
+}
+
 func TestAsHTTPError(t *testing.T) {
 	t.Parallel()
 	// take an HTTPError, convert it to error, then use AsHTTPError to recover it

--- a/store/imsdb/models.go
+++ b/store/imsdb/models.go
@@ -335,6 +335,7 @@ type FieldReport struct {
 	Created        float64
 	Summary        sql.NullString
 	IncidentNumber sql.NullInt32
+	Version        int32
 }
 
 type FieldReportReportEntry struct {
@@ -355,6 +356,7 @@ type Incident struct {
 	LocationName        sql.NullString
 	LocationAddress     sql.NullString
 	LocationDescription sql.NullString
+	Version             int32
 }
 
 type IncidentIncidentType struct {
@@ -444,6 +446,7 @@ type Visit struct {
 	ResourcePogs         sql.NullString
 	ResourceFoodBev      sql.NullString
 	ResourceOther        sql.NullString
+	Version              int32
 }
 
 type VisitRanger struct {

--- a/store/imsdb/querier.go
+++ b/store/imsdb/querier.go
@@ -21,6 +21,14 @@ type Querier interface {
 	AttachReportEntryToIncident(ctx context.Context, db DBTX, arg AttachReportEntryToIncidentParams) error
 	AttachReportEntryToVisit(ctx context.Context, db DBTX, arg AttachReportEntryToVisitParams) error
 	AttachVisitToIncident(ctx context.Context, db DBTX, arg AttachVisitToIncidentParams) error
+	// BumpIncidentVersion is for mutations that change an incident's representation
+	// without going through the version-guarded UpdateIncident query (Ranger
+	// assignments, the peer of a link/unlink, field-report/visit reassignment).
+	BumpIncidentVersion(ctx context.Context, db DBTX, arg BumpIncidentVersionParams) error
+	// BumpVisitVersion is for mutations that change a visit's representation
+	// without going through the version-guarded UpdateVisit query (Ranger
+	// assignments).
+	BumpVisitVersion(ctx context.Context, db DBTX, arg BumpVisitVersionParams) error
 	ClearEventAccessForExpression(ctx context.Context, db DBTX, arg ClearEventAccessForExpressionParams) error
 	ClearEventAccessForMode(ctx context.Context, db DBTX, arg ClearEventAccessForModeParams) error
 	CreateEvent(ctx context.Context, db DBTX, arg CreateEventParams) (int64, error)
@@ -85,12 +93,14 @@ type Querier interface {
 	EventReportEntryIDs(ctx context.Context, db DBTX, arg EventReportEntryIDsParams) ([]int32, error)
 	Events(ctx context.Context, db DBTX) ([]EventsRow, error)
 	FieldReport(ctx context.Context, db DBTX, arg FieldReportParams) (FieldReportRow, error)
+	FieldReportVersion(ctx context.Context, db DBTX, arg FieldReportVersionParams) (int32, error)
 	FieldReport_ReportEntries(ctx context.Context, db DBTX, arg FieldReport_ReportEntriesParams) ([]FieldReport_ReportEntriesRow, error)
 	FieldReports(ctx context.Context, db DBTX, event int32) ([]FieldReportsRow, error)
 	FieldReports_ReportEntries(ctx context.Context, db DBTX, arg FieldReports_ReportEntriesParams) ([]FieldReports_ReportEntriesRow, error)
 	Incident(ctx context.Context, db DBTX, arg IncidentParams) (IncidentRow, error)
 	IncidentType(ctx context.Context, db DBTX, id int32) (IncidentTypeRow, error)
 	IncidentTypes(ctx context.Context, db DBTX) ([]IncidentTypesRow, error)
+	IncidentVersion(ctx context.Context, db DBTX, arg IncidentVersionParams) (int32, error)
 	Incident_LinkedIncidents(ctx context.Context, db DBTX, arg Incident_LinkedIncidentsParams) ([]Incident_LinkedIncidentsRow, error)
 	Incident_Rangers(ctx context.Context, db DBTX, arg Incident_RangersParams) ([]Incident_RangersRow, error)
 	Incident_ReportEntries(ctx context.Context, db DBTX, arg Incident_ReportEntriesParams) ([]Incident_ReportEntriesRow, error)
@@ -127,11 +137,18 @@ type Querier interface {
 	SetVisitReportEntryStricken(ctx context.Context, db DBTX, arg SetVisitReportEntryStrickenParams) error
 	UnlinkIncidents(ctx context.Context, db DBTX, arg UnlinkIncidentsParams) error
 	UpdateEvent(ctx context.Context, db DBTX, arg UpdateEventParams) error
-	UpdateFieldReport(ctx context.Context, db DBTX, arg UpdateFieldReportParams) error
-	UpdateIncident(ctx context.Context, db DBTX, arg UpdateIncidentParams) error
+	// The VERSION bump must stay in the SET clause; see UpdateIncident.
+	UpdateFieldReport(ctx context.Context, db DBTX, arg UpdateFieldReportParams) (int64, error)
+	// The VERSION bump must stay in the SET clause: the MySQL driver reports rows
+	// *changed* (not matched), so the bump guarantees that zero rows affected means
+	// the WHERE clause didn't match (stale version or missing row), never that the
+	// row matched but was already identical.
+	UpdateIncident(ctx context.Context, db DBTX, arg UpdateIncidentParams) (int64, error)
 	UpdateIncidentType(ctx context.Context, db DBTX, arg UpdateIncidentTypeParams) error
-	UpdateVisit(ctx context.Context, db DBTX, arg UpdateVisitParams) error
+	// The VERSION bump must stay in the SET clause; see UpdateIncident.
+	UpdateVisit(ctx context.Context, db DBTX, arg UpdateVisitParams) (int64, error)
 	Visit(ctx context.Context, db DBTX, arg VisitParams) (VisitRow, error)
+	VisitVersion(ctx context.Context, db DBTX, arg VisitVersionParams) (int32, error)
 	Visit_Rangers(ctx context.Context, db DBTX, arg Visit_RangersParams) ([]Visit_RangersRow, error)
 	Visit_ReportEntries(ctx context.Context, db DBTX, arg Visit_ReportEntriesParams) ([]Visit_ReportEntriesRow, error)
 	Visits(ctx context.Context, db DBTX, event int32) ([]VisitsRow, error)

--- a/store/imsdb/queries.sql.go
+++ b/store/imsdb/queries.sql.go
@@ -142,7 +142,7 @@ func (q *Queries) AddEventAccess(ctx context.Context, db DBTX, arg AddEventAcces
 
 const attachFieldReportToIncident = `-- name: AttachFieldReportToIncident :exec
 update FIELD_REPORT
-set INCIDENT_NUMBER = ?
+set INCIDENT_NUMBER = ?, VERSION = VERSION + 1
 where EVENT = ? and NUMBER = ?
 `
 
@@ -279,7 +279,7 @@ func (q *Queries) AttachReportEntryToVisit(ctx context.Context, db DBTX, arg Att
 
 const attachVisitToIncident = `-- name: AttachVisitToIncident :exec
 update VISIT
-set INCIDENT_NUMBER = ?
+set INCIDENT_NUMBER = ?, VERSION = VERSION + 1
 where EVENT = ? and NUMBER = ?
 `
 
@@ -291,6 +291,44 @@ type AttachVisitToIncidentParams struct {
 
 func (q *Queries) AttachVisitToIncident(ctx context.Context, db DBTX, arg AttachVisitToIncidentParams) error {
 	_, err := db.ExecContext(ctx, attachVisitToIncident, arg.IncidentNumber, arg.Event, arg.Number)
+	return err
+}
+
+const bumpIncidentVersion = `-- name: BumpIncidentVersion :exec
+update INCIDENT
+set VERSION = VERSION + 1
+where EVENT = ? and NUMBER = ?
+`
+
+type BumpIncidentVersionParams struct {
+	Event  int32
+	Number int32
+}
+
+// BumpIncidentVersion is for mutations that change an incident's representation
+// without going through the version-guarded UpdateIncident query (Ranger
+// assignments, the peer of a link/unlink, field-report/visit reassignment).
+func (q *Queries) BumpIncidentVersion(ctx context.Context, db DBTX, arg BumpIncidentVersionParams) error {
+	_, err := db.ExecContext(ctx, bumpIncidentVersion, arg.Event, arg.Number)
+	return err
+}
+
+const bumpVisitVersion = `-- name: BumpVisitVersion :exec
+update VISIT
+set VERSION = VERSION + 1
+where EVENT = ? and NUMBER = ?
+`
+
+type BumpVisitVersionParams struct {
+	Event  int32
+	Number int32
+}
+
+// BumpVisitVersion is for mutations that change a visit's representation
+// without going through the version-guarded UpdateVisit query (Ranger
+// assignments).
+func (q *Queries) BumpVisitVersion(ctx context.Context, db DBTX, arg BumpVisitVersionParams) error {
+	_, err := db.ExecContext(ctx, bumpVisitVersion, arg.Event, arg.Number)
 	return err
 }
 
@@ -1435,7 +1473,7 @@ func (q *Queries) Events(ctx context.Context, db DBTX) ([]EventsRow, error) {
 }
 
 const fieldReport = `-- name: FieldReport :one
-select fr.event, fr.number, fr.created, fr.summary, fr.incident_number
+select fr.event, fr.number, fr.created, fr.summary, fr.incident_number, fr.version
 from FIELD_REPORT fr
 where fr.EVENT = ?
     and fr.NUMBER = ?
@@ -1459,8 +1497,27 @@ func (q *Queries) FieldReport(ctx context.Context, db DBTX, arg FieldReportParam
 		&i.FieldReport.Created,
 		&i.FieldReport.Summary,
 		&i.FieldReport.IncidentNumber,
+		&i.FieldReport.Version,
 	)
 	return i, err
+}
+
+const fieldReportVersion = `-- name: FieldReportVersion :one
+select VERSION
+from FIELD_REPORT
+where EVENT = ? and NUMBER = ?
+`
+
+type FieldReportVersionParams struct {
+	Event  int32
+	Number int32
+}
+
+func (q *Queries) FieldReportVersion(ctx context.Context, db DBTX, arg FieldReportVersionParams) (int32, error) {
+	row := db.QueryRowContext(ctx, fieldReportVersion, arg.Event, arg.Number)
+	var version int32
+	err := row.Scan(&version)
+	return version, err
 }
 
 const fieldReport_ReportEntries = `-- name: FieldReport_ReportEntries :many
@@ -1518,7 +1575,7 @@ func (q *Queries) FieldReport_ReportEntries(ctx context.Context, db DBTX, arg Fi
 }
 
 const fieldReports = `-- name: FieldReports :many
-select fr.event, fr.number, fr.created, fr.summary, fr.incident_number
+select fr.event, fr.number, fr.created, fr.summary, fr.incident_number, fr.version
 from FIELD_REPORT fr
 where fr.EVENT = ?
 `
@@ -1542,6 +1599,7 @@ func (q *Queries) FieldReports(ctx context.Context, db DBTX, event int32) ([]Fie
 			&i.FieldReport.Created,
 			&i.FieldReport.Summary,
 			&i.FieldReport.IncidentNumber,
+			&i.FieldReport.Version,
 		); err != nil {
 			return nil, err
 		}
@@ -1615,7 +1673,7 @@ func (q *Queries) FieldReports_ReportEntries(ctx context.Context, db DBTX, arg F
 
 const incident = `-- name: Incident :one
 select
-    i.event, i.number, i.created, i.priority, i.state, i.started, i.closed, i.summary, i.location_name, i.location_address, i.location_description,
+    i.event, i.number, i.created, i.priority, i.state, i.started, i.closed, i.summary, i.location_name, i.location_address, i.location_description, i.version,
     (
         select coalesce(json_arrayagg(iit.INCIDENT_TYPE), "[]")
         from INCIDENT__INCIDENT_TYPE iit
@@ -1666,6 +1724,7 @@ func (q *Queries) Incident(ctx context.Context, db DBTX, arg IncidentParams) (In
 		&i.Incident.LocationName,
 		&i.Incident.LocationAddress,
 		&i.Incident.LocationDescription,
+		&i.Incident.Version,
 		&i.IncidentTypeIds,
 		&i.FieldReportNumbers,
 		&i.VisitNumbers,
@@ -1730,6 +1789,24 @@ func (q *Queries) IncidentTypes(ctx context.Context, db DBTX) ([]IncidentTypesRo
 		return nil, err
 	}
 	return items, nil
+}
+
+const incidentVersion = `-- name: IncidentVersion :one
+select VERSION
+from INCIDENT
+where EVENT = ? and NUMBER = ?
+`
+
+type IncidentVersionParams struct {
+	Event  int32
+	Number int32
+}
+
+func (q *Queries) IncidentVersion(ctx context.Context, db DBTX, arg IncidentVersionParams) (int32, error) {
+	row := db.QueryRowContext(ctx, incidentVersion, arg.Event, arg.Number)
+	var version int32
+	err := row.Scan(&version)
+	return version, err
 }
 
 const incident_LinkedIncidents = `-- name: Incident_LinkedIncidents :many
@@ -1897,7 +1974,7 @@ func (q *Queries) Incident_ReportEntries(ctx context.Context, db DBTX, arg Incid
 
 const incidents = `-- name: Incidents :many
 select
-    i.event, i.number, i.created, i.priority, i.state, i.started, i.closed, i.summary, i.location_name, i.location_address, i.location_description,
+    i.event, i.number, i.created, i.priority, i.state, i.started, i.closed, i.summary, i.location_name, i.location_address, i.location_description, i.version,
     (
         select coalesce(json_arrayagg(iit.INCIDENT_TYPE), "[]")
         from INCIDENT__INCIDENT_TYPE iit
@@ -1952,6 +2029,7 @@ func (q *Queries) Incidents(ctx context.Context, db DBTX, event int32) ([]Incide
 			&i.Incident.LocationName,
 			&i.Incident.LocationAddress,
 			&i.Incident.LocationDescription,
+			&i.Incident.Version,
 			&i.IncidentTypeIds,
 			&i.FieldReportNumbers,
 			&i.VisitNumbers,
@@ -2767,10 +2845,10 @@ func (q *Queries) UpdateEvent(ctx context.Context, db DBTX, arg UpdateEventParam
 	return err
 }
 
-const updateFieldReport = `-- name: UpdateFieldReport :exec
+const updateFieldReport = `-- name: UpdateFieldReport :execrows
 update FIELD_REPORT
-set SUMMARY = ?, INCIDENT_NUMBER = ?
-where EVENT = ? and NUMBER = ?
+set VERSION = VERSION + 1, SUMMARY = ?, INCIDENT_NUMBER = ?
+where EVENT = ? and NUMBER = ? and VERSION = ?
 `
 
 type UpdateFieldReportParams struct {
@@ -2778,20 +2856,27 @@ type UpdateFieldReportParams struct {
 	IncidentNumber sql.NullInt32
 	Event          int32
 	Number         int32
+	Version        int32
 }
 
-func (q *Queries) UpdateFieldReport(ctx context.Context, db DBTX, arg UpdateFieldReportParams) error {
-	_, err := db.ExecContext(ctx, updateFieldReport,
+// The VERSION bump must stay in the SET clause; see UpdateIncident.
+func (q *Queries) UpdateFieldReport(ctx context.Context, db DBTX, arg UpdateFieldReportParams) (int64, error) {
+	result, err := db.ExecContext(ctx, updateFieldReport,
 		arg.Summary,
 		arg.IncidentNumber,
 		arg.Event,
 		arg.Number,
+		arg.Version,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
-const updateIncident = `-- name: UpdateIncident :exec
+const updateIncident = `-- name: UpdateIncident :execrows
 update INCIDENT set
+    VERSION = VERSION + 1,
     -- CREATED should be immutable, so it's not present in this UPDATE query
     PRIORITY = ?,
     STATE = ?,
@@ -2804,6 +2889,7 @@ update INCIDENT set
 where
     EVENT = ?
     and NUMBER = ?
+    and VERSION = ?
 `
 
 type UpdateIncidentParams struct {
@@ -2817,10 +2903,15 @@ type UpdateIncidentParams struct {
 	LocationDescription sql.NullString
 	Event               int32
 	Number              int32
+	Version             int32
 }
 
-func (q *Queries) UpdateIncident(ctx context.Context, db DBTX, arg UpdateIncidentParams) error {
-	_, err := db.ExecContext(ctx, updateIncident,
+// The VERSION bump must stay in the SET clause: the MySQL driver reports rows
+// *changed* (not matched), so the bump guarantees that zero rows affected means
+// the WHERE clause didn't match (stale version or missing row), never that the
+// row matched but was already identical.
+func (q *Queries) UpdateIncident(ctx context.Context, db DBTX, arg UpdateIncidentParams) (int64, error) {
+	result, err := db.ExecContext(ctx, updateIncident,
 		arg.Priority,
 		arg.State,
 		arg.Started,
@@ -2831,8 +2922,12 @@ func (q *Queries) UpdateIncident(ctx context.Context, db DBTX, arg UpdateInciden
 		arg.LocationDescription,
 		arg.Event,
 		arg.Number,
+		arg.Version,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const updateIncidentType = `-- name: UpdateIncidentType :exec
@@ -2860,8 +2955,9 @@ func (q *Queries) UpdateIncidentType(ctx context.Context, db DBTX, arg UpdateInc
 	return err
 }
 
-const updateVisit = `-- name: UpdateVisit :exec
+const updateVisit = `-- name: UpdateVisit :execrows
 update VISIT set
+    VERSION = VERSION + 1,
     -- CREATED should be immutable, so it's not present in this UPDATE query
     INCIDENT_NUMBER = ?,
     GUEST_PREFERRED_NAME = ?,
@@ -2893,6 +2989,7 @@ update VISIT set
 where
     EVENT = ?
     and NUMBER = ?
+    and VERSION = ?
 `
 
 type UpdateVisitParams struct {
@@ -2922,10 +3019,12 @@ type UpdateVisitParams struct {
 	ResourceOther        sql.NullString
 	Event                int32
 	Number               int32
+	Version              int32
 }
 
-func (q *Queries) UpdateVisit(ctx context.Context, db DBTX, arg UpdateVisitParams) error {
-	_, err := db.ExecContext(ctx, updateVisit,
+// The VERSION bump must stay in the SET clause; see UpdateIncident.
+func (q *Queries) UpdateVisit(ctx context.Context, db DBTX, arg UpdateVisitParams) (int64, error) {
+	result, err := db.ExecContext(ctx, updateVisit,
 		arg.IncidentNumber,
 		arg.GuestPreferredName,
 		arg.GuestLegalName,
@@ -2952,13 +3051,17 @@ func (q *Queries) UpdateVisit(ctx context.Context, db DBTX, arg UpdateVisitParam
 		arg.ResourceOther,
 		arg.Event,
 		arg.Number,
+		arg.Version,
 	)
-	return err
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }
 
 const visit = `-- name: Visit :one
 select
-    s.event, s.number, s.created, s.incident_number, s.guest_preferred_name, s.guest_legal_name, s.guest_description, s.guest_action_plan, s.guest_camp_name, s.guest_camp_address, s.guest_camp_description, s.guest_camp_contacts, s.arrival_time, s.arrival_method, s.arrival_state, s.arrival_reason, s.arrival_belongings, s.departure_time, s.departure_method, s.departure_state, s.resource_sitter, s.resource_bed_id, s.resource_rest, s.resource_clothes, s.resource_pogs, s.resource_food_bev, s.resource_other
+    s.event, s.number, s.created, s.incident_number, s.guest_preferred_name, s.guest_legal_name, s.guest_description, s.guest_action_plan, s.guest_camp_name, s.guest_camp_address, s.guest_camp_description, s.guest_camp_contacts, s.arrival_time, s.arrival_method, s.arrival_state, s.arrival_reason, s.arrival_belongings, s.departure_time, s.departure_method, s.departure_state, s.resource_sitter, s.resource_bed_id, s.resource_rest, s.resource_clothes, s.resource_pogs, s.resource_food_bev, s.resource_other, s.version
 from
     VISIT s
 where
@@ -3006,8 +3109,27 @@ func (q *Queries) Visit(ctx context.Context, db DBTX, arg VisitParams) (VisitRow
 		&i.Visit.ResourcePogs,
 		&i.Visit.ResourceFoodBev,
 		&i.Visit.ResourceOther,
+		&i.Visit.Version,
 	)
 	return i, err
+}
+
+const visitVersion = `-- name: VisitVersion :one
+select VERSION
+from VISIT
+where EVENT = ? and NUMBER = ?
+`
+
+type VisitVersionParams struct {
+	Event  int32
+	Number int32
+}
+
+func (q *Queries) VisitVersion(ctx context.Context, db DBTX, arg VisitVersionParams) (int32, error) {
+	row := db.QueryRowContext(ctx, visitVersion, arg.Event, arg.Number)
+	var version int32
+	err := row.Scan(&version)
+	return version, err
 }
 
 const visit_Rangers = `-- name: Visit_Rangers :many
@@ -3117,7 +3239,7 @@ func (q *Queries) Visit_ReportEntries(ctx context.Context, db DBTX, arg Visit_Re
 
 const visits = `-- name: Visits :many
 select
-    s.event, s.number, s.created, s.incident_number, s.guest_preferred_name, s.guest_legal_name, s.guest_description, s.guest_action_plan, s.guest_camp_name, s.guest_camp_address, s.guest_camp_description, s.guest_camp_contacts, s.arrival_time, s.arrival_method, s.arrival_state, s.arrival_reason, s.arrival_belongings, s.departure_time, s.departure_method, s.departure_state, s.resource_sitter, s.resource_bed_id, s.resource_rest, s.resource_clothes, s.resource_pogs, s.resource_food_bev, s.resource_other
+    s.event, s.number, s.created, s.incident_number, s.guest_preferred_name, s.guest_legal_name, s.guest_description, s.guest_action_plan, s.guest_camp_name, s.guest_camp_address, s.guest_camp_description, s.guest_camp_contacts, s.arrival_time, s.arrival_method, s.arrival_state, s.arrival_reason, s.arrival_belongings, s.departure_time, s.departure_method, s.departure_state, s.resource_sitter, s.resource_bed_id, s.resource_rest, s.resource_clothes, s.resource_pogs, s.resource_food_bev, s.resource_other, s.version
 from
     VISIT s
 where
@@ -3167,6 +3289,7 @@ func (q *Queries) Visits(ctx context.Context, db DBTX, event int32) ([]VisitsRow
 			&i.Visit.ResourcePogs,
 			&i.Visit.ResourceFoodBev,
 			&i.Visit.ResourceOther,
+			&i.Visit.Version,
 		); err != nil {
 			return nil, err
 		}

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -132,8 +132,13 @@ values (
    ?,?,?,?,?,?
 );
 
--- name: UpdateIncident :exec
+-- The VERSION bump must stay in the SET clause: the MySQL driver reports rows
+-- *changed* (not matched), so the bump guarantees that zero rows affected means
+-- the WHERE clause didn't match (stale version or missing row), never that the
+-- row matched but was already identical.
+-- name: UpdateIncident :execrows
 update INCIDENT set
+    VERSION = VERSION + 1,
     -- CREATED should be immutable, so it's not present in this UPDATE query
     PRIORITY = ?,
     STATE = ?,
@@ -146,7 +151,21 @@ update INCIDENT set
 where
     EVENT = ?
     and NUMBER = ?
+    and VERSION = ?
 ;
+
+-- BumpIncidentVersion is for mutations that change an incident's representation
+-- without going through the version-guarded UpdateIncident query (Ranger
+-- assignments, the peer of a link/unlink, field-report/visit reassignment).
+-- name: BumpIncidentVersion :exec
+update INCIDENT
+set VERSION = VERSION + 1
+where EVENT = ? and NUMBER = ?;
+
+-- name: IncidentVersion :one
+select VERSION
+from INCIDENT
+where EVENT = ? and NUMBER = ?;
 
 -- name: Incident :one
 select
@@ -309,7 +328,7 @@ where
 
 -- name: AttachFieldReportToIncident :exec
 update FIELD_REPORT
-set INCIDENT_NUMBER = ?
+set INCIDENT_NUMBER = ?, VERSION = VERSION + 1
 where EVENT = ? and NUMBER = ?
 ;
 
@@ -339,10 +358,16 @@ insert into FIELD_REPORT (
 )
 values (?, ?, ?, ?, ?);
 
--- name: UpdateFieldReport :exec
-update FIELD_REPORT
-set SUMMARY = ?, INCIDENT_NUMBER = ?
+-- name: FieldReportVersion :one
+select VERSION
+from FIELD_REPORT
 where EVENT = ? and NUMBER = ?;
+
+-- The VERSION bump must stay in the SET clause; see UpdateIncident.
+-- name: UpdateFieldReport :execrows
+update FIELD_REPORT
+set VERSION = VERSION + 1, SUMMARY = ?, INCIDENT_NUMBER = ?
+where EVENT = ? and NUMBER = ? and VERSION = ?;
 
 -- name: CreateReportEntry :execlastid
 insert into REPORT_ENTRY (
@@ -375,7 +400,7 @@ insert into VISIT__REPORT_ENTRY (
 
 -- name: AttachVisitToIncident :exec
 update VISIT
-set INCIDENT_NUMBER = ?
+set INCIDENT_NUMBER = ?, VERSION = VERSION + 1
 where EVENT = ? and NUMBER = ?
 ;
 
@@ -523,8 +548,10 @@ where
 -- name: CreateVisit :execlastid
 insert into VISIT (`EVENT`, NUMBER, CREATED) values (?, ?, ?);
 
--- name: UpdateVisit :exec
+-- The VERSION bump must stay in the SET clause; see UpdateIncident.
+-- name: UpdateVisit :execrows
 update VISIT set
+    VERSION = VERSION + 1,
     -- CREATED should be immutable, so it's not present in this UPDATE query
     INCIDENT_NUMBER = ?,
     GUEST_PREFERRED_NAME = ?,
@@ -556,7 +583,21 @@ update VISIT set
 where
     EVENT = ?
     and NUMBER = ?
+    and VERSION = ?
 ;
+
+-- BumpVisitVersion is for mutations that change a visit's representation
+-- without going through the version-guarded UpdateVisit query (Ranger
+-- assignments).
+-- name: BumpVisitVersion :exec
+update VISIT
+set VERSION = VERSION + 1
+where EVENT = ? and NUMBER = ?;
+
+-- name: VisitVersion :one
+select VERSION
+from VISIT
+where EVENT = ? and NUMBER = ?;
 
 -- name: Visit :one
 select

--- a/store/schema/36-from-35.sql
+++ b/store/schema/36-from-35.sql
@@ -1,0 +1,12 @@
+/* Optimistic-concurrency version counters, surfaced to clients as ETags.
+
+   Bumped on every change to a record's representation other than report-entry
+   appends, which are append-only and cannot lose data. */
+
+alter table `INCIDENT`     add column `VERSION` integer not null default 1;
+alter table `FIELD_REPORT` add column `VERSION` integer not null default 1;
+alter table `VISIT`        add column `VERSION` integer not null default 1;
+
+update `SCHEMA_INFO`
+set `VERSION` = 36
+where true;

--- a/store/schema/36-from-35.sql
+++ b/store/schema/36-from-35.sql
@@ -1,7 +1,9 @@
 /* Optimistic-concurrency version counters, surfaced to clients as ETags.
 
    Bumped on every change to a record's representation other than report-entry
-   appends, which are append-only and cannot lose data. */
+   changes. Report entries are append-only except for the STRICKEN flag, a
+   reversible boolean toggle that is audited via generated entries — neither
+   appends nor strikes can silently lose data, so neither moves the version. */
 
 alter table `INCIDENT`     add column `VERSION` integer not null default 1;
 alter table `FIELD_REPORT` add column `VERSION` integer not null default 1;

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -6,7 +6,7 @@ create table SCHEMA_INFO (
 -- This value must be updated when you make a new migration file.
 --
 
-insert into SCHEMA_INFO (VERSION) values (35);
+insert into SCHEMA_INFO (VERSION) values (36);
 
 
 create table `EVENT` (
@@ -71,6 +71,11 @@ create table INCIDENT (
     LOCATION_NAME           varchar(1024),
     LOCATION_ADDRESS        varchar(1024),
     LOCATION_DESCRIPTION    varchar(1024),
+
+    -- Optimistic-concurrency version counter, surfaced to clients as an ETag.
+    -- Bumped on every change to the incident's representation other than
+    -- report-entry appends.
+    `VERSION` integer not null default 1,
 
     foreign key (`EVENT`) references `EVENT`(ID),
 
@@ -160,6 +165,9 @@ create table FIELD_REPORT (
 
     SUMMARY         varchar(1024),
     INCIDENT_NUMBER integer,
+
+    -- Optimistic-concurrency version counter; see INCIDENT.VERSION.
+    `VERSION` integer not null default 1,
 
     foreign key (`EVENT`) references `EVENT`(ID),
     foreign key (`EVENT`, INCIDENT_NUMBER) references INCIDENT(`EVENT`, NUMBER),
@@ -253,6 +261,9 @@ create table VISIT (
     RESOURCE_POGS       varchar(256),
     RESOURCE_FOOD_BEV   varchar(256),
     RESOURCE_OTHER      varchar(256),
+
+    -- Optimistic-concurrency version counter; see INCIDENT.VERSION.
+    `VERSION` integer not null default 1,
 
     foreign key `VISIT_TO_EVENT` (`EVENT`) references `EVENT`(ID),
     foreign key `VISIT_TO_INCIDENT` (`EVENT`, INCIDENT_NUMBER) references INCIDENT(`EVENT`, NUMBER),

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -74,7 +74,10 @@ create table INCIDENT (
 
     -- Optimistic-concurrency version counter, surfaced to clients as an ETag.
     -- Bumped on every change to the incident's representation other than
-    -- report-entry appends.
+    -- report-entry changes. Report entries are append-only except for the
+    -- STRICKEN flag, a reversible boolean toggle that is audited via generated
+    -- entries — neither appends nor strikes can silently lose data, so neither
+    -- moves the version.
     `VERSION` integer not null default 1,
 
     foreign key (`EVENT`) references `EVENT`(ID),

--- a/web/static/field_report.js
+++ b/web/static/field_report.js
@@ -18,6 +18,9 @@
 "use strict";
 import * as ims from "./ims.js";
 let fieldReport = null;
+// The ETag from the last read of this field report, sent back as If-Match on
+// edits so that the server can reject an edit based on stale data (HTTP 412).
+let fieldReportETag = null;
 //
 // Initialize UI
 //
@@ -148,9 +151,10 @@ async function loadFieldReport() {
             "number": null,
             "created": null,
         };
+        fieldReportETag = null;
     }
     else {
-        const { json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_fieldReports)}/${number}`, null);
+        const { resp, json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_fieldReports)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
             const message = "Failed to load field report: " + err;
@@ -159,6 +163,7 @@ async function loadFieldReport() {
             return { err: message };
         }
         fieldReport = json;
+        fieldReportETag = ims.etagOf(resp);
     }
     return { err: null };
 }
@@ -282,7 +287,14 @@ function drawSummary() {
 //
 // Editing
 //
-async function frSendEdits(edits) {
+// Sequences frSendEdits calls, so that rapid autosaves don't race one another:
+// each edit must carry the ETag produced by the previous one.
+let frSendEditsChain = Promise.resolve({ err: null });
+function frSendEdits(edits) {
+    frSendEditsChain = frSendEditsChain.then(() => frSendEditsNow(edits), () => frSendEditsNow(edits));
+    return frSendEditsChain;
+}
+async function frSendEditsNow(edits) {
     if (fieldReport == null) {
         return { err: "fieldReport is null!" };
     }
@@ -296,16 +308,29 @@ async function frSendEdits(edits) {
         edits.number = number;
         url += `/${number}`;
     }
+    // Report-entry appends can't lose data, so they're sent unconditionally
+    // rather than failing on a stale ETag when someone else edits a field.
+    const noteOnly = Object.keys(edits).every((key) => key === "report_entries" || key === "number");
+    const headers = {};
+    if (number != null && fieldReportETag != null && !noteOnly) {
+        headers["If-Match"] = fieldReportETag;
+    }
     const { resp, err } = await ims.fetchNoThrow(url, {
+        headers: headers,
         body: JSON.stringify(edits),
     });
     if (err != null) {
-        const message = `Failed to apply edit: ${err}`;
+        let message = `Failed to apply edit: ${err}`;
+        if (resp?.status === 412) {
+            message = "Someone else has edited this field report. " +
+                "The page has been refreshed with their changes; please retry your edit.";
+        }
         console.log(message);
         await loadAndDisplayFieldReport();
         ims.setErrorMessage(message);
         return { err: message };
     }
+    fieldReportETag = ims.etagOf(resp) ?? fieldReportETag;
     if (number == null) {
         // We created a new field report.
         // We need to find out the created field report number so that

--- a/web/static/ims.js
+++ b/web/static/ims.js
@@ -192,6 +192,13 @@ export async function fetchNoThrow(url, init) {
     }
     return { resp: response, json: json, err: err };
 }
+// etagOf reads the ETag header from a response, for optimistic concurrency:
+// pages remember the ETag from the last read of a record and send it back as
+// If-Match on edits, and the server rejects the edit with a 412 if the record
+// has changed in the meantime.
+export function etagOf(resp) {
+    return resp?.headers.get("ETag") ?? null;
+}
 //
 // Generic string formatting
 //

--- a/web/static/incident.js
+++ b/web/static/incident.js
@@ -19,6 +19,9 @@
 import * as ims from "./ims.js";
 import { fetchPersonnel } from "./ims.js";
 let incident = null;
+// The ETag from the last read of this incident, sent back as If-Match on
+// edits so that the server can reject an edit based on stale data (HTTP 412).
+let incidentETag = null;
 let allIncidentTypes = [];
 let allEvents = null;
 let places = {};
@@ -251,9 +254,10 @@ async function loadIncident() {
             "priority": 3,
             "summary": "",
         };
+        incidentETag = null;
     }
     else {
-        const { json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_incidents)}/${number}`, null);
+        const { resp, json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_incidents)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
             const message = `Failed to load Incident ${number}: ${err}`;
@@ -262,6 +266,7 @@ async function loadIncident() {
             return { err: message };
         }
         incident = json;
+        incidentETag = ims.etagOf(resp);
     }
     return { err: null };
 }
@@ -887,7 +892,14 @@ function drawFieldReportsToAttach() {
 //
 // Editing
 //
-async function sendEdits(edits) {
+// Sequences sendEdits calls, so that rapid autosaves don't race one another:
+// each edit must carry the ETag produced by the previous one.
+let sendEditsChain = Promise.resolve({ err: null });
+function sendEdits(edits) {
+    sendEditsChain = sendEditsChain.then(() => sendEditsNow(edits), () => sendEditsNow(edits));
+    return sendEditsChain;
+}
+async function sendEditsNow(edits) {
     const number = incident.number;
     let url = ims.urlReplace(url_incidents);
     if (number == null) {
@@ -905,15 +917,28 @@ async function sendEdits(edits) {
         edits.number = number;
         url += `/${number}`;
     }
+    // Report-entry appends can't lose data, so they're sent unconditionally
+    // rather than failing on a stale ETag when someone else edits a field.
+    const noteOnly = Object.keys(edits).every((key) => key === "report_entries" || key === "number");
+    const headers = {};
+    if (number != null && incidentETag != null && !noteOnly) {
+        headers["If-Match"] = incidentETag;
+    }
     const { resp, err } = await ims.fetchNoThrow(url, {
+        headers: headers,
         body: JSON.stringify(edits),
     });
     if (err != null) {
-        const message = `Failed to apply edit: ${err}`;
+        let message = `Failed to apply edit: ${err}`;
+        if (resp?.status === 412) {
+            message = "Someone else has edited this incident. " +
+                "The page has been refreshed with their changes; please retry your edit.";
+        }
         await loadAndDisplayIncident();
         ims.setErrorMessage(message);
         return { err: message };
     }
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
     if (number == null && resp != null) {
         // We created a new incident.
         // We need to find out the created incident number so that future
@@ -1025,9 +1050,11 @@ async function removeRanger(sender) {
     const url = (ims.urlReplace(url_incidentRanger)
         .replace("<incident_number>", ims.pathIds.incidentNumber.toString())
         .replace("<ranger_name>", encodeURIComponent(rangerHandle)));
-    await ims.fetchNoThrow(url, {
+    const { resp } = await ims.fetchNoThrow(url, {
         method: "DELETE",
     });
+    // The roster change moved the incident's version on the server.
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
 }
 async function setRangerRole(sender) {
     const handle = sender.closest("li")?.dataset["rangerHandle"];
@@ -1038,7 +1065,7 @@ async function setRangerRole(sender) {
     const url = (ims.urlReplace(url_incidentRanger)
         .replace("<incident_number>", ims.pathIds.incidentNumber.toString())
         .replace("<ranger_name>", encodeURIComponent(handle)));
-    const { err } = await ims.fetchNoThrow(url, {
+    const { resp, err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
             role: sender.value,
@@ -1048,6 +1075,7 @@ async function setRangerRole(sender) {
         ims.controlHasError(sender);
         return;
     }
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
     ims.controlHasSuccess(sender);
     return;
 }
@@ -1099,7 +1127,7 @@ async function addRanger() {
     const url = (ims.urlReplace(url_incidentRanger)
         .replace("<incident_number>", ims.pathIds.incidentNumber.toString())
         .replace("<ranger_name>", encodeURIComponent(handle)));
-    const { err } = await ims.fetchNoThrow(url, {
+    const { resp, err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
         }),
@@ -1110,6 +1138,7 @@ async function addRanger() {
         el.rangerAdd.disabled = false;
         return;
     }
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
     el.rangerAdd.value = "";
     el.rangerAdd.disabled = false;
     ims.controlHasSuccess(el.rangerAdd);
@@ -1186,6 +1215,9 @@ async function detachFieldReport(sender) {
         ims.setErrorMessage(message);
         return;
     }
+    // The detachment moved this incident's version on the server, and the
+    // response's ETag belongs to the field report/visit, not the incident.
+    await loadIncident();
     await loadAllVisits();
     await loadAllFieldReports();
     renderFieldReportData();
@@ -1229,6 +1261,9 @@ async function attachFieldReport() {
         ims.controlHasError(el.attachedFieldReportAdd);
         return;
     }
+    // The attachment moved this incident's version on the server, and the
+    // response's ETag belongs to the field report/visit, not the incident.
+    await loadIncident();
     await loadAllVisits();
     await loadAllFieldReports();
     renderFieldReportData();

--- a/web/static/sanctuary_visit.js
+++ b/web/static/sanctuary_visit.js
@@ -18,6 +18,9 @@
 "use strict";
 import * as ims from "./ims.js";
 let visit = null;
+// The ETag from the last read of this visit, sent back as If-Match on edits
+// so that the server can reject an edit based on stale data (HTTP 412).
+let visitETag = null;
 //
 // Initialize UI
 //
@@ -208,9 +211,10 @@ async function loadVisit() {
         visit = {
             "number": null,
         };
+        visitETag = null;
     }
     else {
-        const { json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_visits)}/${number}`, null);
+        const { resp, json, err } = await ims.fetchNoThrow(`${ims.urlReplace(url_visits)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
             const message = `Failed to load Visit ${number}: ${err}`;
@@ -219,6 +223,7 @@ async function loadVisit() {
             return { err: message };
         }
         visit = json;
+        visitETag = ims.etagOf(resp);
     }
     return { err: null };
 }
@@ -319,7 +324,14 @@ function drawVisitTitle(mode) {
     }
     document.title = newTitle;
 }
-async function sendEdits(edits) {
+// Sequences sendEdits calls, so that rapid autosaves don't race one another:
+// each edit must carry the ETag produced by the previous one.
+let sendEditsChain = Promise.resolve({ err: null });
+function sendEdits(edits) {
+    sendEditsChain = sendEditsChain.then(() => sendEditsNow(edits), () => sendEditsNow(edits));
+    return sendEditsChain;
+}
+async function sendEditsNow(edits) {
     const number = visit.number;
     let url = ims.urlReplace(url_visits);
     if (number == null) {
@@ -331,15 +343,28 @@ async function sendEdits(edits) {
         edits.number = number;
         url += `/${number}`;
     }
+    // Report-entry appends can't lose data, so they're sent unconditionally
+    // rather than failing on a stale ETag when someone else edits a field.
+    const noteOnly = Object.keys(edits).every((key) => key === "report_entries" || key === "number");
+    const headers = {};
+    if (number != null && visitETag != null && !noteOnly) {
+        headers["If-Match"] = visitETag;
+    }
     const { resp, err } = await ims.fetchNoThrow(url, {
+        headers: headers,
         body: JSON.stringify(edits),
     });
     if (err != null) {
-        const message = `Failed to apply edit: ${err}`;
+        let message = `Failed to apply edit: ${err}`;
+        if (resp?.status === 412) {
+            message = "Someone else has edited this visit. " +
+                "The page has been refreshed with their changes; please retry your edit.";
+        }
         await loadAndDisplayVisit();
         ims.setErrorMessage(message);
         return { err: message };
     }
+    visitETag = ims.etagOf(resp) ?? visitETag;
     if (number == null && resp != null) {
         // We created a new visit.
         // We need to find out the created visit number so that future
@@ -567,7 +592,7 @@ async function addRanger() {
     const url = (ims.urlReplace(url_visitRanger)
         .replace("<visit_number>", ims.pathIds.visitNumber.toString())
         .replace("<ranger_name>", encodeURIComponent(handle)));
-    const { err } = await ims.fetchNoThrow(url, {
+    const { resp, err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
         }),
@@ -578,6 +603,8 @@ async function addRanger() {
         el.addRanger.disabled = false;
         return;
     }
+    // The roster change moved the visit's version on the server.
+    visitETag = ims.etagOf(resp) ?? visitETag;
     el.addRanger.value = "";
     el.addRanger.disabled = false;
     ims.controlHasSuccess(el.addRanger);
@@ -592,9 +619,11 @@ async function removeRanger(sender) {
     const url = (ims.urlReplace(url_visitRanger)
         .replace("<visit_number>", ims.pathIds.visitNumber.toString())
         .replace("<ranger_name>", encodeURIComponent(rangerHandle)));
-    await ims.fetchNoThrow(url, {
+    const { resp } = await ims.fetchNoThrow(url, {
         method: "DELETE",
     });
+    // The roster change moved the visit's version on the server.
+    visitETag = ims.etagOf(resp) ?? visitETag;
 }
 async function setRangerRole(sender) {
     const handle = sender.closest("li")?.dataset["rangerHandle"];
@@ -605,7 +634,7 @@ async function setRangerRole(sender) {
     const url = (ims.urlReplace(url_visitRanger)
         .replace("<visit_number>", ims.pathIds.visitNumber.toString())
         .replace("<ranger_name>", encodeURIComponent(handle)));
-    const { err } = await ims.fetchNoThrow(url, {
+    const { resp, err } = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
             role: sender.value,
@@ -615,6 +644,7 @@ async function setRangerRole(sender) {
         ims.controlHasError(sender);
         return;
     }
+    visitETag = ims.etagOf(resp) ?? visitETag;
     ims.controlHasSuccess(sender);
     return;
 }

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -32,6 +32,10 @@ declare global {
 
 let fieldReport: ims.FieldReport|null = null;
 
+// The ETag from the last read of this field report, sent back as If-Match on
+// edits so that the server can reject an edit based on stale data (HTTP 412).
+let fieldReportETag: string|null = null;
+
 //
 // Initialize UI
 //
@@ -183,8 +187,9 @@ async function loadFieldReport(): Promise<{err: string|null}> {
             "number": null,
             "created": null,
         };
+        fieldReportETag = null;
     } else {
-        const {json, err} = await ims.fetchNoThrow<ims.FieldReport>(
+        const {resp, json, err} = await ims.fetchNoThrow<ims.FieldReport>(
             `${ims.urlReplace(url_fieldReports)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -194,6 +199,7 @@ async function loadFieldReport(): Promise<{err: string|null}> {
             return {err: message};
         }
         fieldReport = json;
+        fieldReportETag = ims.etagOf(resp);
     }
     return {err: null};
 }
@@ -339,7 +345,19 @@ function drawSummary(): void {
 // Editing
 //
 
-async function frSendEdits(edits: ims.FieldReport): Promise<{err:string|null}> {
+// Sequences frSendEdits calls, so that rapid autosaves don't race one another:
+// each edit must carry the ETag produced by the previous one.
+let frSendEditsChain: Promise<{err:string|null}> = Promise.resolve({err: null});
+
+function frSendEdits(edits: ims.FieldReport): Promise<{err:string|null}> {
+    frSendEditsChain = frSendEditsChain.then(
+        () => frSendEditsNow(edits),
+        () => frSendEditsNow(edits),
+    );
+    return frSendEditsChain;
+}
+
+async function frSendEditsNow(edits: ims.FieldReport): Promise<{err:string|null}> {
     if (fieldReport == null) {
         return {err: "fieldReport is null!"};
     }
@@ -354,16 +372,30 @@ async function frSendEdits(edits: ims.FieldReport): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
+    // Report-entry appends can't lose data, so they're sent unconditionally
+    // rather than failing on a stale ETag when someone else edits a field.
+    const noteOnly = Object.keys(edits).every(
+        (key) => key === "report_entries" || key === "number");
+    const headers: HeadersInit = {};
+    if (number != null && fieldReportETag != null && !noteOnly) {
+        headers["If-Match"] = fieldReportETag;
+    }
     const {resp, err} = await ims.fetchNoThrow(url, {
+        headers: headers,
         body: JSON.stringify(edits),
     });
     if (err != null) {
-        const message = `Failed to apply edit: ${err}`;
+        let message = `Failed to apply edit: ${err}`;
+        if (resp?.status === 412) {
+            message = "Someone else has edited this field report. " +
+                "The page has been refreshed with their changes; please retry your edit.";
+        }
         console.log(message);
         await loadAndDisplayFieldReport();
         ims.setErrorMessage(message);
         return {err: message};
     }
+    fieldReportETag = ims.etagOf(resp) ?? fieldReportETag;
     if (number == null) {
         // We created a new field report.
         // We need to find out the created field report number so that

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -214,6 +214,14 @@ export async function fetchNoThrow<T>(url: string, init: RequestInit|null): Prom
     return {resp: response, json: json, err: err};
 }
 
+// etagOf reads the ETag header from a response, for optimistic concurrency:
+// pages remember the ETag from the last read of a record and send it back as
+// If-Match on edits, and the server rejects the edit with a 412 if the record
+// has changed in the meantime.
+export function etagOf(resp: Response|null): string|null {
+    return resp?.headers.get("ETag") ?? null;
+}
+
 
 //
 // Generic string formatting
@@ -1838,6 +1846,7 @@ export type Incident = {
     created?: string|null;
     started?: string|null;
     last_modified?: string|null;
+    version?: number|null;
     rangers?: IncidentRanger[]|null;
     incident_type_ids?: number[]|null;
     location?: EventLocation|null;
@@ -1851,6 +1860,7 @@ export type FieldReport = {
     event?: string|null;
     number?: number|null;
     created?: string|null;
+    version?: number|null;
     summary?: string|null;
     incident?: number|null;
     report_entries?: ReportEntry[]|null;
@@ -1864,6 +1874,7 @@ export type Visit = {
     event?: string|null;
     created?: string|null;
     last_modified?: string|null;
+    version?: number|null;
     incident?: number|null;
 
     guest_preferred_name?: string|null;

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -45,6 +45,10 @@ declare global {
 
 let incident: ims.Incident|null = null;
 
+// The ETag from the last read of this incident, sent back as If-Match on
+// edits so that the server can reject an edit based on stale data (HTTP 412).
+let incidentETag: string|null = null;
+
 let allIncidentTypes: ims.IncidentType[] = [];
 
 let allEvents: ims.EventData[]|null = null;
@@ -321,8 +325,9 @@ async function loadIncident(): Promise<{err: string|null}> {
             "priority": 3,
             "summary": "",
         };
+        incidentETag = null;
     } else {
-        const {json, err} = await ims.fetchNoThrow<ims.Incident>(
+        const {resp, json, err} = await ims.fetchNoThrow<ims.Incident>(
             `${ims.urlReplace(url_incidents)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -332,6 +337,7 @@ async function loadIncident(): Promise<{err: string|null}> {
             return {err: message};
         }
         incident = json;
+        incidentETag = ims.etagOf(resp);
     }
     return {err: null};
 }
@@ -1082,7 +1088,19 @@ function drawFieldReportsToAttach() {
 // Editing
 //
 
-async function sendEdits(edits: ims.Incident): Promise<{err:string|null}> {
+// Sequences sendEdits calls, so that rapid autosaves don't race one another:
+// each edit must carry the ETag produced by the previous one.
+let sendEditsChain: Promise<{err:string|null}> = Promise.resolve({err: null});
+
+function sendEdits(edits: ims.Incident): Promise<{err:string|null}> {
+    sendEditsChain = sendEditsChain.then(
+        () => sendEditsNow(edits),
+        () => sendEditsNow(edits),
+    );
+    return sendEditsChain;
+}
+
+async function sendEditsNow(edits: ims.Incident): Promise<{err:string|null}> {
     const number = incident!.number;
     let url = ims.urlReplace(url_incidents);
 
@@ -1101,16 +1119,31 @@ async function sendEdits(edits: ims.Incident): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
+    // Report-entry appends can't lose data, so they're sent unconditionally
+    // rather than failing on a stale ETag when someone else edits a field.
+    const noteOnly = Object.keys(edits).every(
+        (key) => key === "report_entries" || key === "number");
+    const headers: HeadersInit = {};
+    if (number != null && incidentETag != null && !noteOnly) {
+        headers["If-Match"] = incidentETag;
+    }
     const {resp, err} = await ims.fetchNoThrow(url, {
+        headers: headers,
         body: JSON.stringify(edits),
     });
 
     if (err != null) {
-        const message = `Failed to apply edit: ${err}`;
+        let message = `Failed to apply edit: ${err}`;
+        if (resp?.status === 412) {
+            message = "Someone else has edited this incident. " +
+                "The page has been refreshed with their changes; please retry your edit.";
+        }
         await loadAndDisplayIncident();
         ims.setErrorMessage(message);
         return {err: message};
     }
+
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
 
     if (number == null && resp != null) {
         // We created a new incident.
@@ -1247,9 +1280,11 @@ async function removeRanger(sender: HTMLElement): Promise<void> {
             .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
             .replace("<ranger_name>", encodeURIComponent(rangerHandle))
     );
-    await ims.fetchNoThrow(url, {
+    const {resp} = await ims.fetchNoThrow(url, {
         method: "DELETE",
     });
+    // The roster change moved the incident's version on the server.
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
 }
 
 async function setRangerRole(sender: HTMLInputElement): Promise<void> {
@@ -1264,7 +1299,7 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
             .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
             .replace("<ranger_name>", encodeURIComponent(handle))
     );
-    const {err} = await ims.fetchNoThrow(url, {
+    const {resp, err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
             role: sender.value,
@@ -1274,6 +1309,7 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
         ims.controlHasError(sender);
         return;
     }
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
     ims.controlHasSuccess(sender);
 
     return;
@@ -1341,7 +1377,7 @@ async function addRanger(): Promise<void> {
             .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
             .replace("<ranger_name>", encodeURIComponent(handle))
     );
-    const {err} = await ims.fetchNoThrow(url, {
+    const {resp, err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
         }),
@@ -1352,6 +1388,7 @@ async function addRanger(): Promise<void> {
         el.rangerAdd.disabled = false;
         return;
     }
+    incidentETag = ims.etagOf(resp) ?? incidentETag;
     el.rangerAdd.value = "";
     el.rangerAdd.disabled = false;
     ims.controlHasSuccess(el.rangerAdd);
@@ -1439,6 +1476,9 @@ async function detachFieldReport(sender: HTMLElement): Promise<void> {
         ims.setErrorMessage(message);
         return;
     }
+    // The detachment moved this incident's version on the server, and the
+    // response's ETag belongs to the field report/visit, not the incident.
+    await loadIncident();
     await loadAllVisits();
     await loadAllFieldReports();
     renderFieldReportData();
@@ -1486,6 +1526,9 @@ async function attachFieldReport(): Promise<void> {
         ims.controlHasError(el.attachedFieldReportAdd);
         return;
     }
+    // The attachment moved this incident's version on the server, and the
+    // response's ETag belongs to the field report/visit, not the incident.
+    await loadIncident();
     await loadAllVisits();
     await loadAllFieldReports();
     renderFieldReportData();

--- a/web/typescript/sanctuary_visit.ts
+++ b/web/typescript/sanctuary_visit.ts
@@ -60,6 +60,10 @@ declare global {
 
 let visit: ims.Visit|null = null;
 
+// The ETag from the last read of this visit, sent back as If-Match on edits
+// so that the server can reject an edit based on stale data (HTTP 412).
+let visitETag: string|null = null;
+
 //
 // Initialize UI
 //
@@ -285,8 +289,9 @@ async function loadVisit(): Promise<{err: string|null}> {
         visit = {
             "number": null,
         };
+        visitETag = null;
     } else {
-        const {json, err} = await ims.fetchNoThrow<ims.Visit>(
+        const {resp, json, err} = await ims.fetchNoThrow<ims.Visit>(
             `${ims.urlReplace(url_visits)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -296,6 +301,7 @@ async function loadVisit(): Promise<{err: string|null}> {
             return {err: message};
         }
         visit = json;
+        visitETag = ims.etagOf(resp);
     }
     return {err: null};
 }
@@ -404,7 +410,19 @@ function drawVisitTitle(mode: "for_display"|"for_print_to_pdf"): void {
 }
 
 
-async function sendEdits(edits: ims.Visit): Promise<{err:string|null}> {
+// Sequences sendEdits calls, so that rapid autosaves don't race one another:
+// each edit must carry the ETag produced by the previous one.
+let sendEditsChain: Promise<{err:string|null}> = Promise.resolve({err: null});
+
+function sendEdits(edits: ims.Visit): Promise<{err:string|null}> {
+    sendEditsChain = sendEditsChain.then(
+        () => sendEditsNow(edits),
+        () => sendEditsNow(edits),
+    );
+    return sendEditsChain;
+}
+
+async function sendEditsNow(edits: ims.Visit): Promise<{err:string|null}> {
     const number = visit!.number;
     let url = ims.urlReplace(url_visits);
 
@@ -417,16 +435,31 @@ async function sendEdits(edits: ims.Visit): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
+    // Report-entry appends can't lose data, so they're sent unconditionally
+    // rather than failing on a stale ETag when someone else edits a field.
+    const noteOnly = Object.keys(edits).every(
+        (key) => key === "report_entries" || key === "number");
+    const headers: HeadersInit = {};
+    if (number != null && visitETag != null && !noteOnly) {
+        headers["If-Match"] = visitETag;
+    }
     const {resp, err} = await ims.fetchNoThrow(url, {
+        headers: headers,
         body: JSON.stringify(edits),
     });
 
     if (err != null) {
-        const message = `Failed to apply edit: ${err}`;
+        let message = `Failed to apply edit: ${err}`;
+        if (resp?.status === 412) {
+            message = "Someone else has edited this visit. " +
+                "The page has been refreshed with their changes; please retry your edit.";
+        }
         await loadAndDisplayVisit();
         ims.setErrorMessage(message);
         return {err: message};
     }
+
+    visitETag = ims.etagOf(resp) ?? visitETag;
 
     if (number == null && resp != null) {
         // We created a new visit.
@@ -695,7 +728,7 @@ async function addRanger(): Promise<void> {
             .replace("<visit_number>", ims.pathIds.visitNumber!.toString())
             .replace("<ranger_name>", encodeURIComponent(handle))
     );
-    const {err} = await ims.fetchNoThrow(url, {
+    const {resp, err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
         }),
@@ -706,6 +739,8 @@ async function addRanger(): Promise<void> {
         el.addRanger.disabled = false;
         return;
     }
+    // The roster change moved the visit's version on the server.
+    visitETag = ims.etagOf(resp) ?? visitETag;
     el.addRanger.value = "";
     el.addRanger.disabled = false;
     ims.controlHasSuccess(el.addRanger);
@@ -724,9 +759,11 @@ async function removeRanger(sender: HTMLElement): Promise<void> {
             .replace("<visit_number>", ims.pathIds.visitNumber!.toString())
             .replace("<ranger_name>", encodeURIComponent(rangerHandle))
     );
-    await ims.fetchNoThrow(url, {
+    const {resp} = await ims.fetchNoThrow(url, {
         method: "DELETE",
     });
+    // The roster change moved the visit's version on the server.
+    visitETag = ims.etagOf(resp) ?? visitETag;
 }
 
 
@@ -742,7 +779,7 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
             .replace("<visit_number>", ims.pathIds.visitNumber!.toString())
             .replace("<ranger_name>", encodeURIComponent(handle))
     );
-    const {err} = await ims.fetchNoThrow(url, {
+    const {resp, err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({
             handle: handle,
             role: sender.value,
@@ -752,6 +789,7 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
         ims.controlHasError(sender);
         return;
     }
+    visitETag = ims.etagOf(resp) ?? visitETag;
     ims.controlHasSuccess(sender);
 
     return;

--- a/web/typescripttest/field_report.test.ts
+++ b/web/typescripttest/field_report.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
+import { jsonResponse, loadFixture, mockFetch, problemResponse } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -28,6 +28,9 @@ const frUrl = `/ims/api/events/${eventName}/field_reports`;
 let serverEventAccess: ims.AuthInfoEventAccess;
 let serverFieldReport: ims.FieldReport;
 let serverEvents: ims.EventData[];
+// The field report's current ETag; edits through frRoutes bump it, the way
+// the server's version counter would.
+let serverETag: string;
 
 beforeEach((): void => {
     vi.resetModules();
@@ -61,6 +64,7 @@ beforeEach((): void => {
         ],
     };
     serverEvents = [{ id: eventId, name: eventName }];
+    serverETag = `"3"`;
 });
 
 function frRoutes(url: string, init?: RequestInit): Response | undefined {
@@ -77,11 +81,12 @@ function frRoutes(url: string, init?: RequestInit): Response | undefined {
         return jsonResponse(serverEvents);
     }
     if (url === `${frUrl}/7` && !hasBody) {
-        return jsonResponse(serverFieldReport);
+        return jsonResponse(serverFieldReport, 200, { "ETag": serverETag });
     }
     if (url.startsWith(`${frUrl}/7`) && hasBody) {
         // Edits and attach/detach.
-        return new Response(null, { status: 204 });
+        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
+        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
     }
     if (url === `/ims/api/events/${eventName}/incidents` && hasBody) {
         return new Response(null, { status: 201, headers: { "IMS-Incident-Number": "42" } });
@@ -156,6 +161,55 @@ test("a viewer without field-report read access sees an authorization error", as
 
     expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
     expect(document.getElementById("error_text")!.textContent).toContain("not currently authorized");
+});
+
+test("summary edits carry If-Match from the loaded ETag; note appends do not", async (): Promise<void> => {
+    const mock = await initFieldReportPage();
+
+    // A summary edit sends the ETag captured when the field report was loaded.
+    const summary = document.getElementById("field_report_summary") as HTMLInputElement;
+    summary.value = "Found the child";
+    await window.editSummary();
+    let posts = mock.mock.calls.filter(([u, init]) => u === `${frUrl}/7` && init?.body != null);
+    expect(posts).toHaveLength(1);
+    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBe(`"3"`);
+
+    // A report-entry append is unconditional.
+    mock.mockClear();
+    const textarea = document.getElementById("report_entry_add") as HTMLTextAreaElement;
+    textarea.value = "an update from the field";
+    window.reportEntryEdited();
+    await window.submitReportEntry();
+    posts = mock.mock.calls.filter(([u, init]) => u === `${frUrl}/7` && init?.body != null);
+    expect(posts).toHaveLength(1);
+    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBeNull();
+});
+
+test("a 412 conflict shows the conflict banner and refetches the field report", async (): Promise<void> => {
+    const mock = await initFieldReportPage();
+
+    const conflictRoutes = (url: string, init?: RequestInit): Response | undefined => {
+        if (url === `${frUrl}/7` && init?.body != null) {
+            return problemResponse("Someone else got here first", 412);
+        }
+        return frRoutes(url, init);
+    };
+    mock.mockImplementation(async (url: string, init?: RequestInit): Promise<Response> => {
+        const response = conflictRoutes(url, init);
+        if (response == null) {
+            throw new Error(`no mocked fetch route for ${url}`);
+        }
+        return response;
+    });
+
+    serverFieldReport.summary = "Their conflicting summary";
+    const summary = document.getElementById("field_report_summary") as HTMLInputElement;
+    summary.value = "My rejected summary";
+    await window.editSummary();
+
+    expect(document.getElementById("error_text")!.textContent).toContain(
+        "Someone else has edited this field report");
+    expect(inputValue("field_report_summary")).toBe("Their conflicting summary");
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {

--- a/web/typescripttest/helpers.ts
+++ b/web/typescripttest/helpers.ts
@@ -46,10 +46,11 @@ export function loadFixture(name: string): void {
 
 // Make a JSON Response like the IMS API would return. fetchNoThrow only
 // parses the body when the content-type is exactly "application/json".
-export function jsonResponse(body: unknown, status: number = 200): Response {
+// Extra headers (e.g. an ETag) are merged over the content-type.
+export function jsonResponse(body: unknown, status: number = 200, headers?: Record<string, string>): Response {
     return new Response(JSON.stringify(body), {
         status: status,
-        headers: { "content-type": "application/json" },
+        headers: { "content-type": "application/json", ...headers },
     });
 }
 

--- a/web/typescripttest/incident.test.ts
+++ b/web/typescripttest/incident.test.ts
@@ -19,13 +19,16 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
+import { jsonResponse, loadFixture, MockFlatpickr, mockFetch, problemResponse } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
 
 let serverEventAccess: ims.AuthInfoEventAccess;
 let serverIncident: ims.Incident;
+// The incident's current ETag; edits through incidentRoutes bump it, the way
+// the server's version counter would.
+let serverETag: string;
 let serverPersonnel: ims.Personnel[];
 let serverTypes: ims.IncidentType[];
 let serverEvents: ims.EventData[];
@@ -48,6 +51,7 @@ beforeEach((): void => {
         value: { request: (): Promise<undefined> => new Promise<undefined>((): void => {}) },
     });
 
+    serverETag = `"5"`;
     serverEventAccess = {
         event_id: eventId,
         readIncidents: true,
@@ -120,6 +124,11 @@ beforeEach((): void => {
     ];
 });
 
+// Increment a quoted-integer ETag, e.g. `"5"` -> `"6"`.
+function bumpETag(etag: string): string {
+    return `"${Number(etag.replaceAll(`"`, "")) + 1}"`;
+}
+
 function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
     const hasBody = init?.body != null;
     if (url === `/ims/api/auth?event_id=${eventName}`) {
@@ -149,7 +158,8 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
         return jsonResponse(serverVisits);
     }
     if (url.startsWith(`/ims/api/events/${eventName}/incidents/1/rangers/`)) {
-        return new Response(null, { status: 204 });
+        serverETag = bumpETag(serverETag);
+        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
     }
     if (url.startsWith(`/ims/api/events/${eventName}/incidents/1/report_entries/`) && hasBody) {
         return new Response(null, { status: 204 });
@@ -163,10 +173,11 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
         return new Response(null, { status: 201, headers: { "IMS-Incident-Number": "42" } });
     }
     if ((url === `/ims/api/events/${eventName}/incidents/1` || url === `/ims/api/events/${eventName}/incidents/42`) && !hasBody) {
-        return jsonResponse(serverIncident);
+        return jsonResponse(serverIncident, 200, { "ETag": serverETag });
     }
     if ((url === `/ims/api/events/${eventName}/incidents/1` || url === `/ims/api/events/${eventName}/incidents/42`) && hasBody) {
-        return new Response(null, { status: 204 });
+        serverETag = bumpETag(serverETag);
+        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
     }
     if (url === `/ims/api/events/${eventName}/field_reports/8` && !hasBody) {
         return jsonResponse(serverFieldReports.find((fr: ims.FieldReport): boolean => fr.number === 8));
@@ -200,6 +211,14 @@ function postedBodies(mock: ReturnType<typeof mockFetch>, url: string): unknown[
     return mock.mock.calls
         .filter(([u, init]): boolean => u === url && init?.body != null)
         .map(([, init]): unknown => JSON.parse(init!.body as string));
+}
+
+// The If-Match header of each POST to the given URL, oldest first
+// (null for a POST that carried no If-Match).
+function postedIfMatches(mock: ReturnType<typeof mockFetch>, url: string): (string|null)[] {
+    return mock.mock.calls
+        .filter(([u, init]): boolean => u === url && init?.body != null)
+        .map(([, init]): string|null => new Headers(init!.headers).get("If-Match"));
 }
 
 test("page init draws the incident fields from the API", async (): Promise<void> => {
@@ -343,6 +362,67 @@ test("editing the summary sends the edit and reloads the incident", async (): Pr
         { summary: "Bigger dust storm", number: 1 },
     ]);
     expect(summary.classList.contains("is-valid")).toBe(true);
+});
+
+test("field edits carry If-Match from the loaded ETag; note appends do not", async (): Promise<void> => {
+    const mock = await initIncidentPage();
+    const incidentURL = "/ims/api/events/2025/incidents/1";
+
+    // A field edit sends the ETag captured when the incident was loaded.
+    const summary = document.getElementById("incident_summary") as HTMLInputElement;
+    summary.value = "Bigger dust storm";
+    await window.editIncidentSummary();
+    expect(postedIfMatches(mock, incidentURL)).toEqual([`"5"`]);
+
+    // After the edit round-trip, the stored ETag is the server's new one.
+    mock.mockClear();
+    summary.value = "Even bigger dust storm";
+    await window.editIncidentSummary();
+    expect(postedIfMatches(mock, incidentURL)).toEqual([`"6"`]);
+
+    // A report-entry append is unconditional: it can't lose data, and it must
+    // not fail just because someone else edited a field.
+    mock.mockClear();
+    const textarea = document.getElementById("report_entry_add") as HTMLTextAreaElement;
+    textarea.value = "saw a thing";
+    window.reportEntryEdited();
+    await window.submitReportEntry();
+    expect(postedBodies(mock, incidentURL)).toEqual([
+        { report_entries: [{ text: "saw a thing", id: -1 }], number: 1 },
+    ]);
+    expect(postedIfMatches(mock, incidentURL)).toEqual([null]);
+});
+
+test("a 412 conflict shows the conflict banner and refetches the incident", async (): Promise<void> => {
+    const mock = await initIncidentPage();
+    const incidentURL = "/ims/api/events/2025/incidents/1";
+
+    // Someone else edited the incident: the next edit is rejected with a 412.
+    const conflictRoutes = (url: string, init?: RequestInit): Response | undefined => {
+        if (url === incidentURL && init?.body != null) {
+            return problemResponse("Someone else got here first", 412);
+        }
+        return incidentRoutes(url, init);
+    };
+    mock.mockImplementation(async (url: string, init?: RequestInit): Promise<Response> => {
+        const response = conflictRoutes(url, init);
+        if (response == null) {
+            throw new Error(`no mocked fetch route for ${url}`);
+        }
+        return response;
+    });
+
+    serverIncident.summary = "Their conflicting edit";
+    const summary = document.getElementById("incident_summary") as HTMLInputElement;
+    summary.value = "My rejected edit";
+    const { err } = await window.editIncidentSummary().then((): {err: string|null} => ({err: null}), (e: Error): {err: string} => ({err: e.message}));
+    expect(err).toBeNull();
+
+    // The user is told what happened, and the page refetched the other
+    // person's version of the incident.
+    expect(document.getElementById("error_text")!.textContent).toContain(
+        "Someone else has edited this incident");
+    expect(inputValue("incident_summary")).toBe("Their conflicting edit");
 });
 
 test("editState warns when closing an incident that has no incident types", async (): Promise<void> => {

--- a/web/typescripttest/sanctuary_visit.test.ts
+++ b/web/typescripttest/sanctuary_visit.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
+import { jsonResponse, loadFixture, mockFetch, problemResponse } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -29,6 +29,9 @@ let serverEventAccess: ims.AuthInfoEventAccess;
 let serverVisit: ims.Visit;
 let serverPersonnel: ims.Personnel[];
 let serverEvents: ims.EventData[];
+// The visit's current ETag; edits through visitRoutes bump it, the way the
+// server's version counter would.
+let serverETag: string;
 
 beforeEach((): void => {
     vi.resetModules();
@@ -65,6 +68,7 @@ beforeEach((): void => {
         { handle: "Tool", status: "active", directory_id: 2 },
     ];
     serverEvents = [{ id: eventId, name: eventName }];
+    serverETag = `"4"`;
 });
 
 function visitRoutes(url: string, init?: RequestInit): Response | undefined {
@@ -84,13 +88,15 @@ function visitRoutes(url: string, init?: RequestInit): Response | undefined {
         return jsonResponse(serverPersonnel);
     }
     if (url === `${visitsUrl}/2` && !hasBody) {
-        return jsonResponse(serverVisit);
+        return jsonResponse(serverVisit, 200, { "ETag": serverETag });
     }
     if (url === `${visitsUrl}/2` && hasBody) {
-        return new Response(null, { status: 204 });
+        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
+        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
     }
     if (url.startsWith(`${visitsUrl}/2/rangers/`) && hasBody) {
-        return new Response(null, { status: 204 });
+        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
+        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
     }
     if (url === `${visitsUrl}/2/attachments` && hasBody) {
         return new Response(null, { status: 200 });
@@ -131,6 +137,53 @@ test("editing the guest's preferred name posts the change to the visit", async (
 
     const editCall = mock.mock.calls.find(([url, init]) => url === `${visitsUrl}/2` && init?.body != null)!;
     expect(JSON.parse(editCall[1]!.body as string)).toMatchObject({ guest_preferred_name: "Stardust" });
+});
+
+test("field edits carry If-Match from the loaded ETag and refresh it from the response", async (): Promise<void> => {
+    const mock = await initVisitPage();
+
+    const nameField = document.getElementById("guest_preferred_name") as HTMLInputElement;
+    nameField.value = "Stardust";
+    await window.editGuestPreferredName();
+
+    let posts = mock.mock.calls.filter(([u, init]) => u === `${visitsUrl}/2` && init?.body != null);
+    expect(posts).toHaveLength(1);
+    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBe(`"4"`);
+
+    // The next edit carries the ETag produced by the first one.
+    mock.mockClear();
+    nameField.value = "Moonbeam";
+    await window.editGuestPreferredName();
+    posts = mock.mock.calls.filter(([u, init]) => u === `${visitsUrl}/2` && init?.body != null);
+    expect(posts).toHaveLength(1);
+    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBe(`"5"`);
+});
+
+test("a 412 conflict shows the conflict banner and refetches the visit", async (): Promise<void> => {
+    const mock = await initVisitPage();
+
+    const conflictRoutes = (url: string, init?: RequestInit): Response | undefined => {
+        if (url === `${visitsUrl}/2` && init?.body != null) {
+            return problemResponse("Someone else got here first", 412);
+        }
+        return visitRoutes(url, init);
+    };
+    mock.mockImplementation(async (url: string, init?: RequestInit): Promise<Response> => {
+        const response = conflictRoutes(url, init);
+        if (response == null) {
+            throw new Error(`no mocked fetch route for ${url}`);
+        }
+        return response;
+    });
+
+    serverVisit.guest_preferred_name = "Their Conflicting Name";
+    const nameField = document.getElementById("guest_preferred_name") as HTMLInputElement;
+    nameField.value = "My Rejected Name";
+    await window.editGuestPreferredName();
+
+    expect(document.getElementById("error_text")!.textContent).toContain(
+        "Someone else has edited this visit");
+    expect(inputValue("guest_preferred_name")).toBe("Their Conflicting Name");
 });
 
 test("adding a known ranger posts to that visit's ranger endpoint", async (): Promise<void> => {


### PR DESCRIPTION
We had a problem before with concurrent modification, in that two users touching the same Incident at the same time could stomp on each others' changes. This PR gets us using the ETag mechanism to prevent that sort of thing.