### PR TITLE
fix: stop using flatpickr on admin_events page

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -11,6 +11,7 @@ tmp_dir = "air_tmp"
     "node_modules",
     "playwright",
     "ims-attachments",
+    "web/typescripttest",
     ".git",
     ".idea",
   ]
@@ -18,7 +19,6 @@ tmp_dir = "air_tmp"
     "compose.ranger-ims-go",
     "web/template/*_templ.go",
     "web/static/*.js",
-    "web/typescripttest/*",
     "store/imsdb/*.go",
     "directory/clubhousedb/*.go",
     "coverage.out",

--- a/web/template/adminevents.templ
+++ b/web/template/adminevents.templ
@@ -88,7 +88,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
     <li><strong>Always</strong> - valid all year long</li>
     <li><strong>On-Site</strong> - valid only when a matching Ranger is marked "on-site" in Clubhouse</li>
   </ul>
-  <p>Click "Set dates" on a rule to set a <strong>not-after</strong> time, after which the rule will stop granting access, and/or a <strong>not-before</strong> time, before which the rule will not yet grant access. Times are shown in your time zone (<span id="browser_tz"></span>).</p>
+  <p>Use a rule's date fields to set a <strong>not-after</strong> time, after which the rule will stop granting access, and/or a <strong>not-before</strong> time, before which the rule will not yet grant access. Type a time like <strong id="date_format_example"></strong> and clear the field to remove it. Times are in your time zone (<span id="browser_tz"></span>).</p>
   <p>A rule with an invalid person, position, or team name is highlighted as an "Unknown target", and the event's header shows a count of such issues. Use the rule's "Fix" button to correct a typo.</p>
   <p>You can click the "Explain" button to see which Rangers currently match which rules, based on Clubhouse position/team mappings, validity rules, and expiration times.</p>
   <datalist id="access_target_list"></datalist>
@@ -176,22 +176,20 @@ templ AdminEvents(deployment, versionName, versionRef string) {
       </td>
       <td>
         <span class="d-flex align-items-center flex-wrap column-gap-2">
-          <button type="button" class="access_dates_toggle btn btn-sm btn-link p-0 d-none" title="Set not-before/not-after times for this rule">Set dates</button>
-          <button type="button" class="access_dates_badge badge btn btn-secondary d-none" title="Click to edit the not-before/not-after times"></button>
           <span class="access_interval_text badge text-bg-warning d-none"></span>
-          <span class="access_dates d-none">
+          <span class="access_dates">
             <input
-                class="access_not_before p-1 me-1 auto-width"
+                class="access_not_before form-control form-control-sm auto-width me-1"
                 type="text"
                 aria-label="Not before time"
-                title="Not before: permission does not grant access before this time (your browser's time zone)"
+                title="Not before: permission does not grant access before this time (your browser's time zone). E.g. Sun 2026-08-23 @ 12:00"
                 placeholder="Not before"
             />
             <input
-                class="access_not_after p-1 auto-width"
+                class="access_not_after form-control form-control-sm auto-width"
                 type="text"
                 aria-label="Not after time"
-                title="Not after: permission stops granting access after this time (your browser's time zone)"
+                title="Not after: permission stops granting access after this time (your browser's time zone). E.g. Sun 2026-08-23 @ 12:00"
                 placeholder="Not after"
             />
           </span>

--- a/web/typescript/admin_events.ts
+++ b/web/typescript/admin_events.ts
@@ -40,6 +40,7 @@ let editEventModal: ims.bootstrap.Modal|null = null;
 
 const el = {
     browserTz: ims.typedElement("browser_tz", HTMLElement),
+    dateFormatExample: ims.typedElement("date_format_example", HTMLElement),
     explainModal: ims.typedElement("explainModal", HTMLElement),
     editEventModal: ims.typedElement("editEventModal", HTMLElement),
     eventAccessContainer: ims.typedElement("event_access_container", HTMLElement),
@@ -78,6 +79,8 @@ async function initAdminEventsPage(): Promise<void> {
     window.setMapURL = setMapURL;
 
     el.browserTz.textContent = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // Show the current time as the example, so it's useful to copy-paste from.
+    el.dateFormatExample.textContent = formatDateForInput(new Date());
 
     await Promise.all([loadAccessControlList(), loadAccessTargets()]);
     expandEventsWithRules();
@@ -130,11 +133,8 @@ let sortedEvents: ims.EventData[];
 let accessControlList: EventsAccess|null = null;
 // All valid rule expressions (e.g. "person:Tool"), or null if they couldn't be fetched.
 let validExpressions: Set<string>|null = null;
-let flatpickrIdCounter = 0;
 // Names of events whose rule tables are currently expanded.
 const expandedEvents = new Set<string>();
-// Rules (keyed by event|mode|expression) whose date editors are currently shown.
-const openDateEditors = new Set<string>();
 
 async function loadAccessControlList() : Promise<{err: string|null}> {
     const {json: eventsJson, err: eventsErr} = await ims.fetchNoThrow<ims.EventData[]>(url_events + "?include_groups=true", {
@@ -244,7 +244,7 @@ function eventCard(event: ims.EventData): DocumentFragment {
     if (event.parent_group) {
         const parentGroup = sortedEvents.find(value => {return value.id === event.parent_group});
         if (parentGroup) {
-            eventWithGroupName += ` (inherits ${parentGroup.name})`;
+            eventWithGroupName += ` (extends ${parentGroup.name})`;
         }
     }
     card.querySelector(".event_name")!.textContent = eventWithGroupName;
@@ -321,7 +321,7 @@ function eventCard(event: ims.EventData): DocumentFragment {
             if (ruleHasIssue(accessEntry)) {
                 issueCount++;
             }
-            tbody.append(ruleRow(event.name, mode, accessEntry));
+            tbody.append(ruleRow(mode, accessEntry));
         }
     }
 
@@ -409,7 +409,7 @@ function explainMsgsForEvent(event: ims.EventData): string[] {
     return explainMsgs;
 }
 
-function ruleRow(event: string, mode: AccessMode, accessEntry: Access): HTMLTableRowElement {
+function ruleRow(mode: AccessMode, accessEntry: Access): HTMLTableRowElement {
     const rowFrag = el.accessRuleTemplate.content.cloneNode(true) as DocumentFragment;
     const row = rowFrag.querySelector("tr")!;
 
@@ -427,53 +427,31 @@ function ruleRow(event: string, mode: AccessMode, accessEntry: Access): HTMLTabl
     const validityField = row.querySelector(".access_validity") as HTMLSelectElement;
     validityField.value = accessEntry.validity;
 
-    const notBeforeInput = row.querySelector(".access_not_before") as ims.FlatpickrHTMLInputElement;
-    ims.newFlatpickr(notBeforeInput, `alt_not_before_${flatpickrIdCounter++}`, (selectedDates) => {
-        saveNotBefore(row, selectedDates[0] ?? null);
-    });
+    const notBeforeInput = row.querySelector(".access_not_before") as HTMLInputElement;
     if (accessEntry.not_before) {
-        notBeforeInput._flatpickr.setDate(new Date(accessEntry.not_before), false, "Z");
+        notBeforeInput.value = formatDateForInput(new Date(accessEntry.not_before));
     }
-
-    const notAfterInput = row.querySelector(".access_not_after") as ims.FlatpickrHTMLInputElement;
-    ims.newFlatpickr(notAfterInput, `alt_not_after_${flatpickrIdCounter++}`, (selectedDates) => {
-        saveNotAfter(row, selectedDates[0] ?? null);
-    });
-    if (accessEntry.not_after) {
-        notAfterInput._flatpickr.setDate(new Date(accessEntry.not_after), false, "Z");
-    }
-
-    // Most rules have no dates, so the date pickers stay hidden until the rule
-    // has a date range (date badge) or the user asks for one ("Set dates" button).
-    const datesKey = `${event}|${mode}|${accessEntry.expression}`;
-    const datesSpan = row.querySelector(".access_dates") as HTMLElement;
-    const datesToggle = row.querySelector(".access_dates_toggle") as HTMLButtonElement;
-    const datesBadge = row.querySelector(".access_dates_badge") as HTMLButtonElement;
-    const showDateEditors = (): void => {
-        datesSpan.classList.remove("d-none");
-        datesToggle.classList.add("d-none");
-        datesBadge.classList.add("d-none");
-        openDateEditors.add(datesKey);
-    };
-    datesToggle.addEventListener("click", showDateEditors);
-    datesBadge.addEventListener("click", showDateEditors);
-    if (accessEntry.not_before || accessEntry.not_after) {
-        const notBefore = accessEntry.not_before ? notBeforeInput._flatpickr.altInput!.value : null;
-        const notAfter = accessEntry.not_after ? notAfterInput._flatpickr.altInput!.value : null;
-        if (notBefore && notAfter) {
-            datesBadge.textContent = `${notBefore} → ${notAfter}`;
-        } else if (notBefore) {
-            datesBadge.textContent = `from ${notBefore}`;
-        } else {
-            datesBadge.textContent = `until ${notAfter}`;
+    notBeforeInput.addEventListener("change", (): void => {
+        const date = parseDateInput(notBeforeInput.value);
+        if (date === undefined) {
+            ims.controlHasError(notBeforeInput);
+            return;
         }
-        datesBadge.classList.remove("d-none");
-    } else {
-        datesToggle.classList.remove("d-none");
+        saveNotBefore(row, date);
+    });
+
+    const notAfterInput = row.querySelector(".access_not_after") as HTMLInputElement;
+    if (accessEntry.not_after) {
+        notAfterInput.value = formatDateForInput(new Date(accessEntry.not_after));
     }
-    if (openDateEditors.has(datesKey)) {
-        showDateEditors();
-    }
+    notAfterInput.addEventListener("change", (): void => {
+        const date = parseDateInput(notAfterInput.value);
+        if (date === undefined) {
+            ims.controlHasError(notAfterInput);
+            return;
+        }
+        saveNotAfter(row, date);
+    });
 
     const intervalText = row.querySelector(".access_interval_text") as HTMLSpanElement;
     let intervalStatus = "";
@@ -519,6 +497,42 @@ function displayMode(m: AccessMode): string {
         default:
             throw new Error(`unexpected access mode ${m satisfies never}`);
     }
+}
+
+// Format a date for display in a rule's date input, in the browser's time zone,
+// e.g. "Sun 2026-08-23 @ 12:00". This matches the format parseDateInput accepts.
+function formatDateForInput(date: Date): string {
+    const weekday = new Intl.DateTimeFormat("en-US", {weekday: "short"}).format(date);
+    return `${weekday} ${ims.localDateISO(date)} @ ${ims.localTimeHHMM(date)}`;
+}
+
+// Parse a human-entered datetime into a Date in the browser's time zone. Returns
+// null for empty input (the date is being cleared), or undefined if the input
+// couldn't be parsed. It's lenient: an optional weekday prefix and "@" separator
+// are ignored, so it round-trips formatDateForInput's output, and the time is
+// optional (defaulting to midnight).
+function parseDateInput(input: string): Date|null|undefined {
+    const trimmed = input.trim();
+    if (trimmed === "") {
+        return null;
+    }
+    const match = trimmed.match(/(\d{4})-(\d{1,2})-(\d{1,2})(?:[\sT@]+(\d{1,2}):(\d{2}))?\s*$/);
+    if (match == null) {
+        return undefined;
+    }
+    const year = ims.parseInt10(match[1]!)!;
+    const month = ims.parseInt10(match[2]!)!;
+    const day = ims.parseInt10(match[3]!)!;
+    const hour = match[4] != null ? ims.parseInt10(match[4])! : 0;
+    const minute = match[5] != null ? ims.parseInt10(match[5])! : 0;
+    if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 || minute > 59) {
+        return undefined;
+    }
+    const date = new Date(year, month - 1, day, hour, minute);
+    if (Number.isNaN(date.getTime())) {
+        return undefined;
+    }
+    return date;
 }
 
 async function addEvent(sender: HTMLInputElement, type: "group"|"not-group"): Promise<void> {

--- a/web/typescripttest/admin_events.test.ts
+++ b/web/typescripttest/admin_events.test.ts
@@ -144,29 +144,66 @@ test("a rule with an unknown target is flagged and its event auto-expands", asyn
     expect(row.querySelector(".fix_button")!.classList.contains("d-none")).toBe(false);
 });
 
-test("a rule with dates shows a badge that reveals the date editors on click", async (): Promise<void> => {
+test("date fields are always shown, with a rule's dates displayed in them", async (): Promise<void> => {
     await initAdminEventsPage();
 
     const rows = ruleRows(eventCards()[0]!);
 
-    // The dateless reader rule offers the "Set dates" button, no badge.
+    // Both rows show their date editors inline, with no toggle or badge.
     const reader = rows[0]!;
-    expect(reader.querySelector(".access_dates_toggle")!.classList.contains("d-none")).toBe(false);
-    expect(reader.querySelector(".access_dates_badge")!.classList.contains("d-none")).toBe(true);
+    expect(reader.querySelector(".access_dates")!.classList.contains("d-none")).toBe(false);
+    // The dateless reader rule has empty date inputs.
+    expect((reader.querySelector(".access_not_before") as HTMLInputElement).value).toBe("");
+    expect((reader.querySelector(".access_not_after") as HTMLInputElement).value).toBe("");
 
-    // The writer rule has dates, summarized in a badge; the date editors stay
-    // hidden until the badge is clicked.
+    // The writer rule has dates, shown formatted like "Sun 2025-08-24 @ 12:00"
+    // in the browser's time zone (so an exact match here would be TZ-dependent).
     const writer = rows[1]!;
-    const badge = writer.querySelector(".access_dates_badge") as HTMLButtonElement;
-    expect(badge.classList.contains("d-none")).toBe(false);
-    expect(badge.textContent).toContain("→");
-    expect(writer.querySelector(".access_dates_toggle")!.classList.contains("d-none")).toBe(true);
-    const editors = writer.querySelector(".access_dates")!;
-    expect(editors.classList.contains("d-none")).toBe(true);
+    expect(writer.querySelector(".access_dates")!.classList.contains("d-none")).toBe(false);
+    const dateFormat = /^[A-Z][a-z]{2} \d{4}-\d{2}-\d{2} @ \d{2}:\d{2}$/;
+    expect((writer.querySelector(".access_not_before") as HTMLInputElement).value).toMatch(dateFormat);
+    expect((writer.querySelector(".access_not_after") as HTMLInputElement).value).toMatch(dateFormat);
+});
 
-    badge.click();
-    expect(editors.classList.contains("d-none")).toBe(false);
-    expect(badge.classList.contains("d-none")).toBe(true);
+test("typing a date into a rule's field posts the parsed not-before time", async (): Promise<void> => {
+    const mock = await initAdminEventsPage();
+
+    const reader = ruleRows(eventCards()[0]!)[0]!;
+    const notBefore = reader.querySelector(".access_not_before") as HTMLInputElement;
+    notBefore.value = "Sun 2025-08-24 @ 12:00";
+    notBefore.dispatchEvent(new Event("change"));
+
+    const postCall = await vi.waitFor(() => {
+        const call = mock.mock.calls.find(
+            ([url, init]) => url === url_acl && init?.body != null,
+        );
+        expect(call).toBeDefined();
+        return call!;
+    });
+    const body = JSON.parse(postCall[1]!.body as string);
+    const rule = body["2025"].readers[0];
+    expect(rule.expression).toBe("person:Tool");
+    // The typed local time is serialized as a UTC ISO instant.
+    expect(rule.not_before).toBe(new Date(2025, 7, 24, 12, 0).toISOString());
+});
+
+test("clearing a rule's date field posts a null not-before time", async (): Promise<void> => {
+    const mock = await initAdminEventsPage();
+
+    const writer = ruleRows(eventCards()[0]!)[1]!;
+    const notBefore = writer.querySelector(".access_not_before") as HTMLInputElement;
+    notBefore.value = "";
+    notBefore.dispatchEvent(new Event("change"));
+
+    const postCall = await vi.waitFor(() => {
+        const call = mock.mock.calls.find(
+            ([url, init]) => url === url_acl && init?.body != null,
+        );
+        expect(call).toBeDefined();
+        return call!;
+    });
+    const body = JSON.parse(postCall[1]!.body as string);
+    expect(body["2025"].writers[0].not_before).toBe(null);
 });
 
 test("clicking the card header toggles the collapse, except on its buttons", async (): Promise<void> => {


### PR DESCRIPTION
There were too many date inputs, and the whole page would slow down noticeably trying to render them all. This is an admin-only page, so it's fine to deprioritize UX and get users to input datetimes manually.