### PR TITLE
feat: use a select for admin places events, and date the On-Duty link

### DIFF
--- a/web/template/adminplaces.templ
+++ b/web/template/adminplaces.templ
@@ -33,8 +33,9 @@ templ AdminPlaces(deployment, versionName, versionRef string) {
 <form id="place-form">
   <div class="mb-3">
     <label for="event-name" class="form-label">Event name</label>
-    <input id="event-name" type="text" class="form-control" autocomplete="off" list="event-names" onchange="loadPlaces();">
-    <datalist id="event-names"></datalist>
+    <select id="event-name" class="form-control form-select" onchange="loadPlaces();">
+      <option value="" selected>Select an event&hellip;</option>
+    </select>
   </div>
   <h2 class="h5">Art data</h2>
   <div class="mb-3">

--- a/web/template/incident.templ
+++ b/web/template/incident.templ
@@ -129,7 +129,7 @@ templ Incident(deployment, versionName, versionRef, eventName string) {
         <div class="card">
           <h2 class="control-label card-header h6 mb-0">
           Rangers
-          <a href="https://ranger-clubhouse.burningman.org/reports/on-duty" target="_blank" class="link-body-emphasis float-end no-print" title="On-Duty Report" tabindex="-1">
+          <a id="onduty_link" href="" target="_blank" class="link-body-emphasis float-end no-print" title="On-Duty Report" tabindex="-1">
             On-Duty
             <span class="visually-hidden">report (opens in a new tab)</span>
             <svg fill="currentColor" class="bi" aria-hidden="true" focusable="false">

--- a/web/typescript/admin_places.ts
+++ b/web/typescript/admin_places.ts
@@ -30,8 +30,7 @@ declare global {
 
 const el = {
     placeForm: ims.typedElement("place-form", HTMLFormElement),
-    eventName: ims.typedElement("event-name", HTMLInputElement),
-    eventNames: ims.typedElement("event-names", HTMLDataListElement),
+    eventName: ims.typedElement("event-name", HTMLSelectElement),
     artData: ims.typedElement("art-data", HTMLTextAreaElement),
     campData: ims.typedElement("camp-data", HTMLTextAreaElement),
     mvData: ims.typedElement("mv-data", HTMLTextAreaElement),
@@ -59,15 +58,19 @@ async function initAdminPlacesPage(): Promise<void> {
 }
 
 function drawEventNames(events: ims.EventData[]|null): void {
-    el.eventNames.replaceChildren();
-    for (const event of events??[]) {
+    const sortedEvents = events?.toSorted((a, b) => {
+        // reverse alphabetical order
+        return b.name.localeCompare(a.name);
+    });
+    for (const event of sortedEvents??[]) {
         // groups are containers for events; they have no places of their own
         if (event.is_group) {
             continue;
         }
         const option: HTMLOptionElement = document.createElement("option");
         option.value = event.name;
-        el.eventNames.append(option);
+        option.textContent = event.name;
+        el.eventName.append(option);
     }
 }
 
@@ -131,6 +134,10 @@ async function submit(): Promise<void> {
         return;
     }
     const eventName = el.eventName.value;
+    if (!eventName) {
+        ims.setErrorMessage("Select an event before saving.");
+        return;
+    }
 
     const {err} = await ims.fetchNoThrow(
         url_places.replace("<event_id>", eventName), {
@@ -155,6 +162,9 @@ async function submit(): Promise<void> {
 async function loadPlaces(): Promise<void> {
     ims.clearErrorMessage();
     const eventName = el.eventName.value;
+    if (!eventName) {
+        return;
+    }
 
     const {json, err} = await ims.fetchNoThrow<ims.Places>(
         url_places.replace("<event_id>", eventName), {

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -78,6 +78,7 @@ const el = {
     rangerHandles: ims.typedElement("ranger_handles", HTMLDataListElement),
     rangersList: ims.typedElement("incident_rangers_list", HTMLElement),
     rangersLiTemplate: ims.typedElement("incident_rangers_li_template", HTMLTemplateElement),
+    onDutyLink: ims.typedElement("onduty_link", HTMLAnchorElement),
 
     incidentTypeAdd: ims.typedElement("incident_type_add", HTMLInputElement),
     incidentTypes: ims.typedElement("incident_types", HTMLDataListElement),
@@ -756,6 +757,14 @@ function drawRangers() {
 
         el.rangersList.append(rangerFragment);
     }
+
+    // Set the on-duty link. This uses a UTC timestamp, which Clubhouse seems to support as the duty_date param.
+    let params = new URLSearchParams();
+    if (incident?.started) {
+        const d = new Date(incident.started);
+        params.set("duty_date", d.toISOString());
+    }
+    el.onDutyLink.href = `https://ranger-clubhouse.burningman.org/reports/on-duty?${params.toString()}`;
 }
 
 

--- a/web/typescripttest/admin_places.test.ts
+++ b/web/typescripttest/admin_places.test.ts
@@ -60,18 +60,59 @@ function field(id: string): HTMLTextAreaElement {
     return document.getElementById(id) as HTMLTextAreaElement;
 }
 
-test("the event-names datalist is populated, excluding groups", async (): Promise<void> => {
+// Waits for drawEventNames, which runs after init awaits the events fetch.
+async function eventSelect(): Promise<HTMLSelectElement> {
+    const select = document.getElementById("event-name") as HTMLSelectElement;
+    await vi.waitFor((): void => {
+        expect(select.options.length).toBeGreaterThan(1);
+    });
+    return select;
+}
+
+test("the event-name select is populated in reverse-alphabetical order, excluding groups", async (): Promise<void> => {
     await initAdminPlacesPage();
 
-    // drawEventNames runs after init awaits the events fetch.
-    await vi.waitFor((): void => {
-        expect(document.querySelectorAll("#event-names option").length).toBeGreaterThan(0);
-    });
-    const options = [...document.querySelectorAll<HTMLOptionElement>("#event-names option")].map(o => o.value);
-    expect(options).toContain("2025");
-    expect(options).toContain("2024");
+    const select = await eventSelect();
+    const options = [...select.options].map(o => o.value);
+    // The templ-rendered placeholder stays first, then events newest-first.
+    expect(options).toEqual(["", "2025", "2024"]);
     // Groups hold no places of their own.
     expect(options).not.toContain("Group");
+    // Options need visible text, not just a value, to be pickable in a select.
+    expect([...select.options].map(o => o.textContent)).toEqual([
+        "Select an event…", "2025", "2024",
+    ]);
+    // Nothing is selected until the user picks an event.
+    expect(select.value).toBe("");
+});
+
+test("loading places with no event selected fetches nothing", async (): Promise<void> => {
+    const mock = await initAdminPlacesPage();
+    await eventSelect();
+
+    await window.loadPlaces();
+
+    expect(mock.mock.calls.some(([url]) => url === placesUrl)).toBe(false);
+});
+
+test("submitting with no event selected surfaces an error and posts nothing", async (): Promise<void> => {
+    const mock = await initAdminPlacesPage();
+    await eventSelect();
+
+    field("art-data").value = "[]";
+    field("camp-data").value = "[]";
+    field("mv-data").value = "[]";
+    field("other-data").value = "[]";
+
+    document.getElementById("place-form")!.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+    );
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
+    });
+    expect(document.getElementById("error_text")!.textContent).toContain("Select an event");
+    expect(mock.mock.calls.some(([url, init]) => url === placesUrl && init?.body != null)).toBe(false);
 });
 
 test("loading places fills each JSON textarea and its count label", async (): Promise<void> => {
@@ -82,7 +123,7 @@ test("loading places fills each JSON textarea and its count label", async (): Pr
         other: [],
     }));
 
-    (document.getElementById("event-name") as HTMLInputElement).value = "2025";
+    (await eventSelect()).value = "2025";
     await window.loadPlaces();
 
     expect(JSON.parse(field("art-data").value)).toEqual([{ name: "Temple", location_string: "9:00" }]);
@@ -102,7 +143,7 @@ test("submitting the form posts the parsed places to the event's places endpoint
         return undefined;
     });
 
-    (document.getElementById("event-name") as HTMLInputElement).value = "2025";
+    (await eventSelect()).value = "2025";
     field("art-data").value = JSON.stringify([{ name: "Temple", location_string: "9:00" }]);
     field("camp-data").value = "[]";
     field("mv-data").value = "[]";
@@ -125,7 +166,7 @@ test("submitting the form posts the parsed places to the event's places endpoint
 test("invalid JSON in a textarea surfaces an error and posts nothing", async (): Promise<void> => {
     const mock = await initAdminPlacesPage();
 
-    (document.getElementById("event-name") as HTMLInputElement).value = "2025";
+    (await eventSelect()).value = "2025";
     field("art-data").value = "this is not json";
     field("camp-data").value = "[]";
     field("mv-data").value = "[]";

--- a/web/typescripttest/incident.test.ts
+++ b/web/typescripttest/incident.test.ts
@@ -259,6 +259,13 @@ test("rangers and incident types are drawn with their add datalists", async (): 
     expect(hotSlotsLink.href).toBe("https://ranger-clubhouse.burningman.org/person/1234");
     expect(rangerItems[1]!.querySelector("input")!.value).toBe("lead");
 
+    // The On-Duty report link is pointed at the incident's start time.
+    const onDuty = document.getElementById("onduty_link") as HTMLAnchorElement;
+    expect(onDuty.href).toBe(
+        "https://ranger-clubhouse.burningman.org/reports/on-duty" +
+        "?duty_date=" + encodeURIComponent("2025-08-25T10:00:00.000Z"),
+    );
+
     // The Ranger add datalist holds all personnel except auditors.
     const handleOptions = [...document.querySelectorAll<HTMLOptionElement>("#ranger_handles option")]
         .map((o: HTMLOptionElement): string => o.value);


### PR DESCRIPTION
Replace the admin places event-name text input + datalist with a real select, listing non-group events newest-first behind a placeholder option, and guard load/submit against no event being selected.

Point the incident page's On-Duty report link at the incident's start time via Clubhouse's duty_date param.