### PR TITLE
refactor: tidy CSS font-size rules and refine admin events UI

### DIFF
--- a/playwright/tests/ims.spec.ts
+++ b/playwright/tests/ims.spec.ts
@@ -269,7 +269,7 @@ test("admin_events", async ({ browser }) => {
   // The new writer lands in a "Write all" grant, flagged as an unknown target.
   await expect(grant.locator(".grant_level_badge")).toHaveText("Write all");
   await expect(grant.locator(".who-chip").filter({hasText: "person:SomeGuy"})).toHaveClass(/who-unknown/);
-  await expect(card.locator(".rule_count")).toHaveText("1 grant · 1 person");
+  await expect(card.locator(".rule_count")).toHaveText("1 grant · 1 expression");
   await expect(card.locator(".issue_count")).toHaveText("1 issue");
 
   // Edit the grant's terms all at once: make it On-Site and set a not-after

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -52,7 +52,6 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 .table {
-  font-size: var(--font-size-smaller);
   --bs-table-color: var(--bs-body-color);
   --bs-table-striped-color: var(--bs-body-color);
 }
@@ -61,28 +60,14 @@ h1, h2, h3, h4, h5, h6 {
   font-size: var(--font-size-smallest);
 }
 
-.btn-sm {
-  font-size: var(--font-size-smaller);
+.btn-sm,
+.btn-xs {
   border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
 }
 
 .btn-xs {
-  font-size: var(--font-size-smaller);
   --bs-btn-padding-y: 0.1rem;
   --bs-btn-padding-x: 0.3rem;
-}
-
-.btn-xs {
-  font-size: var(--font-size-smaller);
-  border: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color) !important;
-}
-
-.text-smaller {
-  font-size: var(--font-size-smaller);
-}
-
-.text-size-normal {
-  font-size: 1rem !important;
 }
 
 .form-control-static {
@@ -95,25 +80,20 @@ h1, h2, h3, h4, h5, h6 {
   padding-bottom: 0;
 }
 
-/*.table-hover > tbody > tr:hover {*/
-/*  background-color: #FFFF00;*/
-/*}*/
+.auto-width {
+  width: auto;
+  display: inline;        /* .form-control is display:block, which would break the flow */
+  field-sizing: content;  /* Automatically fits the text length */
+  min-width: 100px;       /* Keeps it from completely collapsing when empty */
+}
 
-.table > tbody > tr > td,
-.table > tbody > tr > th,
-.table > tfoot > tr > td,
-.table > tfoot > tr > th,
-.table > thead > tr > td,
-.table > thead > tr > th {
+/* Tighter than Bootstrap's 0.5rem default, looser than .table-sm's 0.25rem. */
+.table > :not(caption) > * > * {
   padding: 0.3rem;
 }
 
 .footer-hr {
   margin: 0;
-}
-
-.footer-text {
-  font-size: var(--font-size-smaller);
 }
 
 .nonprod-warning {
@@ -139,28 +119,17 @@ h1, h2, h3, h4, h5, h6 {
   font-size: var(--font-size-smaller);
 }
 
-.auto-width {
-  width: auto;
-  display: inline;
+.report_entry_system,
+.report_entry_stricken {
+  filter: opacity(75%);
 }
 
-.report_entry_system {
-  font-size: var(--font-size-smaller);
-  filter: opacity(75%);
+.report_entry_stricken {
+  text-decoration: line-through;
 }
 
 .report_entry_system > .report_entry_text {
   margin: 0 0 0 0.5rem;
-}
-
-.report_entry_stricken {
-  font-size: var(--font-size-smaller);
-  filter: opacity(75%);
-  text-decoration: line-through;
-}
-
-.report_entry_text {
-  font-size: var(--font-size-smaller);
 }
 
 .report_entry_metadata {
@@ -171,25 +140,29 @@ h1, h2, h3, h4, h5, h6 {
   margin: 0.9rem 0 0 0;
 }
 
-.form-control {
+/*
+ * The app runs at a smaller type scale than Bootstrap's default. Anything that
+ * needs to opt in explicitly can use .text-smaller (or Bootstrap's .fs-6 to opt
+ * back out to 1rem).
+ */
+.table,
+.btn-sm,
+.btn-xs,
+.form-control,
+.control-label,
+.control-follow-text,
+.search-box,
+.dt-info,
+.footer-text,
+.report_entry_text,
+.report_entry_system,
+.report_entry_stricken,
+.text-smaller {
   font-size: var(--font-size-smaller);
 }
 
 .control-label {
   font-weight: 700;
-  font-size: var(--font-size-smaller);
-}
-
-.control-follow-text {
-  font-size: var(--font-size-smaller);
-}
-
-.search-box {
-  font-size: var(--font-size-smaller);
-}
-
-.dt-info {
-  font-size: var(--font-size-smaller);
 }
 
 /*
@@ -237,36 +210,16 @@ h1 {
   display: none;
 }
 
-.no-touch .list-group-item:hover .remove-badge {
-  display: inline-block;
-}
-.no-touch .report_entry:hover .remove-badge {
+.no-touch :is(.list-group-item, .report_entry):hover .remove-badge {
   display: inline-block;
 }
 
-/* Disable on touch devices if editing is disabled. */
-.no-edit .remove-badge {
+/* Disable on touch devices, and override the hover behavior above, if editing
+   is disabled. */
+.no-edit .remove-badge,
+.no-edit :is(.list-group-item, .report_entry):hover .remove-badge,
+.no-edit :is(.new_incident, .new_field_report) {
   display: none;
-}
-
-/* Override hover behavior if editing is disabled. */
-.no-edit .list-group-item:hover .remove-badge {
-  display: none;
-}
-.no-edit .report_entry:hover .remove-badge {
-  display: none;
-}
-
-.no-edit .new_incident {
-  display: none;
-}
-
-.no-edit .new_field_report {
-  display: none;
-}
-
-#report_entry_well > .panel {
-  margin-bottom: 0.5rem;
 }
 
 #report_entry_add {
@@ -275,20 +228,9 @@ h1 {
   field-sizing: content;
 }
 
-.item-hidden > .badge-visible {
-  display: none;
-}
-
+.item-hidden > .badge-visible,
 .item-visible > .badge-hidden {
   display: none;
-}
-
-.badge-visible {
-  float: right !important;
-}
-
-.badge-hidden {
-  float: right !important;
 }
 
 /*
@@ -314,11 +256,7 @@ h1 {
   --bs-btn-hover-border-color: var(--bs-border-color);
 }
 
-.hide-history .report_entry_system {
-  display: none;
-}
-
-.hide-history .report_entry_stricken {
+.hide-history :is(.report_entry_system, .report_entry_stricken) {
   display: none;
 }
 
@@ -339,47 +277,6 @@ h1 {
   .no-print {
     display: none;
   }
-
-  /*!* The below tweaks make the print version have multiple columns, like the desktop >768 px version. *!*/
-  /*.col-sm-1, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9, .col-sm-10, .col-sm-11, .col-sm-12 {*/
-  /*  float: left;*/
-  /*}*/
-  /*.col-sm-12 {*/
-  /*  width: 100%;*/
-  /*}*/
-  /*.col-sm-11 {*/
-  /*  width: 91.67%;*/
-  /*}*/
-  /*.col-sm-10 {*/
-  /*  width: 83.33%;*/
-  /*}*/
-  /*.col-sm-9 {*/
-  /*  width: 75%;*/
-  /*}*/
-  /*.col-sm-8 {*/
-  /*  width: 66.67%;*/
-  /*}*/
-  /*.col-sm-7 {*/
-  /*  width: 58.33%;*/
-  /*}*/
-  /*.col-sm-6 {*/
-  /*  width: 50%;*/
-  /*}*/
-  /*.col-sm-5 {*/
-  /*  width: 41.67%;*/
-  /*}*/
-  /*.col-sm-4 {*/
-  /*  width: 33.33%;*/
-  /*}*/
-  /*.col-sm-3 {*/
-  /*  width: 25%;*/
-  /*}*/
-  /*.col-sm-2 {*/
-  /*  width: 16.67%;*/
-  /*}*/
-  /*.col-sm-1 {*/
-  /*  width: 8.33%;*/
-  /*}*/
 
   /* don't print the full name under the abbreviation */
   abbr[title]:after {
@@ -415,26 +312,9 @@ h1 {
   font-weight: 600;
 }
 
-#queue_table>tbody>tr {
-  cursor: pointer;
-}
-
-#field_reports_table>tbody>tr {
-  cursor: pointer;
-}
-
-#visits_table>tbody>tr {
-  cursor: pointer;
-}
-
-#places_table>tbody>tr {
-  cursor: pointer;
-}
-
-#search_results_table>tbody>tr {
-  cursor: pointer;
-}
-
+/* Rows in these tables are click-to-open. They're rendered by DataTables, so
+   the rows can't carry .show-pointer themselves. */
+:is(#queue_table, #field_reports_table, #visits_table, #places_table, #search_results_table) > tbody > tr,
 .show-pointer {
   cursor: pointer;
 }
@@ -478,6 +358,17 @@ h1 {
 }
 
 /*
+ * Plain-language gloss for an expression whose literal form is opaque, e.g. "*".
+ * Roman and muted, so it reads as an annotation rather than part of the
+ * monospace expression the admin actually typed.
+ */
+.who-gloss {
+  font-family: var(--bs-body-font-family);
+  color: var(--bs-secondary-color);
+  margin-left: 0.4rem;
+}
+
+/*
  * A chip whose target doesn't match any known person, position, or team. Use
  * Bootstrap's coordinated subtle-background / emphasis-text danger tokens,
  * which are contrast-checked in both themes (a plain --bs-danger foreground on
@@ -516,9 +407,7 @@ h1 {
   height: 100%;
   z-index: 1000;
   top: 40%;
-  left: 0px;
-  /*opacity: 0.5;*/
-  /*filter: alpha(opacity=50);*/
+  left: 0;
 }
 
 .white-space-pre-wrap {
@@ -540,13 +429,4 @@ h1 {
 
 .hover-placeholder:hover::placeholder {
   opacity: 1;
-}
-
-.w-160 {
-  width: 150px !important;
-}
-
-.auto-width {
-  field-sizing: content;  /* Automatically fits the text length */
-  min-width: 100px;       /* Keeps it from completely collapsing when empty */
 }

--- a/web/template/adminactionlogs.templ
+++ b/web/template/adminactionlogs.templ
@@ -36,7 +36,7 @@ templ AdminActionLogs(deployment, versionName, versionRef string) {
   <div class="col-md mb-2">
     <div class="form-floating">
       <input id="filter_min_time" type="text" name="Minimum time"
-             class="form-control text-size-normal"
+             class="form-control fs-6"
              onchange="updateTable()"/>
       <label for="filter_min_time">Minimum Time</label>
     </div>
@@ -44,7 +44,7 @@ templ AdminActionLogs(deployment, versionName, versionRef string) {
   <div class="col-md mb-2">
     <div class="form-floating">
       <input id="filter_max_time" type="text" name="Maximum time"
-             class="form-control text-size-normal"
+             class="form-control fs-6"
              onchange="updateTable()"/>
       <label for="filter_max_time">Maximum Time</label>
     </div>
@@ -54,7 +54,7 @@ templ AdminActionLogs(deployment, versionName, versionRef string) {
   <div class="col-md mb-2">
     <div class="form-floating">
       <input id="filter_user_name" type="text" inputmode="latin-name"
-             class="form-control text-size-normal"
+             class="form-control fs-6"
              onchange="updateTable()"/>
       <label for="filter_user_name">User</label>
     </div>
@@ -62,7 +62,7 @@ templ AdminActionLogs(deployment, versionName, versionRef string) {
   <div class="col-md mb-2">
     <div class="form-floating">
       <input id="filter_path" type="text" inputmode="latin-name"
-             class="form-control text-size-normal"
+             class="form-control fs-6"
              onchange="updateTable()"
              value="/ims/api/auth"/>
       <label for="filter_path">Path</label>

--- a/web/template/admindirectory.templ
+++ b/web/template/admindirectory.templ
@@ -123,7 +123,7 @@ templ AdminDirectory(deployment, versionName, versionRef string) {
         <div class="card-footer">
           <label>Add person:</label>
           <input
-              class="form-control input-sm auto-width"
+              class="form-control auto-width"
               type="text" inputmode="verbatim"
               disabled=""
               placeholder="Handle"
@@ -158,7 +158,7 @@ templ AdminDirectory(deployment, versionName, versionRef string) {
         <div class="card-footer">
           <label>Add team:</label>
           <input
-              class="form-control input-sm auto-width"
+              class="form-control auto-width"
               type="text" inputmode="verbatim"
               disabled=""
               placeholder="Green Dot"
@@ -176,7 +176,7 @@ templ AdminDirectory(deployment, versionName, versionRef string) {
         <div class="card-footer">
           <label>Add position:</label>
           <input
-              class="form-control input-sm auto-width"
+              class="form-control auto-width"
               type="text" inputmode="verbatim"
               disabled=""
               placeholder="Khaki"

--- a/web/template/adminevents.templ
+++ b/web/template/adminevents.templ
@@ -96,7 +96,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
           <button type="button" class="access_collapse_toggle btn fw-bold fs-5 p-0 border-0" data-bs-toggle="collapse">
             <span class="access_collapse_chevron me-1" aria-hidden="true">&#9656;</span><span class="event_name"></span>
           </button>
-          <span class="rule_count badge text-bg-secondary" title="Grants and people for this event"></span>
+          <span class="rule_count badge text-bg-secondary" title="Grants and expressions for this event"></span>
           <span class="issue_count badge text-bg-danger d-none" title="Number of targets with problems, such as unknown targets"></span>
           <span class="ms-auto">
             <button type="button" class="explain_button badge btn btn-primary me-2">Explain</button>
@@ -169,7 +169,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
         </span>
       </div>
       <div class="grant-body">
-        <div class="who_chips d-flex flex-wrap align-items-center gap-2">
+        <div class="who_chips d-flex flex-column align-items-start gap-1">
           <!-- who_chip_template elements go here -->
           <input
               class="who_add form-control form-control-sm auto-width"
@@ -185,6 +185,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
   <template id="who_chip_template">
     <span class="who-chip">
       <span class="who_expression"></span>
+      <span class="who-gloss d-none">(ALL authenticated users)</span>
       <button type="button" class="who_fix btn btn-warning btn-xs ms-1 d-none">Fix</button>
       <input
           class="who_fix_input form-control form-control-sm auto-width d-none"
@@ -200,7 +201,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
       <label for="event_add">Create New Event:</label>
       <input
               id="event_add"
-              class="form-control input-sm auto-width"
+              class="form-control auto-width"
               disabled=""
               type="text" inputmode="verbatim"
               placeholder="Burn-A-Matic-3000"
@@ -213,7 +214,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
       <label for="event_add_group">Create New Event Group:</label>
       <input
               id="event_add_group"
-              class="form-control input-sm auto-width"
+              class="form-control auto-width"
               disabled=""
               type="text" inputmode="verbatim"
               placeholder="Collection-of-Burns"

--- a/web/template/admintypes.templ
+++ b/web/template/admintypes.templ
@@ -78,7 +78,7 @@ templ AdminTypes(deployment, versionName, versionRef string) {
         <div class="card-footer">
           <label>Add:</label>
           <input
-              class="form-control input-sm auto-width"
+              class="form-control auto-width"
               type="text" inputmode="verbatim"
               disabled=""
               placeholder="Chooch"

--- a/web/template/field_report.templ
+++ b/web/template/field_report.templ
@@ -65,7 +65,7 @@ templ FieldReport(deployment, versionName, versionRef, eventName string) {
       <div class="py-1 input-group">
         <a id="incident_number_link" href="#" class="control-label input-group-text">IMS #</a>
         <input
-            id="incident_number" aria-label="IMS #" type="text" class="form-control form-control-static input-sm"
+            id="incident_number" aria-label="IMS #" type="text" class="form-control form-control-static"
             onchange="updateIncident(this);" readonly
         />
       </div>
@@ -91,7 +91,7 @@ templ FieldReport(deployment, versionName, versionRef, eventName string) {
       <div class="py-1 input-group">
         <label for="field_report_summary" class="control-label input-group-text">Summary</label>
         <input
-                id="field_report_summary" class="form-control input-sm"
+                id="field_report_summary" class="form-control"
                 type="text" inputmode="latin-prose" autocomplete="off"
                 onchange="editSummary()"
         />
@@ -176,7 +176,7 @@ templ FieldReport(deployment, versionName, versionRef, eventName string) {
             <textarea
                     id="report_entry_add"
                     aria-label="New report entry text"
-                    class="form-control no-print input-sm"
+                    class="form-control no-print"
                     placeholder="Press &quot;a&quot; to add report text"
                     onchange="reportEntryEdited()"
             ></textarea>

--- a/web/template/login.templ
+++ b/web/template/login.templ
@@ -46,7 +46,7 @@ templ Login(deployment, versionName, versionRef string) {
 
 <div class="form-floating mb-3">
   <input id="username_input" type="text" name="username" inputmode="latin-name"
-         class="form-control text-size-normal"
+         class="form-control fs-6"
          autocomplete="username" placeholder="name@example.com"/>
   <label for="username_input">Email address</label>
 </div>
@@ -54,7 +54,7 @@ templ Login(deployment, versionName, versionRef string) {
 <div class="input-group mb-3">
   <div class="form-floating">
     <input id="password_input" type="password" name="password" inputmode="latin-prose"
-           class="form-control text-size-normal"
+           class="form-control fs-6"
            autocomplete="current-password" placeholder="Password"/>
     <label for="password_input">Password</label>
   </div>

--- a/web/typescript/admin_events.ts
+++ b/web/typescript/admin_events.ts
@@ -408,11 +408,11 @@ function eventCard(event: ims.EventData): DocumentFragment {
     // Build the grant blocks, plus any drafts the admin is composing.
     const grantsContainer = card.querySelector(".grants_container") as HTMLElement;
     const grants = grantsForEvent(event.name);
-    let peopleCount = 0;
+    let expressionCount = 0;
     let issueCount = 0;
     for (const grant of grants) {
         for (const who of grant.whos) {
-            peopleCount++;
+            expressionCount++;
             if (ruleHasIssue(who)) {
                 issueCount++;
             }
@@ -423,10 +423,11 @@ function eventCard(event: ims.EventData): DocumentFragment {
         grantsContainer.append(grantBlock(event.name, null, draft));
     }
 
+    // Count expressions, not people: one expression can match many Rangers or none.
     const grantWord = grants.length === 1 ? "grant" : "grants";
-    const peopleWord = peopleCount === 1 ? "person" : "people";
+    const expressionWord = expressionCount === 1 ? "expression" : "expressions";
     card.querySelector(".rule_count")!.textContent =
-        `${grants.length} ${grantWord} · ${peopleCount} ${peopleWord}`;
+        `${grants.length} ${grantWord} · ${expressionCount} ${expressionWord}`;
     if (issueCount > 0) {
         const issueBadge = card.querySelector(".issue_count") as HTMLElement;
         issueBadge.textContent = `${issueCount} ${issueCount === 1 ? "issue" : "issues"}`;
@@ -592,14 +593,20 @@ function renderGrantTermsDisplay(grantEl: HTMLElement, grant: Grant): void {
         whenBadge.classList.add("text-bg-secondary");
     }
 
+    // The badges show the date alone to keep the terms line compact; the time of
+    // day is still reachable via the hover title and the "Edit terms" controls.
     if (grant.notBefore) {
         const badge = grantEl.querySelector(".grant_not_before_badge") as HTMLElement;
-        badge.textContent = `not-before ${formatDateForInput(new Date(grant.notBefore))}`;
+        const date = new Date(grant.notBefore);
+        badge.textContent = `not-before ${ims.localDateISO(date)}`;
+        badge.title = `Not before: ${ims.longFormatDate(date)}`;
         badge.classList.remove("d-none");
     }
     if (grant.notAfter) {
         const badge = grantEl.querySelector(".grant_not_after_badge") as HTMLElement;
-        badge.textContent = `not-after ${formatDateForInput(new Date(grant.notAfter))}`;
+        const date = new Date(grant.notAfter);
+        badge.textContent = `not-after ${ims.localDateISO(date)}`;
+        badge.title = `Not after: ${ims.longFormatDate(date)}`;
         badge.classList.remove("d-none");
     }
 
@@ -634,6 +641,12 @@ function whoChip(grantEl: HTMLElement, who: Access): DocumentFragment {
     const chip = frag.querySelector(".who-chip") as HTMLElement;
     const expressionSpan = chip.querySelector(".who_expression") as HTMLElement;
     expressionSpan.textContent = who.expression;
+
+    // The bare "*" gives no hint of how much it grants, so spell it out. The
+    // wildcard is always a known target, so this never collides with the fix flow.
+    if (who.expression === "*") {
+        show(chip.querySelector(".who-gloss") as HTMLElement);
+    }
 
     const removeButton = chip.querySelector(".who-remove") as HTMLButtonElement;
     removeButton.addEventListener("click", (): void => void removeWho(grantEl, who.expression));

--- a/web/typescripttest/admin_events.test.ts
+++ b/web/typescripttest/admin_events.test.ts
@@ -120,8 +120,8 @@ test("event cards render their rules grouped into grant blocks", async (): Promi
     expect(cards.length).toBe(1);
     const card = cards[0]!;
     expect(card.querySelector(".event_name")!.textContent).toBe("2025");
-    // Two rules with different terms form two grants, one person in each.
-    expect(card.querySelector(".rule_count")!.textContent).toBe("2 grants · 2 people");
+    // Two rules with different terms form two grants, one expression in each.
+    expect(card.querySelector(".rule_count")!.textContent).toBe("2 grants · 2 expressions");
     // No rules have issues, so the issue badge stays hidden. The event has
     // rules, though, so its grant list auto-expands.
     expect(card.querySelector(".issue_count")!.classList.contains("d-none")).toBe(true);
@@ -156,14 +156,42 @@ test("a grant with a dateless rule hides its date badges; a dated rule shows the
     expect(reader.querySelector(".grant_not_before_badge")!.classList.contains("d-none")).toBe(true);
     expect(reader.querySelector(".grant_not_after_badge")!.classList.contains("d-none")).toBe(true);
 
-    // The writer grant has dates, shown formatted like "Sun 2025-08-24 @ 12:00"
-    // in the browser's time zone (so an exact match here would be TZ-dependent).
+    // The writer grant has dates, shown as a bare ISO date like "2025-08-24" in
+    // the browser's time zone (so an exact match here would be TZ-dependent).
     const writer = grants[1]!;
-    const dateFormat = /\bnot-(before|after) [A-Z][a-z]{2} \d{4}-\d{2}-\d{2} @ \d{2}:\d{2}$/;
+    const dateFormat = /^not-(before|after) \d{4}-\d{2}-\d{2}$/;
     expect(writer.querySelector(".grant_not_before_badge")!.classList.contains("d-none")).toBe(false);
     expect(writer.querySelector(".grant_not_before_badge")!.textContent).toMatch(dateFormat);
     expect(writer.querySelector(".grant_not_after_badge")!.classList.contains("d-none")).toBe(false);
     expect(writer.querySelector(".grant_not_after_badge")!.textContent).toMatch(dateFormat);
+
+    // The time of day the badges omit stays available on hover.
+    const titleFormat = /^Not (before|after): [A-Z][a-z]{2}, \d{4}-\d{2}-\d{2} at \d{2}:\d{2}:\d{2} /;
+    expect((writer.querySelector(".grant_not_before_badge") as HTMLElement).title).toMatch(titleFormat);
+    expect((writer.querySelector(".grant_not_after_badge") as HTMLElement).title).toMatch(titleFormat);
+});
+
+test("a wildcard chip is glossed as granting all authenticated users", async (): Promise<void> => {
+    serverACL["2025"]!["readers"] = [
+        { expression: "*", validity: "always", debug_info: { known_target: true } },
+    ];
+    await initAdminEventsPage();
+
+    const chips = whoChips(grantBlocks(eventCards()[0]!)[0]!);
+    expect(chips.length).toBe(1);
+    // The expression itself stays the bare wildcard; the gloss is a sibling.
+    expect(chips[0]!.querySelector(".who_expression")!.textContent).toBe("*");
+    const gloss = chips[0]!.querySelector(".who-gloss")!;
+    expect(gloss.classList.contains("d-none")).toBe(false);
+    expect(gloss.textContent).toBe("(ALL authenticated users)");
+});
+
+test("a non-wildcard chip shows no gloss", async (): Promise<void> => {
+    await initAdminEventsPage();
+
+    const chips = whoChips(grantBlocks(eventCards()[0]!)[0]!);
+    expect(chips[0]!.querySelector(".who_expression")!.textContent).toBe("person:Tool");
+    expect(chips[0]!.querySelector(".who-gloss")!.classList.contains("d-none")).toBe(true);
 });
 
 test("a rule with an unknown target is flagged and its event auto-expands", async (): Promise<void> => {


### PR DESCRIPTION
Consolidate the scattered `font-size: var(--font-size-smaller)` declarations in style.css into a single grouped selector, drop dead commented-out blocks, and merge duplicate rules. Replace the ad-hoc `input-sm`/`text-size-normal` classes in templates with `auto-width` and Bootstrap's `fs-6`.

On the admin events page:
- Count "expressions" rather than "people" in the rule badge, since one expression can match many Rangers or none.
- Show grant date badges as a bare ISO date with the full datetime on hover.
- Gloss a bare `*` who-expression as "(ALL authenticated users)".