### PR TITLE
feat: allow editing state from Incidents page

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -340,6 +340,12 @@ h1 {
     display: none;
   }
 
+  /* The State dropdown already looks like plain text at rest; drop the space it
+     reserves for the caret it only shows on hover. */
+  .incident-state-select {
+    padding: 0;
+  }
+
   /*!* The below tweaks make the print version have multiple columns, like the desktop >768 px version. *!*/
   /*.col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {*/
   /*  float: left;*/
@@ -417,6 +423,31 @@ h1 {
 
 #queue_table>tbody>tr {
   cursor: pointer;
+}
+
+/* The State dropdown in each Incidents table row. At rest it looks like the plain text
+   it replaced, so that the State column stays as narrow as it was before the dropdown
+   existed. It shows its border and caret when the user is on the row or tabs into it.
+   The caret's space is reserved at rest, so revealing it doesn't reflow the row. */
+.incident-state-select {
+  width: auto;
+  display: inline-block;
+  padding: 0 1rem 0 0.25rem;
+  background-color: transparent;
+  background-image: none;
+  border-color: transparent;
+  cursor: pointer;
+  font-size: var(--font-size-smaller);
+}
+
+#queue_table>tbody>tr:hover .incident-state-select,
+.incident-state-select:hover,
+.incident-state-select:focus {
+  background-color: var(--bs-body-bg);
+  background-image: var(--bs-form-select-bg-img);
+  background-position: right 0.25rem center;
+  background-size: 10px 8px;
+  border-color: var(--bs-border-color);
 }
 
 #field_reports_table>tbody>tr {

--- a/web/template/incidents.templ
+++ b/web/template/incidents.templ
@@ -216,6 +216,17 @@ templ Incidents(deployment, versionName, versionRef, eventName string) {
 
     </div>
 
+    <!-- The State cell of each row, for users who are allowed to edit Incidents. -->
+    <template id="incident_state_template">
+      <select class="form-select form-select-sm incident-state-select">
+        <option value="new">New</option>
+        <option value="on_hold">On Hold</option>
+        <option value="dispatched">Dispatched</option>
+        <option value="on_scene">On Scene</option>
+        <option value="closed">Closed</option>
+      </select>
+    </template>
+
     <table id="queue_table" class="table table-striped table-hover">
       <caption class="visually-hidden">Incidents</caption>
       <thead>

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -983,7 +983,7 @@ export function renderDate(date: string|undefined, type: string, _incidentOrFROr
     }
 }
 
-export function renderState(state: IncidentState, type: string, incident: Incident): RenderValue {
+export function renderState(state: IncidentState, type: RenderType, incident: Incident): RenderValue {
     if (state == null) {
         state = stateForIncident(incident);
     }

--- a/web/typescript/incidents.ts
+++ b/web/typescript/incidents.ts
@@ -65,6 +65,8 @@ const el = {
     searchInput: ims.typedElement("search_input", HTMLInputElement),
     newIncident: ims.typedElement("new_incident", HTMLElement),
 
+    stateSelectTemplate: ims.typedElement("incident_state_template", HTMLTemplateElement),
+
     showState: ims.typedElement("show_state", HTMLButtonElement),
     showDays: ims.typedElement("show_days", HTMLButtonElement),
     showType: ims.typedElement("show_type", HTMLElement),
@@ -415,7 +417,7 @@ function initDataTables(tablePrereqs: Promise<void>): void {
                 "className": "incident_state text-center",
                 "data": "state",
                 "defaultContent": null,
-                "render": ims.renderState,
+                "render": renderState,
                 "responsivePriority": 3,
             },
             {   // 3
@@ -466,8 +468,9 @@ function initDataTables(tablePrereqs: Promise<void>): void {
         ],
         "createdRow": function (row: HTMLElement, incident: ims.Incident, _index: number) {
             const openLink = function(e: MouseEvent): void {
-                // If the user clicked on a link, then let them access that link without the JS below.
-                if (e.target?.constructor?.name === "HTMLAnchorElement") {
+                // If the user clicked on a link or on the row's State dropdown, let them use
+                // that control, rather than navigating away to the Incident.
+                if (e.target instanceof Element && e.target.closest("a, select") != null) {
                     return;
                 }
 
@@ -536,6 +539,93 @@ function renderIncidentTypes(ids: number[], type: ims.RenderType, _incident: ims
         default:
             return undefined;
     }
+}
+
+
+//
+// Incident state, which is editable from this page
+//
+
+// Render the State cell as a dropdown, so that an Incident's state can be changed
+// without opening the Incident. Users who can't write Incidents, and Incidents whose
+// state IMS doesn't recognize, get the plain text that every other page shows.
+//
+// This has to happen in the renderer, rather than in a createdCell callback, because
+// DataTables rewrites a cell from its "display" value whenever the row's data changes,
+// which here is on every update that arrives over SSE.
+function renderState(state: ims.IncidentState, type: ims.RenderType, incident: ims.Incident): ims.RenderValue {
+    const currentState: ims.IncidentState = ims.stateForIncident(incident);
+    if (type !== "display" || !ims.eventAccess?.writeIncidents ||
+        incident.number == null || currentState === "null") {
+        return ims.renderState(state, type, incident);
+    }
+
+    const fragment = el.stateSelectTemplate.content.cloneNode(true) as DocumentFragment;
+    const select = fragment.querySelector("select")!;
+    select.value = currentState;
+    select.ariaLabel = `State of Incident ${incident.number}`;
+    // The Incident this dropdown was drawn from is the one the user is looking at, so
+    // it's the right thing to diff against and to send an If-Match version from. A row
+    // that changes gets a new dropdown, drawn from the new data.
+    select.addEventListener("change", (): void => {
+        editIncidentState(select, incident);
+    });
+    return select;
+}
+
+async function editIncidentState(select: HTMLSelectElement, incident: ims.Incident): Promise<void> {
+    if (incident.number == null) {
+        return;
+    }
+    const newState = select.value as ims.IncidentState;
+
+    if (newState === "closed" && (incident.incident_type_ids??[]).length === 0) {
+        window.alert(
+            "Closing out this incident?\n"+
+            "Please add an incident type!\n\n" +
+            "Special cases:\n" +
+            "    Junk: for erroneously-created Incidents\n" +
+            "    Admin: for administrative information, i.e. not Incidents at all\n\n" +
+            "See the Incident Types help link for more details.\n"
+        );
+    }
+
+    // Send the version we drew this row from as If-Match, so that the server rejects the
+    // edit (412) if someone else has changed the Incident in the meantime.
+    const headers: HeadersInit = {};
+    if (incident.version != null) {
+        headers["If-Match"] = `"${incident.version}"`;
+    }
+
+    select.disabled = true;
+    const {resp, err} = await ims.fetchNoThrow(
+        ims.urlReplace(url_incidentNumber).replace("<incident_number>", incident.number.toString()),
+        {
+            headers: headers,
+            body: JSON.stringify({
+                number: incident.number,
+                state: newState,
+            }),
+        },
+    );
+    select.disabled = false;
+
+    if (err != null) {
+        let message = `Failed to update state of Incident ${incident.number}: ${err}`;
+        if (resp?.status === 412) {
+            message = `Someone else has edited Incident ${incident.number}. ` +
+                "That row will refresh with their changes; please retry your edit.";
+        }
+        console.error(message);
+        ims.setErrorMessage(message);
+        ims.controlHasError(select);
+        // Put the dropdown back to the state we last read from the server. If the row has
+        // since been redrawn, this select is detached and the redraw already did the job.
+        select.value = ims.stateForIncident(incident);
+        return;
+    }
+    ims.clearErrorMessage();
+    ims.controlHasSuccess(select);
 }
 
 

--- a/web/typescripttest/incidents.test.ts
+++ b/web/typescripttest/incidents.test.ts
@@ -21,7 +21,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, MockDataTable, mockFetch } from "./helpers.ts";
+import { jsonResponse, loadFixture, MockDataTable, mockFetch, problemResponse } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -196,6 +196,138 @@ test("the types column renders type names and handles missing ids", async (): Pr
     // Null ids (no types column data) render as undefined.
     expect(render(null, "display", incident)).toBeUndefined();
     expect(render(incident.incident_type_ids, "bogus", incident)).toBeUndefined();
+});
+
+// Render the state column for an incident and return the dropdown it produced,
+// or null if the column rendered plain text instead.
+function renderStateSelect(incident: ims.Incident): HTMLSelectElement|null {
+    const rendered = renderColumn("incident_state")(incident.state, "display", incident);
+    return rendered instanceof HTMLSelectElement ? rendered : null;
+}
+
+test("the state column renders a dropdown set to the incident's state", async (): Promise<void> => {
+    await initIncidentsPage();
+    const incident = serverIncidents[0]!; // on_scene
+
+    const select = renderStateSelect(incident)!;
+    expect(select).not.toBeNull();
+    expect(select.value).toBe("on_scene");
+    expect(select.ariaLabel).toContain("Incident 1");
+    // Every state IMS knows is offered.
+    const states = [...select.options].map((o: HTMLOptionElement) => o.value);
+    expect(states).toEqual(["new", "on_hold", "dispatched", "on_scene", "closed"]);
+});
+
+test("the state column renders plain text for a user who can't write incidents", async (): Promise<void> => {
+    serverEventAccess.writeIncidents = false;
+    await initIncidentsPage();
+    const incident = serverIncidents[0]!;
+
+    expect(renderStateSelect(incident)).toBeNull();
+    expect(renderColumn("incident_state")(incident.state, "display", incident)).toBe("On Scene");
+});
+
+test("the state column still renders sort and filter values", async (): Promise<void> => {
+    await initIncidentsPage();
+    const render = renderColumn("incident_state");
+    const incident = serverIncidents[0]!; // on_scene
+
+    expect(render(incident.state, "filter", incident)).toBe("On Scene");
+    // Sort keys order the states from new (1) through closed (5).
+    expect(render(incident.state, "sort", incident)).toBe(4);
+    expect(render(incident.state, "bogus", incident)).toBeUndefined();
+});
+
+// Accept a write to any single incident, on top of the usual page routes.
+function savingRoutes(url: string, init?: RequestInit): Response | undefined {
+    const incident = serverIncidents.find(i => url === `/ims/api/events/${eventName}/incidents/${i.number}`);
+    if (incident != null) {
+        return jsonResponse(incident);
+    }
+    return incidentsRoutes(url, init);
+}
+
+test("changing the state dropdown saves the new state with an If-Match version", async (): Promise<void> => {
+    serverIncidents[0]!.version = 7;
+    const mock = await initIncidentsPage(savingRoutes);
+    const select = renderStateSelect(serverIncidents[0]!)!;
+
+    select.value = "closed";
+    select.dispatchEvent(new Event("change"));
+
+    await vi.waitFor((): void => {
+        expect(mock.mock.calls.some(([url]) => url === `/ims/api/events/${eventName}/incidents/1`)).toBe(true);
+    });
+    const [, init] = mock.mock.calls.find(([url]) => url === `/ims/api/events/${eventName}/incidents/1`)!;
+    expect(init!.method).toBe("POST");
+    expect(JSON.parse(init!.body as string)).toEqual({ number: 1, state: "closed" });
+    expect(new Headers(init!.headers).get("If-Match")).toBe('"7"');
+    expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(true);
+});
+
+test("a failed state change reverts the dropdown and shows the error", async (): Promise<void> => {
+    const handler = (url: string, init?: RequestInit): Response | undefined => {
+        if (url === `/ims/api/events/${eventName}/incidents/1`) {
+            return problemResponse("Nope", 500);
+        }
+        return incidentsRoutes(url, init);
+    };
+    await initIncidentsPage(handler);
+    const select = renderStateSelect(serverIncidents[0]!)!; // on_scene
+
+    select.value = "closed";
+    select.dispatchEvent(new Event("change"));
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
+    });
+    // The dropdown goes back to the state the server last gave us.
+    expect(select.value).toBe("on_scene");
+    expect(select.classList.contains("is-invalid")).toBe(true);
+    expect(select.disabled).toBe(false);
+});
+
+test("a conflicting state change reports that someone else edited the incident", async (): Promise<void> => {
+    const handler = (url: string, init?: RequestInit): Response | undefined => {
+        if (url === `/ims/api/events/${eventName}/incidents/1`) {
+            return problemResponse("Version mismatch", 412);
+        }
+        return incidentsRoutes(url, init);
+    };
+    await initIncidentsPage(handler);
+    const select = renderStateSelect(serverIncidents[0]!)!;
+
+    select.value = "closed";
+    select.dispatchEvent(new Event("change"));
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_text")!.textContent).toContain("Someone else has edited");
+    });
+});
+
+test("closing an incident with no incident type warns the user, but still saves", async (): Promise<void> => {
+    // happy-dom doesn't implement window.alert.
+    const alertSpy = vi.fn();
+    vi.stubGlobal("alert", alertSpy);
+    const mock = await initIncidentsPage(savingRoutes);
+    // serverIncidents[1] has no incident types.
+    const select = renderStateSelect(serverIncidents[1]!)!;
+
+    select.value = "closed";
+    select.dispatchEvent(new Event("change"));
+
+    expect(alertSpy).toHaveBeenCalledOnce();
+    expect(alertSpy.mock.calls[0]![0]).toContain("Please add an incident type");
+    await vi.waitFor((): void => {
+        expect(mock.mock.calls.some(([url]) => url === `/ims/api/events/${eventName}/incidents/2`)).toBe(true);
+    });
+
+    // An incident that has a type draws no warning.
+    alertSpy.mockClear();
+    const typed = renderStateSelect(serverIncidents[0]!)!;
+    typed.value = "closed";
+    typed.dispatchEvent(new Event("change"));
+    expect(alertSpy).not.toHaveBeenCalled();
 });
 
 test("the state filter shows open, active, and all states correctly", async (): Promise<void> => {


### PR DESCRIPTION
The Operators have been requesting this for a while. I think I'll wait until post-2026 event to merge this though, because it's too close to event time to be changing features.