### PR TITLE
refactor: replace ETag preconditions with an internal version CAS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,7 +220,7 @@ The API (`api/` package) uses a custom middleware adapter pattern:
 - Middleware includes: authentication, logging, panic recovery, request size limits
 - Handlers return `*herr.HTTPError` (`lib/herr/`), which carries both an internal error and a client-safe response message
 - Real-time updates are pushed to clients via Server-Sent Events (`api/eventsource.go`); mutations publish events that the web UI listens for
-- Incidents, Field Reports, and Visits use optimistic concurrency: each row carries a `VERSION` counter, surfaced to clients as a strong ETag; writes send `If-Match` and get a 412 on version mismatch (see `parseIfMatch`/`setETag` in `api/helpers.go`)
+- Incidents, Field Reports, and Visits carry a `VERSION` counter used as an internal concurrency gate: an edit reads the record, then applies a version-guarded `UPDATE`, and retries the read-merge-write if a concurrent writer moved the version first (`maxCASAttempts` in `api/incident.go`). The counter is reported in the record body but is not part of the request contract — clients send no precondition header. It guards only the record's own columns, so nothing else moves it: report entries, roster changes, incident types, links, and field-report/visit assignment all live in other tables, where no edit can clobber them. Set-valued fields are mutated one member at a time through their own endpoints so that concurrent writers can't undo each other
 - Cross-event search (`api/search.go`) matches a substring or regex query against Incidents, Field Reports, and Visits across all events the requestor can read
 
 ### Web UI

--- a/README.md
+++ b/README.md
@@ -142,6 +142,181 @@ go get -t -u ./...
 go mod tidy
 ```
 
+## How IMS handles concurrent access
+
+Several Rangers routinely work the same Incident at once: an Operator typing a summary
+while a shift lead adds a Ranger to the roster and someone else attaches a Field Report.
+This section records how the system deals with that, layer by layer, and — more
+importantly — *why* each layer looks the way it does. Some of these choices have been
+reversed once already; the reasoning is here so the next person doesn't have to
+rediscover it.
+
+### The governing idea
+
+**Concurrent edits are resolved by making operations not conflict, rather than by
+detecting conflicts and asking a human to sort them out.**
+
+The alternative — optimistic concurrency exposed to the client, with `ETag`/`If-Match`
+and a 412 on mismatch — was implemented and later removed. It's worth understanding why,
+because it looks like the textbook answer:
+
+* The failure it prevents is narrow. Edits are **sparse patches**, so two people editing
+  different fields never clobber each other regardless of ordering. The only real hazard
+  was two people overwriting *the same* field.
+* Even that hazard is recoverable. Every field change produces a change-log line
+  (`applyStringChange` in `api/helpers.go`) that `addChangeReportEntries` writes as a
+  generated report entry, naming the new value, its author, and the time. A
+  last-writer-wins overwrite isn't silent data loss — the previous value is one entry up
+  in the record's permanent change log.
+* The cost was high and fell on the common case. Because *any* change moved the version,
+  a Ranger editing the location would get a 412 for a summary edit someone else made a
+  second earlier — a conflict error for two edits that didn't actually conflict. The
+  frontend needed a serializing mutation queue purely to keep a page's own edits from
+  412ing each other.
+
+So the guiding rule is: **if two Rangers can plausibly do these two things at the same
+time, the operations must commute.** Reach for conflict detection only where they
+genuinely can't.
+
+### Layer 1: the database
+
+Incidents, Field Reports, and Visits each carry a `VERSION` counter
+(`store/schema/current.sql`). It is *not* part of the client contract — it's reported in
+the record body but clients never send it back. It exists to make the server's own
+read-merge-write safe:
+
+1. Read the stored record.
+2. Merge the request's fields over it.
+3. `UPDATE ... WHERE VERSION = <the value just read>`.
+
+If a competing writer committed in between, that `UPDATE` matches zero rows and the whole
+attempt is retried against fresh state. The guarded `UPDATE` is also the *first* lock the
+transaction takes, which makes the record's own row the single place competing writers
+queue.
+
+Two related rules:
+
+* **Lock ordering.** Anything touching two records (linking Incidents) takes their row
+  locks in a fixed global order — ascending by event, then number — regardless of which
+  end the request arrived on. See `bumpIncidentPairVersions` in `api/incidentrelation.go`.
+  Otherwise two requests from opposite ends of the same pair each hold the row the other
+  is waiting for.
+* **Bump before writing membership.** Writing to a child table (an Incident's types, its
+  roster) takes a *shared* FK lock on the parent row, and the version bump needs that same
+  row *exclusively*. Doing the child write first means two writers each hold a shared lock
+  the other must upgrade past — which MariaDB resolves by killing one with a deadlock
+  error, i.e. a 500 on an endpoint that promises to be safely concurrent.
+
+Deadlocks are still possible under load, so transactions that can hit one are wrapped in
+`retryOnDeadlock` (`maxDeadlockAttempts`, jittered exponential backoff). **Nothing may
+escape the database before the commit** — no SSE notification, no response — because the
+whole closure may run again.
+
+Record numbers are allocated with a plain `SELECT`, so two concurrent creators in one
+event can pick the same number. The `(EVENT, NUMBER)` primary key turns that into a
+duplicate-key error and the insert retries with a fresh number
+(`maxNumberAllocAttempts`).
+
+### Layer 2: the API
+
+**Sparse patches.** An edit body carries only the fields being changed. The server seeds
+the update from the stored row and overrides just what was provided
+(`buildIncidentUpdate`). This is what makes disjoint field edits inherently safe.
+
+**One member at a time, never a whole set.** Every set-valued relation on an Incident is
+mutated by naming the single member being changed. Types, links, and the Ranger roster
+each have a per-item sub-resource endpoint:
+
+```
+POST   /ims/api/events/{event}/incidents/{number}/incident_types/{typeId}
+DELETE /ims/api/events/{event}/incidents/{number}/incident_types/{typeId}
+```
+
+Attached Field Reports and Visits reach the same end from the other side: attachment is a
+single-valued field on the Field Report or Visit itself, so there's no list to replace.
+
+This exists specifically because the alternative doesn't commute. The API used to accept a
+replacement list and diff it against stored state; a client whose list was built from a
+stale read would silently *remove* another Ranger's addition while adding its own. A
+per-item request says "attach this type" rather than "the set is now exactly this," so two
+Rangers adding different types both win. They're idempotent too, which makes retries safe:
+a request for membership the record already has is a true no-op that doesn't even move the
+version.
+
+Those list fields are now **response-only**. Sending one on an edit is a `400` naming the
+endpoint to use instead (`rejectSetReplacement` in `api/incident.go`) — deliberately loud,
+because silently ignoring the field would report success for a change that never happened.
+
+**Report entries are exempt from all of this.** Appends can't lose data, and striking is a
+reversible boolean that is itself audited. Neither moves the version. This matters:
+appending a note must never fail because someone else edited a field, and must never
+cause someone else's in-flight edit to retry.
+
+**Retry, don't reject.** When the guarded `UPDATE` reports a conflict, the server re-reads
+and retries (`maxCASAttempts`, currently 3) rather than surfacing the conflict. Only if it
+loses repeatedly does the client see a `409`.
+
+**Deliberate exception — event access.** Admin permission writes are last-write-wins with
+no versioning at all, serialized by a process-level mutex (`eventAccessWriteMu` in
+`api/eventaccess.go`). Two admins editing the same event can overwrite each other. That's
+accepted because the writes are admin-only, rare, and immediately visible on the admin
+page. Note this only serializes *within one process*; it is not a distributed lock.
+
+### Layer 3: real-time propagation
+
+After a transaction commits — never before — the handler publishes an event through
+`EventSourcerer` (`api/eventsource.go`), and browsers viewing the affected record refetch
+and redraw. When a change alters how a *different* record reads (linking two Incidents,
+reassigning a Visit), that record's version is bumped and its own event published, so
+every open page converges.
+
+This is a large part of why loud conflict detection turned out to be unnecessary: the
+losing side of a last-writer-wins race sees the winning value appear on their screen as
+soon as the SSE update lands, rather than having to be told about the conflict.
+
+### Layer 4: the web frontend
+
+* **No preconditions.** Pages send no `If-Match` and track no ETag. Edits are fire and
+  reload.
+* **One mutation chain per page.** Every mutation a detail page makes goes through
+  `newMutationChain` (`web/typescript/ims.ts`), which runs them one at a time. The reason
+  is no longer ETags — it's that each mutation refetches and redraws when it completes, so
+  concurrent mutations race their redraws and the page can settle on state the server has
+  already moved past.
+* **Redraws never clobber in-progress typing.** `setInputValue` skips a control the user
+  is currently typing into. Overwriting it would discard the keystrokes *and* clear the
+  browser's dirty flag, so the `change` event wouldn't fire on blur and the edit would be
+  lost. Such a control may briefly show a stale value; it reconciles on the next redraw
+  after blur.
+* **Announce only other people's changes.** A detail page redraws for its own saves too
+  (they come back over SSE). `newRemoteUpdateAnnouncer` debounces and suppresses those, so
+  assistive tech announces only what the user couldn't otherwise know: someone else
+  editing the record in front of them.
+
+### Layer 5: the audit trail
+
+The backstop under everything above. Every field change appends a generated report entry
+naming the new value, its author, and the time; so do roster, type, link, and attachment
+changes. Report entries are immutable — strikeable, never edited or deleted.
+
+This is what makes last-writer-wins acceptable rather than reckless. There is no such
+thing as a change nobody can see: the losing value is still in the record, visible under
+"Show history and stricken."
+
+### If you're adding a new mutating endpoint
+
+1. Can two Rangers plausibly do this at the same time? If so, make the operation
+   commutative — express one gesture, not a replacement of a whole set.
+2. Route every write through a version-guarded `UPDATE` or a version bump, so racing
+   edits retry instead of clobbering. Skip it only if the operation genuinely cannot lose
+   data (appends, strikes).
+3. Take multi-record locks in a globally fixed order, and take the parent row before its
+   children.
+4. Wrap anything that can deadlock in `retryOnDeadlock`, and let nothing escape the
+   database before the commit.
+5. Publish an SSE notification after the commit.
+6. Write a generated report entry describing the change.
+
 ## Differences between the Go and Python IMS servers
 
 1. We didn't bring over support for a SQLite IMS database, so MariaDB is the only option currently.

--- a/api/deadlock_test.go
+++ b/api/deadlock_test.go
@@ -1,0 +1,125 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/burningmantech/ranger-ims-go/lib/herr"
+	"github.com/go-sql-driver/mysql"
+	"github.com/stretchr/testify/require"
+)
+
+func deadlockErr() error {
+	return &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock; try restarting transaction"}
+}
+
+func TestIsDeadlockError(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, isDeadlockError(deadlockErr()))
+
+	// The handlers wrap the driver error several layers deep before it reaches
+	// the retry, so it has to be found through the wrapping.
+	require.True(t, isDeadlockError(fmt.Errorf("[attach]: %w", deadlockErr())))
+
+	require.False(t, isDeadlockError(nil))
+	require.False(t, isDeadlockError(errors.New("some other failure")))
+	// A duplicate key is a different error that must not be retried this way.
+	require.False(t, isDeadlockError(&mysql.MySQLError{Number: 1062}))
+}
+
+func TestRetryOnDeadlockReturnsFirstSuccessWithoutRetrying(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	got, errHTTP := retryOnDeadlock(func() (int32, *herr.HTTPError) {
+		calls++
+		return 7, nil
+	})
+
+	require.Nil(t, errHTTP)
+	require.Equal(t, int32(7), got)
+	require.Equal(t, 1, calls)
+}
+
+func TestRetryOnDeadlockRetriesUntilItSucceeds(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	got, errHTTP := retryOnDeadlock(func() (int32, *herr.HTTPError) {
+		calls++
+		if calls < 3 {
+			return 0, herr.InternalServerError("Failed to attach", deadlockErr()).From("[attach]")
+		}
+		return 7, nil
+	})
+
+	require.Nil(t, errHTTP)
+	require.Equal(t, int32(7), got)
+	require.Equal(t, 3, calls)
+}
+
+func TestRetryOnDeadlockGivesUpAndReportsTheDeadlock(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	_, errHTTP := retryOnDeadlock(func() (int32, *herr.HTTPError) {
+		calls++
+		return 0, herr.InternalServerError("Failed to attach", deadlockErr()).From("[attach]")
+	})
+
+	require.NotNil(t, errHTTP)
+	require.Equal(t, maxDeadlockAttempts, calls)
+	// The underlying deadlock is still identifiable in what's returned, so the
+	// logs say why the request failed rather than just that it did.
+	require.True(t, isDeadlockError(errHTTP.InternalErr))
+	require.Contains(t, errHTTP.InternalErr.Error(), "gave up after")
+}
+
+// Anything that isn't a deadlock is the caller's answer, returned as-is.
+func TestRetryOnDeadlockDoesNotRetryOtherErrors(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	_, errHTTP := retryOnDeadlock(func() (int32, *herr.HTTPError) {
+		calls++
+		return 0, herr.NotFound("Incident not found", errors.New("no rows"))
+	})
+
+	require.NotNil(t, errHTTP)
+	require.Equal(t, 1, calls)
+	require.Equal(t, "Incident not found", errHTTP.ResponseMessage)
+}
+
+func TestRetryOnDeadlockErrRetriesTheSameWay(t *testing.T) {
+	t.Parallel()
+
+	calls := 0
+	errHTTP := retryOnDeadlockErr(func() *herr.HTTPError {
+		calls++
+		if calls < 2 {
+			return herr.InternalServerError("Failed to strike", deadlockErr()).From("[strike]")
+		}
+		return nil
+	})
+
+	require.Nil(t, errHTTP)
+	require.Equal(t, 2, calls)
+}

--- a/api/eventaccess.go
+++ b/api/eventaccess.go
@@ -326,7 +326,7 @@ func (action PostEventAccess) maybeSetAccess(
 	// just to be safe that we don't end up holding the lock forever.
 	//
 	// Event-access writes are deliberately last-write-wins, with no
-	// optimistic-concurrency VERSION/ETag like incidents have: two admins
+	// optimistic-concurrency VERSION like incidents have: two admins
 	// editing the same event and mode concurrently can overwrite each other.
 	// That's acceptable because writes are admin-only and rare, this mutex
 	// serializes them, and the result is immediately visible (and fixable)

--- a/api/fieldreport.go
+++ b/api/fieldreport.go
@@ -150,7 +150,6 @@ func (action GetFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Request)
 		errHTTP.From("[getFieldReport]").WriteResponse(w)
 		return
 	}
-	setETag(w, resp.Version)
 	mustWriteJSON(w, req, resp)
 }
 
@@ -244,21 +243,20 @@ type EditFieldReport struct {
 }
 
 func (action EditFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := action.editFieldReport(req)
+	errHTTP := action.editFieldReport(req)
 	if errHTTP != nil {
 		errHTTP.From("[editFieldReport]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
-func (action EditFieldReport) editFieldReport(req *http.Request) (int32, *herr.HTTPError) {
+func (action EditFieldReport) editFieldReport(req *http.Request) *herr.HTTPError {
 	event, jwt, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[getEventPermissions]")
+		return errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&(authz.EventWriteAllFieldReports|authz.EventWriteOwnFieldReports) == 0 {
-		return 0, herr.Forbidden("The requestor does not have permission to edit Field Reports on this Event", nil)
+		return herr.Forbidden("The requestor does not have permission to edit Field Reports on this Event", nil)
 	}
 	// i.e. they have EventWriteOwnFieldReports, but not EventWriteAllFieldReports
 	limitedAccess := eventPermissions&authz.EventWriteAllFieldReports == 0
@@ -266,24 +264,20 @@ func (action EditFieldReport) editFieldReport(req *http.Request) (int32, *herr.H
 	ctx := req.Context()
 	err := req.ParseForm()
 	if err != nil {
-		return 0, herr.BadRequest("Failed to parse form data", err).From("[ParseForm]")
+		return herr.BadRequest("Failed to parse form data", err).From("[ParseForm]")
 	}
 	fieldReportNumber, err := conv.ParseInt32(req.PathValue("fieldReportNumber"))
 	if err != nil {
-		return 0, herr.BadRequest("Invalid field report number", err).From("[ParseInt32]")
-	}
-	ifMatch, errHTTP := parseIfMatch(req)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[parseIfMatch]")
+		return herr.BadRequest("Invalid field report number", err).From("[ParseInt32]")
 	}
 	author := jwt.Claims.RangerHandle()
 	if limitedAccess {
 		isPrevAuthor, errHTTP := action.isPreviousAuthor(req, event.ID, fieldReportNumber, author)
 		if errHTTP != nil {
-			return 0, errHTTP.From("[isPreviousAuthor]")
+			return errHTTP.From("[isPreviousAuthor]")
 		}
 		if !isPrevAuthor {
-			return 0, herr.Forbidden("The requestor does not have permission to edit this Field Report", nil)
+			return herr.Forbidden("The requestor does not have permission to edit this Field Report", nil)
 		}
 	}
 
@@ -295,87 +289,62 @@ func (action EditFieldReport) editFieldReport(req *http.Request) (int32, *herr.H
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, herr.NotFound("Field Report does not exist", err).From("[FieldReport]")
+			return herr.NotFound("Field Report does not exist", err).From("[FieldReport]")
 		}
-		return 0, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
+		return herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
 	}
 	storedFR := frr.FieldReport
-	version := storedFR.Version
 
 	// If there's an "action" in the form, we're either linking or unlinking this FR from an Incident.
 	if queryAction := req.FormValue("action"); queryAction != "" {
 		targetIncidentVal := req.FormValue("incident")
 
-		// The link bumps this Field Report's version, so If-Match is verified
-		// here, against the version read above. The guarded update below then
-		// re-reads, so that this request's own bump doesn't read as a conflict.
-		if ifMatch != nil && *ifMatch != version {
-			return 0, herr.PreconditionFailed(
-				"This field report was changed by someone else while you were editing it", nil,
-			).SetExpectedError()
-		}
-		ifMatch = nil
-
 		// TODO: get rid of this "action" framework, and just allow a standard POST, as with visit's incident field.
 		errHTTP = action.handleLinkToIncident(ctx, storedFR, event, queryAction, targetIncidentVal, author)
 		if errHTTP != nil {
-			return 0, errHTTP.From("[handleLinkToIncident]")
-		}
-		version, err = action.imsDBQ.FieldReportVersion(ctx, action.imsDBQ, imsdb.FieldReportVersionParams{
-			Event:  event.ID,
-			Number: fieldReportNumber,
-		})
-		if err != nil {
-			return 0, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReportVersion]")
+			return errHTTP.From("[handleLinkToIncident]")
 		}
 	}
 
 	requestFR, errHTTP := readBodyAs[imsjson.FieldReport](req)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[readBodyAs]")
+		return errHTTP.From("[readBodyAs]")
 	}
 	// This is fine, as it may be that only a link/unlink was requested
 	if requestFR.Number == 0 {
 		slog.Debug("No field report number provided")
-		return version, nil
+		return nil
 	}
 
-	version, errHTTP = action.updateFieldReport(ctx, event, fieldReportNumber, requestFR, author, ifMatch)
+	errHTTP = action.updateFieldReport(ctx, event, fieldReportNumber, requestFR, author)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[updateFieldReport]")
+		return errHTTP.From("[updateFieldReport]")
 	}
-	return version, nil
+	return nil
 }
 
 func (action EditFieldReport) updateFieldReport(
 	ctx context.Context, event imsdb.Event, fieldReportNumber int32,
-	requestFR imsjson.FieldReport, author string, ifMatch *int32,
-) (newVersion int32, errHTTP *herr.HTTPError) {
-	attempts := maxCASAttempts
-	if ifMatch != nil {
-		attempts = 1
-	}
-	for range attempts {
-		version, conflict, errHTTP := action.updateFieldReportAttempt(ctx, event, fieldReportNumber, requestFR, author, ifMatch)
+	requestFR imsjson.FieldReport, author string,
+) *herr.HTTPError {
+	for range maxCASAttempts {
+		conflict, errHTTP := retryOnDeadlock(func() (bool, *herr.HTTPError) {
+			return action.updateFieldReportAttempt(ctx, event, fieldReportNumber, requestFR, author)
+		})
 		if errHTTP != nil {
-			return 0, errHTTP.From("[updateFieldReportAttempt]")
+			return errHTTP.From("[updateFieldReportAttempt]")
 		}
 		if !conflict {
-			return version, nil
-		}
-		if ifMatch != nil {
-			return 0, herr.PreconditionFailed(
-				"This field report was changed by someone else while you were editing it", nil,
-			).SetExpectedError()
+			return nil
 		}
 	}
-	return 0, herr.Conflict("The field report is being modified concurrently. Please try again.", nil)
+	return herr.Conflict("The field report is being modified concurrently. Please try again.", nil)
 }
 
 func (action EditFieldReport) updateFieldReportAttempt(
 	ctx context.Context, event imsdb.Event, fieldReportNumber int32,
-	requestFR imsjson.FieldReport, author string, ifMatch *int32,
-) (newVersion int32, conflict bool, errHTTP *herr.HTTPError) {
+	requestFR imsjson.FieldReport, author string,
+) (conflict bool, errHTTP *herr.HTTPError) {
 	frr, err := action.imsDBQ.FieldReport(ctx, action.imsDBQ,
 		imsdb.FieldReportParams{
 			Event:  event.ID,
@@ -384,19 +353,16 @@ func (action EditFieldReport) updateFieldReportAttempt(
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, false, herr.NotFound("Field Report does not exist", err).From("[FieldReport]")
+			return false, herr.NotFound("Field Report does not exist", err).From("[FieldReport]")
 		}
-		return 0, false, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
+		return false, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReport]")
 	}
 	storedFR := frr.FieldReport
 	expectedVersion := storedFR.Version
-	if ifMatch != nil && *ifMatch != expectedVersion {
-		return 0, true, nil
-	}
 
 	txn, err := action.imsDBQ.Begin()
 	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to begin transaction", err).From("[Begin]")
+		return false, herr.InternalServerError("Failed to begin transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
@@ -407,7 +373,6 @@ func (action EditFieldReport) updateFieldReportAttempt(
 	}
 	// A request that only appends report entries is applied without the
 	// guarded update below; see updateIncidentAttempt.
-	newVersion = expectedVersion
 	if len(logs) > 0 {
 		// The version-guarded update is the concurrency gate; see updateIncidentAttempt.
 		rows, err := action.imsDBQ.UpdateFieldReport(ctx, txn,
@@ -420,7 +385,7 @@ func (action EditFieldReport) updateFieldReportAttempt(
 			},
 		)
 		if err != nil {
-			return 0, false, herr.InternalServerError("Failed to update Field Report", err).From("[UpdateFieldReport]")
+			return false, herr.InternalServerError("Failed to update Field Report", err).From("[UpdateFieldReport]")
 		}
 		if rows == 0 {
 			// Stale version or vanished row; re-read to tell which.
@@ -430,27 +395,26 @@ func (action EditFieldReport) updateFieldReportAttempt(
 			})
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
-					return 0, false, herr.NotFound("Field Report does not exist", err).From("[FieldReportVersion]")
+					return false, herr.NotFound("Field Report does not exist", err).From("[FieldReportVersion]")
 				}
-				return 0, false, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReportVersion]")
+				return false, herr.InternalServerError("Failed to fetch Field Report", err).From("[FieldReportVersion]")
 			}
-			return 0, true, nil
+			return true, nil
 		}
-		newVersion = expectedVersion + 1
 	}
 	errHTTP = addChangeReportEntries(ctx, action.imsDBQ, txn, event.ID, storedFR.Number, author,
 		logs, requestFR.ReportEntries, addFRReportEntry)
 	if errHTTP != nil {
-		return 0, false, errHTTP.From("[addChangeReportEntries]")
+		return false, errHTTP.From("[addChangeReportEntries]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	action.eventSource.notifyFieldReportUpdate(event.ID, storedFR.Number)
-	return newVersion, false, nil
+	return false, nil
 }
 
 func (action EditFieldReport) handleLinkToIncident(
@@ -494,20 +458,6 @@ func (action EditFieldReport) handleLinkToIncident(
 			return herr.NotFound("No such Incident", err).From("[AttachFieldReportToIncident]")
 		}
 		return herr.InternalServerError("Failed to attach Field Report to incident", err).From("[AttachFieldReportToIncident]")
-	}
-	// The affected incidents' field-report lists changed, so their versions
-	// must move for clients holding their ETags to notice.
-	for _, incidentNumber := range []sql.NullInt32{previousIncident, newIncident} {
-		if !incidentNumber.Valid {
-			continue
-		}
-		err = action.imsDBQ.BumpIncidentVersion(ctx, action.imsDBQ, imsdb.BumpIncidentVersionParams{
-			Event:  event.ID,
-			Number: incidentNumber.Int32,
-		})
-		if err != nil {
-			return herr.InternalServerError("Failed to update incident", err).From("[BumpIncidentVersion]")
-		}
 	}
 	_, errHTTP := addFRReportEntry(ctx, action.imsDBQ, action.imsDBQ, event.ID, fieldReportNumber, newReportEntry{
 		author:    actor,
@@ -570,9 +520,6 @@ func (action NewFieldReport) ServeHTTP(w http.ResponseWriter, req *http.Request)
 
 	w.Header().Set("IMS-Field-Report-Number", strconv.Itoa(int(number)))
 	w.Header().Set("Location", location)
-	// A new Field Report is created directly (not via the guarded update path),
-	// so its version is the column default.
-	setETag(w, 1)
 	herr.WriteCreatedResponse(w, http.StatusText(http.StatusCreated))
 }
 
@@ -627,25 +574,32 @@ func (action NewFieldReport) newFieldReport(req *http.Request) (frNumber int32, 
 	}
 	fr.Number = newFrNum
 
-	txn, err := action.imsDBQ.Begin()
-	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to begin transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
+	_, errHTTP = retryOnDeadlock(func() (struct{}, *herr.HTTPError) {
+		var none struct{}
+		txn, err := action.imsDBQ.Begin()
+		if err != nil {
+			return none, herr.InternalServerError("Failed to begin transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
 
-	var logs []string
-	if fr.Summary != nil {
-		logs = append(logs, "Changed summary to: "+*fr.Summary)
-	}
-	errHTTP = addChangeReportEntries(ctx, action.imsDBQ, txn, event.ID, fr.Number, author,
-		logs, fr.ReportEntries, addFRReportEntry)
+		var logs []string
+		if fr.Summary != nil {
+			logs = append(logs, "Changed summary to: "+*fr.Summary)
+		}
+		errHTTP := addChangeReportEntries(ctx, action.imsDBQ, txn, event.ID, fr.Number, author,
+			logs, fr.ReportEntries, addFRReportEntry)
+		if errHTTP != nil {
+			return none, errHTTP.From("[addChangeReportEntries]")
+		}
+
+		err = txn.Commit()
+		if err != nil {
+			return none, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		}
+		return none, nil
+	})
 	if errHTTP != nil {
-		return 0, "", errHTTP.From("[addChangeReportEntries]")
-	}
-
-	err = txn.Commit()
-	if err != nil {
-		return 0, "", herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return 0, "", errHTTP
 	}
 
 	loc := fmt.Sprintf("/ims/api/events/%v/field_reports/%v", event.Name, fr.Number)

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -26,13 +26,14 @@ import (
 	"log/slog"
 	"mime"
 	"net/http"
-	"strconv"
 	"strings"
+	"time"
 
 	"github.com/burningmantech/ranger-ims-go/directory"
 	"github.com/burningmantech/ranger-ims-go/lib/authz"
 	"github.com/burningmantech/ranger-ims-go/lib/conv"
 	"github.com/burningmantech/ranger-ims-go/lib/herr"
+	"github.com/burningmantech/ranger-ims-go/lib/rand"
 	"github.com/burningmantech/ranger-ims-go/store"
 	"github.com/burningmantech/ranger-ims-go/store/imsdb"
 	"github.com/go-sql-driver/mysql"
@@ -42,6 +43,21 @@ import (
 // Report, or Visit whose freshly allocated number was claimed by a concurrent
 // creator in the same event first.
 const maxNumberAllocAttempts = 3
+
+// maxDeadlockAttempts bounds the retries when InnoDB picks a transaction as its
+// deadlock victim and rolls it back.
+//
+// Three wasn't enough: with several Rangers writing one Incident's roster at
+// once, a retry can lose again to the next writer in the queue. Six, with the
+// backoff below, held up over repeated runs of the concurrency tests.
+const maxDeadlockAttempts = 6
+
+// deadlockRetryBackoff is the base delay before retrying a deadlock victim,
+// doubled per attempt and jittered. Retrying immediately puts every victim back
+// in contention at the same instant, which is how they collided in the first
+// place. The worst case adds up to a few tens of milliseconds before the
+// attempts run out, which is cheap next to returning a 500.
+const deadlockRetryBackoff = 2 * time.Millisecond
 
 var (
 	errNoContentType      = errors.New("request has no Content-Type header")
@@ -54,6 +70,54 @@ func isDuplicateKeyError(err error) bool {
 	const mySQLErDupEntry = 1062
 	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
 	return ok && mysqlErr.Number == mySQLErDupEntry
+}
+
+// isDeadlockError reports whether err is a MySQL/MariaDB deadlock error
+// (ER_LOCK_DEADLOCK), meaning InnoDB chose this transaction as the victim and
+// rolled it back. Nothing it did was applied, so the whole transaction can be
+// run again; MariaDB's own error text says as much.
+func isDeadlockError(err error) bool {
+	const mySQLErLockDeadlock = 1213
+	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
+	return ok && mysqlErr.Number == mySQLErLockDeadlock
+}
+
+// retryOnDeadlock runs body, running it again if InnoDB rolled its transaction
+// back as a deadlock victim.
+//
+// Ordering the locks a transaction takes reduces deadlocks but can't remove
+// them: foreign keys make writers take shared locks on parent rows they never
+// name, and InnoDB also locks index gaps, so two transactions can still end up
+// each holding what the other needs. The database resolves that by killing one
+// of them, and the survivor's work is unaffected. Retrying the victim is what
+// keeps that from reaching a Ranger as a 500.
+//
+// body must do all of its work inside one transaction and must not publish
+// anything outside the database (an SSE notification, say) until that
+// transaction has committed, or a retry would emit it twice.
+func retryOnDeadlock[T any](body func() (T, *herr.HTTPError)) (T, *herr.HTTPError) {
+	backoff := deadlockRetryBackoff
+	for attempt := 1; ; attempt++ {
+		result, errHTTP := body()
+		if errHTTP == nil || !isDeadlockError(errHTTP.InternalErr) {
+			return result, errHTTP
+		}
+		if attempt == maxDeadlockAttempts {
+			return result, errHTTP.From(fmt.Sprintf("[retryOnDeadlock] gave up after %v attempts", attempt))
+		}
+		time.Sleep(rand.Jitter(backoff))
+		backoff *= 2
+	}
+}
+
+// retryOnDeadlockErr is retryOnDeadlock for a transaction that returns only an
+// error. The same rule applies: nothing may escape the database until the
+// commit.
+func retryOnDeadlockErr(body func() *herr.HTTPError) *herr.HTTPError {
+	_, errHTTP := retryOnDeadlock(func() (struct{}, *herr.HTTPError) {
+		return struct{}{}, body()
+	})
+	return errHTTP
 }
 
 // applyStringChange overwrites dst if the client provided a new value, and
@@ -118,38 +182,6 @@ func requireJSONContentType(req *http.Request) *herr.HTTPError {
 		)
 	}
 	return nil
-}
-
-// parseIfMatch returns the record version from a request's If-Match header, or
-// nil if the header is absent or "*" (which matches any current version).
-// IMS ETags are strong and hold a single integer version, e.g. `"7"`.
-//
-// RFC 9110 says weak ETags aren't valid in If-Match, but a `W/` prefix is
-// accepted anyway: proxies that compress responses (nginx's gzip module, among
-// others) rewrite our strong ETag to a weak one on the way out, and the browser
-// sends back what it was given. The weak/strong distinction is meaningless here
-// regardless, since the validator is a record version rather than a digest of
-// the response body.
-func parseIfMatch(req *http.Request) (*int32, *herr.HTTPError) {
-	raw := strings.TrimSpace(req.Header.Get("If-Match"))
-	if raw == "" || raw == "*" {
-		return nil, nil
-	}
-	if strings.Contains(raw, ",") {
-		return nil, herr.BadRequest("If-Match with multiple ETags is not supported", nil)
-	}
-	raw = strings.TrimPrefix(raw, "W/")
-	version, err := conv.ParseInt32(strings.Trim(raw, `"`))
-	if err != nil {
-		return nil, herr.BadRequest("Invalid If-Match header", err)
-	}
-	return &version, nil
-}
-
-// setETag sets a strong ETag response header from a record version, e.g. `"7"`.
-// It must be called before the response status is written.
-func setETag(w http.ResponseWriter, version int32) {
-	w.Header().Set("ETag", `"`+strconv.FormatInt(int64(version), 10)+`"`)
 }
 
 func eventFromFormValue(req *http.Request, imsDBQ *store.DBQ) (imsdb.Event, *herr.HTTPError) {

--- a/api/helpers_test.go
+++ b/api/helpers_test.go
@@ -135,64 +135,6 @@ func jsonContentType() http.Header {
 	return http.Header{"Content-Type": []string{"application/json"}}
 }
 
-func TestParseIfMatch(t *testing.T) {
-	t.Parallel()
-
-	requestWithIfMatch := func(value string) *http.Request {
-		req := &http.Request{Header: http.Header{}}
-		if value != "" {
-			req.Header.Set("If-Match", value)
-		}
-		return req
-	}
-
-	// absent header means no version check
-	version, errHTTP := parseIfMatch(requestWithIfMatch(""))
-	require.Nil(t, errHTTP)
-	assert.Nil(t, version)
-
-	// "*" matches any current version, so it also means no version check
-	version, errHTTP = parseIfMatch(requestWithIfMatch("*"))
-	require.Nil(t, errHTTP)
-	assert.Nil(t, version)
-
-	// a quoted ETag is the normal case
-	version, errHTTP = parseIfMatch(requestWithIfMatch(`"7"`))
-	require.Nil(t, errHTTP)
-	require.NotNil(t, version)
-	assert.Equal(t, int32(7), *version)
-
-	// an unquoted value is tolerated too
-	version, errHTTP = parseIfMatch(requestWithIfMatch("12"))
-	require.Nil(t, errHTTP)
-	require.NotNil(t, version)
-	assert.Equal(t, int32(12), *version)
-
-	// a weak ETag is accepted, since compressing proxies weaken the strong
-	// ETag we send and the browser echoes back whatever it was given
-	version, errHTTP = parseIfMatch(requestWithIfMatch(`W/"7"`))
-	require.Nil(t, errHTTP)
-	require.NotNil(t, version)
-	assert.Equal(t, int32(7), *version)
-
-	// multiple ETags aren't supported
-	_, errHTTP = parseIfMatch(requestWithIfMatch(`"7", "8"`))
-	require.NotNil(t, errHTTP)
-	assert.Equal(t, http.StatusBadRequest, errHTTP.Code)
-
-	// garbage isn't a version
-	_, errHTTP = parseIfMatch(requestWithIfMatch(`"unversioned"`))
-	require.NotNil(t, errHTTP)
-	assert.Equal(t, http.StatusBadRequest, errHTTP.Code)
-}
-
-func TestSetETag(t *testing.T) {
-	t.Parallel()
-	rec := httptest.NewRecorder()
-	setETag(rec, 42)
-	assert.Equal(t, `"42"`, rec.Header().Get("ETag"))
-}
-
 func TestEventFromFormValue(t *testing.T) {
 	t.Parallel()
 

--- a/api/incident.go
+++ b/api/incident.go
@@ -154,7 +154,6 @@ func (action GetIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		errHTTP.From("[getIncident]").WriteResponse(w)
 		return
 	}
-	setETag(w, resp.Version)
 	mustWriteJSON(w, req, resp)
 }
 
@@ -323,7 +322,7 @@ type NewIncident struct {
 }
 
 func (action NewIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	number, version, location, errHTTP := action.newIncident(req)
+	number, location, errHTTP := action.newIncident(req)
 	if errHTTP != nil {
 		errHTTP.From("[newIncident]").WriteResponse(w)
 		return
@@ -331,21 +330,20 @@ func (action NewIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("IMS-Incident-Number", strconv.Itoa(int(number)))
 	w.Header().Set("Location", location)
-	setETag(w, version)
 	herr.WriteCreatedResponse(w, http.StatusText(http.StatusCreated))
 }
-func (action NewIncident) newIncident(req *http.Request) (incidentNumber, version int32, location string, errHTTP *herr.HTTPError) {
+func (action NewIncident) newIncident(req *http.Request) (incidentNumber int32, location string, errHTTP *herr.HTTPError) {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, 0, "", errHTTP.From("[getEventPermissions]")
+		return 0, "", errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteIncidents == 0 {
-		return 0, 0, "", herr.Forbidden("The requestor does not have EventWriteIncidents permission on this Event", nil)
+		return 0, "", herr.Forbidden("The requestor does not have EventWriteIncidents permission on this Event", nil)
 	}
 	ctx := req.Context()
 	newIncident, errHTTP := readBodyAs[imsjson.Incident](req)
 	if errHTTP != nil {
-		return 0, 0, "", errHTTP.From("[readBodyAs]")
+		return 0, "", errHTTP.From("[readBodyAs]")
 	}
 
 	author := jwtCtx.Claims.RangerHandle()
@@ -361,7 +359,7 @@ func (action NewIncident) newIncident(req *http.Request) (incidentNumber, versio
 		var err error
 		newIncidentNumber, err = action.imsDBQ.NextIncidentNumber(ctx, action.imsDBQ, event.ID)
 		if err != nil {
-			return 0, 0, "", herr.InternalServerError("Failed to find next Incident number", err).From("[NextIncidentNumber]")
+			return 0, "", herr.InternalServerError("Failed to find next Incident number", err).From("[NextIncidentNumber]")
 		}
 		_, err = action.imsDBQ.CreateIncident(ctx, action.imsDBQ, imsdb.CreateIncidentParams{
 			Event:    event.ID,
@@ -375,22 +373,22 @@ func (action NewIncident) newIncident(req *http.Request) (incidentNumber, versio
 			break
 		}
 		if !isDuplicateKeyError(err) {
-			return 0, 0, "", herr.InternalServerError("Failed to create incident", err).From("[CreateIncident]")
+			return 0, "", herr.InternalServerError("Failed to create incident", err).From("[CreateIncident]")
 		}
 		if attempt == maxNumberAllocAttempts {
-			return 0, 0, "", herr.Conflict("Incidents are being created concurrently. Please try again.", err).From("[CreateIncident]")
+			return 0, "", herr.Conflict("Incidents are being created concurrently. Please try again.", err).From("[CreateIncident]")
 		}
 	}
 	newIncident.EventID = event.ID
 	newIncident.Event = event.Name
 	newIncident.Number = newIncidentNumber
 
-	version, errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author, nil)
+	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author)
 	if errHTTP != nil {
-		return 0, 0, "", errHTTP.From("[updateIncident]")
+		return 0, "", errHTTP.From("[updateIncident]")
 	}
 
-	return newIncident.Number, version, fmt.Sprintf("/ims/api/events/%v/incidents/%d", event.Name, newIncident.Number), nil
+	return newIncident.Number, fmt.Sprintf("/ims/api/events/%v/incidents/%d", event.Name, newIncident.Number), nil
 }
 
 func unmarshalByteSlice[T any](isByteSlice any) (T, error) {
@@ -422,38 +420,58 @@ func readExtraIncidentRowFields(row imsdb.IncidentRow) (incidentTypeIDs, fieldRe
 	return incidentTypeIDs, fieldReportNumbers, visitNumbers, nil
 }
 
-// maxCASAttempts bounds the read-merge-write retries for edits that don't
-// carry an If-Match header. Edits that do carry one get a single attempt,
-// since a version mismatch must be reported back to the client as a 412.
+// maxCASAttempts bounds the read-merge-write retries an edit makes when a
+// concurrent writer moves the record's version out from under it.
 const maxCASAttempts = 3
 
-func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
-	ifMatch *int32,
-) (newVersion int32, errHTTP *herr.HTTPError) {
-	attempts := maxCASAttempts
-	if ifMatch != nil {
-		attempts = 1
+// rejectSetReplacement refuses an edit body that carries one of the Incident's
+// set-valued fields. These used to be applied by diffing the client's list
+// against stored state, which silently undid a concurrent writer's add or
+// remove whenever the client's list was built from a stale read. Each is now
+// mutated one member at a time through its own endpoint, so those requests
+// commute and need no such diff. The fields remain in the response body.
+//
+// Rejecting is deliberate: ignoring them would report success for a change
+// that never happened.
+func rejectSetReplacement(newIncident imsjson.Incident) *herr.HTTPError {
+	var msg string
+	switch {
+	case newIncident.IncidentTypeIDs != nil:
+		msg = "incident_type_ids is read-only; use POST/DELETE .../incidents/{number}/incident_types/{incidentTypeId}"
+	case newIncident.LinkedIncidents != nil:
+		msg = "linked_incidents is read-only; use POST/DELETE .../incidents/{number}/linked_incidents/{eventName}/{number}"
+	case newIncident.FieldReports != nil:
+		msg = "field_reports is read-only; attach or detach via the Field Report endpoint"
+	case newIncident.Visits != nil:
+		msg = "visits is read-only; set the Visit's incident field via the Visit endpoint"
+	default:
+		return nil
 	}
-	for range attempts {
-		version, conflict, errHTTP := updateIncidentAttempt(ctx, imsDBQ, es, newIncident, author, ifMatch)
+	return herr.BadRequest(msg, nil).SetExpectedError()
+}
+
+func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
+) *herr.HTTPError {
+	errHTTP := rejectSetReplacement(newIncident)
+	if errHTTP != nil {
+		return errHTTP.From("[rejectSetReplacement]")
+	}
+	for range maxCASAttempts {
+		conflict, errHTTP := retryOnDeadlock(func() (bool, *herr.HTTPError) {
+			return updateIncidentAttempt(ctx, imsDBQ, es, newIncident, author)
+		})
 		if errHTTP != nil {
-			return 0, errHTTP.From("[updateIncidentAttempt]")
+			return errHTTP.From("[updateIncidentAttempt]")
 		}
 		if !conflict {
-			return version, nil
-		}
-		if ifMatch != nil {
-			return 0, herr.PreconditionFailed(
-				"This incident was changed by someone else while you were editing it", nil,
-			).SetExpectedError()
+			return nil
 		}
 	}
-	return 0, herr.Conflict("The incident is being modified concurrently. Please try again.", nil)
+	return herr.Conflict("The incident is being modified concurrently. Please try again.", nil)
 }
 
 func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
-	ifMatch *int32,
-) (newVersion int32, conflict bool, errHTTP *herr.HTTPError) {
+) (conflict bool, errHTTP *herr.HTTPError) {
 	storedIncidentRow, err := imsDBQ.Incident(ctx, imsDBQ,
 		imsdb.IncidentParams{
 			Event:  newIncident.EventID,
@@ -462,75 +480,32 @@ func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSour
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, false, herr.NotFound("Incident not found", err).From("[Incident]")
+			return false, herr.NotFound("Incident not found", err).From("[Incident]")
 		}
-		return 0, false, herr.InternalServerError("Failed to fetch incident", err).From("[Incident]")
+		return false, herr.InternalServerError("Failed to fetch incident", err).From("[Incident]")
 	}
 	storedIncident := storedIncidentRow.Incident
-	expectedVersion := storedIncident.Version
-	if ifMatch != nil && *ifMatch != expectedVersion {
-		return 0, true, nil
-	}
-
-	allEvents, err := imsDBQ.Events(ctx, imsDBQ)
-	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to fetch events", err).From("[Events]")
-	}
-	eventNameById := make(map[int32]string)
-	for _, event := range allEvents {
-		eventNameById[event.Event.ID] = event.Event.Name
-	}
-
-	// Look up the incident types before starting the transaction, to avoid DB connection contention.
-	var allIncidentTypes []imsdb.IncidentTypesRow
-	if newIncident.IncidentTypeIDs != nil {
-		allIncidentTypes, err = imsDBQ.IncidentTypes(ctx, imsDBQ)
-		if err != nil {
-			return 0, false, herr.InternalServerError("Failed to get incident types", err).From("[IncidentTypes]")
-		}
-	}
-
-	linkedIncidents, err := imsDBQ.Incident_LinkedIncidents(ctx, imsDBQ, imsdb.Incident_LinkedIncidentsParams{
-		Event1:          storedIncident.Event,
-		IncidentNumber1: storedIncident.Number,
-	})
-	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to fetch linked incidents", err)
-	}
-
-	incidentTypeIDs, fieldReportNumbers, visitNumbers, err := readExtraIncidentRowFields(storedIncidentRow)
-	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to read incident details", err).From("[readExtraIncidentRowFields]")
-	}
 
 	txn, err := imsDBQ.Begin()
 	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		return false, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
 	update, logs := buildIncidentUpdate(storedIncident, newIncident)
 
-	// A request that only appends report entries is applied without the
-	// guarded update below: appends can't lose data, so they must neither
-	// conflict with concurrent field edits nor move the version and thereby
-	// invalidate other clients' ETags.
-	changesIncident := len(logs) > 0 ||
-		newIncident.IncidentTypeIDs != nil ||
-		newIncident.FieldReports != nil ||
-		newIncident.Visits != nil ||
-		newIncident.LinkedIncidents != nil
-	newVersion = expectedVersion
-	if changesIncident {
+	// A request that only appends report entries is applied without the guarded
+	// update below: appends can't lose data, so they must not conflict with
+	// concurrent field edits.
+	if len(logs) > 0 {
 		// The version-guarded update is the concurrency gate for everything in
 		// this transaction: if another writer committed since the read above,
-		// it affects zero rows and the whole edit is retried (or rejected with
-		// a 412) rather than clobbering the other writer's changes. Once it
-		// succeeds, the row lock it takes serializes any competing writers
-		// until commit.
+		// it affects zero rows and the whole edit is retried rather than
+		// clobbering the other writer's changes. Once it succeeds, the row lock
+		// it takes serializes any competing writers until commit.
 		rows, err := imsDBQ.UpdateIncident(ctx, txn, update)
 		if err != nil {
-			return 0, false, herr.InternalServerError("Failed to update incident", err).From("[UpdateIncident]")
+			return false, herr.InternalServerError("Failed to update incident", err).From("[UpdateIncident]")
 		}
 		if rows == 0 {
 			// Stale version or vanished row; re-read to tell which.
@@ -540,62 +515,28 @@ func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSour
 			})
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
-					return 0, false, herr.NotFound("Incident not found", err).From("[IncidentVersion]")
+					return false, herr.NotFound("Incident not found", err).From("[IncidentVersion]")
 				}
-				return 0, false, herr.InternalServerError("Failed to fetch incident", err).From("[IncidentVersion]")
+				return false, herr.InternalServerError("Failed to fetch incident", err).From("[IncidentVersion]")
 			}
-			return 0, true, nil
+			return true, nil
 		}
-		newVersion = expectedVersion + 1
 	}
-
-	typeLogs, errHTTP := applyIncidentTypeChanges(ctx, imsDBQ, txn, newIncident, incidentTypeIDs, allIncidentTypes)
-	if errHTTP != nil {
-		return 0, false, errHTTP.From("[applyIncidentTypeChanges]")
-	}
-	logs = append(logs, typeLogs...)
-
-	frLogs, updatedFieldReports, errHTTP := applyIncidentFieldReportChanges(ctx, imsDBQ, txn, newIncident, fieldReportNumbers)
-	if errHTTP != nil {
-		return 0, false, errHTTP.From("[applyIncidentFieldReportChanges]")
-	}
-	logs = append(logs, frLogs...)
-
-	visitLogs, updatedVisits, errHTTP := applyIncidentVisitChanges(ctx, imsDBQ, txn, newIncident, visitNumbers)
-	if errHTTP != nil {
-		return 0, false, errHTTP.From("[applyIncidentVisitChanges]")
-	}
-	logs = append(logs, visitLogs...)
-
-	linkLogs, updatedLinkedIncidents, errHTTP := applyLinkedIncidentChanges(ctx, imsDBQ, txn, newIncident, linkedIncidents, eventNameById, author)
-	if errHTTP != nil {
-		return 0, false, errHTTP.From("[applyLinkedIncidentChanges]")
-	}
-	logs = append(logs, linkLogs...)
 
 	errHTTP = addChangeReportEntries(ctx, imsDBQ, txn, newIncident.EventID, newIncident.Number, author,
 		logs, newIncident.ReportEntries, addIncidentReportEntry)
 	if errHTTP != nil {
-		return 0, false, errHTTP.From("[addChangeReportEntries]")
+		return false, errHTTP.From("[addChangeReportEntries]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	es.notifyIncidentUpdate(newIncident.EventID, newIncident.Number)
-	for _, fr := range updatedFieldReports {
-		es.notifyFieldReportUpdate(newIncident.EventID, fr)
-	}
-	for _, inc := range updatedLinkedIncidents {
-		es.notifyIncidentUpdate(inc.EventID, inc.Number)
-	}
-	for _, s := range updatedVisits {
-		es.notifyVisitUpdate(newIncident.EventID, s)
-	}
 
-	return newVersion, false, nil
+	return false, nil
 }
 
 // buildIncidentUpdate merges the client-provided fields of newIncident over the
@@ -643,274 +584,6 @@ func buildIncidentUpdate(stored imsdb.Incident, newIncident imsjson.Incident) (i
 	return update, logs
 }
 
-// applyIncidentTypeChanges reconciles the Incident's types with the
-// client-provided list, returning change-log lines for the differences.
-func applyIncidentTypeChanges(
-	ctx context.Context, imsDBQ *store.DBQ, dbtx imsdb.DBTX,
-	newIncident imsjson.Incident, currentTypeIDs []int32, allIncidentTypes []imsdb.IncidentTypesRow,
-) ([]string, *herr.HTTPError) {
-	if newIncident.IncidentTypeIDs == nil {
-		return nil, nil
-	}
-	var logs []string
-	add := sliceSubtract(*newIncident.IncidentTypeIDs, currentTypeIDs)
-	sub := sliceSubtract(currentTypeIDs, *newIncident.IncidentTypeIDs)
-	if len(add) > 0 {
-		names := namesForIncidentTypes(allIncidentTypes, add)
-		logs = append(logs, fmt.Sprintf("Added type: %v", names))
-		for _, itype := range add {
-			err := imsDBQ.AttachIncidentTypeToIncident(ctx, dbtx,
-				imsdb.AttachIncidentTypeToIncidentParams{
-					Event:          newIncident.EventID,
-					IncidentNumber: newIncident.Number,
-					IncidentType:   itype,
-				},
-			)
-			if err != nil {
-				return nil, herr.InternalServerError("Failed to add Incident Type", err).From("[AttachIncidentTypeToIncident]")
-			}
-		}
-	}
-	if len(sub) > 0 {
-		names := namesForIncidentTypes(allIncidentTypes, sub)
-		logs = append(logs, fmt.Sprintf("Removed type: %v", names))
-		for _, rh := range sub {
-			err := imsDBQ.DetachIncidentTypeFromIncident(ctx, dbtx,
-				imsdb.DetachIncidentTypeFromIncidentParams{
-					Event:          newIncident.EventID,
-					IncidentNumber: newIncident.Number,
-					IncidentType:   rh,
-				},
-			)
-			if err != nil {
-				return nil, herr.InternalServerError("Failed to detach Incident Type", err).From("[DetachIncidentTypeFromIncident]")
-			}
-		}
-	}
-	return logs, nil
-}
-
-// applyIncidentFieldReportChanges attaches and detaches Field Reports so the
-// Incident matches the client-provided list. It returns change-log lines and
-// the numbers of the Field Reports whose attachment changed.
-func applyIncidentFieldReportChanges(
-	ctx context.Context, imsDBQ *store.DBQ, dbtx imsdb.DBTX,
-	newIncident imsjson.Incident, currentFRNumbers []int32,
-) ([]string, []int32, *herr.HTTPError) {
-	if newIncident.FieldReports == nil {
-		return nil, nil, nil
-	}
-	var logs []string
-	add := sliceSubtract(*newIncident.FieldReports, currentFRNumbers)
-	sub := sliceSubtract(currentFRNumbers, *newIncident.FieldReports)
-	if len(add) > 0 {
-		logs = append(logs, fmt.Sprintf("Field Report added: %v", add))
-		for _, frNum := range add {
-			err := imsDBQ.AttachFieldReportToIncident(ctx, dbtx,
-				imsdb.AttachFieldReportToIncidentParams{
-					Event:          newIncident.EventID,
-					Number:         frNum,
-					IncidentNumber: sql.NullInt32{Int32: newIncident.Number, Valid: true},
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to attach Field Report", err).From("[AttachFieldReportToIncident]")
-			}
-		}
-	}
-	if len(sub) > 0 {
-		logs = append(logs, fmt.Sprintf("Field Report removed: %v", sub))
-		for _, frNum := range sub {
-			err := imsDBQ.AttachFieldReportToIncident(ctx, dbtx,
-				imsdb.AttachFieldReportToIncidentParams{
-					Event:          newIncident.EventID,
-					Number:         frNum,
-					IncidentNumber: sql.NullInt32{},
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to detach Field Report", err).From("[AttachFieldReportToIncident]")
-			}
-		}
-	}
-	return logs, slices.Concat(add, sub), nil
-}
-
-// applyIncidentVisitChanges attaches and detaches Visits so the Incident
-// matches the client-provided list. It returns change-log lines and the
-// numbers of the Visits whose attachment changed.
-func applyIncidentVisitChanges(
-	ctx context.Context, imsDBQ *store.DBQ, dbtx imsdb.DBTX,
-	newIncident imsjson.Incident, currentVisitNumbers []int32,
-) ([]string, []int32, *herr.HTTPError) {
-	if newIncident.Visits == nil {
-		return nil, nil, nil
-	}
-	var logs []string
-	add := sliceSubtract(*newIncident.Visits, currentVisitNumbers)
-	sub := sliceSubtract(currentVisitNumbers, *newIncident.Visits)
-	if len(add) > 0 {
-		logs = append(logs, fmt.Sprintf("Visit added: %v", add))
-		for _, visitNum := range add {
-			err := imsDBQ.AttachVisitToIncident(ctx, dbtx,
-				imsdb.AttachVisitToIncidentParams{
-					Event:          newIncident.EventID,
-					Number:         visitNum,
-					IncidentNumber: sql.NullInt32{Int32: newIncident.Number, Valid: true},
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to attach Visit", err).From("[AttachVisitToIncident]")
-			}
-		}
-	}
-	if len(sub) > 0 {
-		logs = append(logs, fmt.Sprintf("Visit removed: %v", sub))
-		for _, visitNum := range sub {
-			err := imsDBQ.AttachVisitToIncident(ctx, dbtx,
-				imsdb.AttachVisitToIncidentParams{
-					Event:          newIncident.EventID,
-					Number:         visitNum,
-					IncidentNumber: sql.NullInt32{},
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to detach Visit", err).From("[AttachVisitToIncident]")
-			}
-		}
-	}
-	return logs, slices.Concat(add, sub), nil
-}
-
-// applyLinkedIncidentChanges links and unlinks other Incidents so this Incident
-// matches the client-provided list, adding a generated report entry on each
-// affected other Incident. It returns change-log lines and the Incidents whose
-// links changed.
-func applyLinkedIncidentChanges(
-	ctx context.Context, imsDBQ *store.DBQ, dbtx imsdb.DBTX,
-	newIncident imsjson.Incident, currentLinks []imsdb.Incident_LinkedIncidentsRow,
-	eventNameById map[int32]string, author string,
-) ([]string, []imsjson.LinkedIncident, *herr.HTTPError) {
-	if newIncident.LinkedIncidents == nil {
-		return nil, nil, nil
-	}
-	var currentLinkedIncidents []imsjson.LinkedIncident
-	for _, cli := range currentLinks {
-		currentLinkedIncidents = append(currentLinkedIncidents, imsjson.LinkedIncident{
-			EventID: cli.LinkedEvent,
-			Number:  cli.LinkedIncident,
-		})
-	}
-	var desiredLinkedIncidents []imsjson.LinkedIncident
-	for _, dli := range *newIncident.LinkedIncidents {
-		desiredLinkedIncidents = append(desiredLinkedIncidents, imsjson.LinkedIncident{
-			EventID: dli.EventID,
-			Number:  dli.Number,
-		})
-	}
-
-	var logs []string
-	add := sliceSubtract(desiredLinkedIncidents, currentLinkedIncidents)
-	sub := sliceSubtract(currentLinkedIncidents, desiredLinkedIncidents)
-	if len(add) > 0 {
-		names := namesForLinkedIncidents(add, eventNameById)
-		logs = append(logs, fmt.Sprintf("Incident linked: %v", names))
-		for _, otherIncident := range add {
-			err := imsDBQ.LinkIncidents(ctx, dbtx,
-				imsdb.LinkIncidentsParams{
-					Event1:          newIncident.EventID,
-					IncidentNumber1: newIncident.Number,
-					Event2:          otherIncident.EventID,
-					IncidentNumber2: otherIncident.Number,
-				},
-			)
-			if err != nil {
-				// We'll just assume in this case that the problem is that the otherIncident ID
-				// is invalid. This is probably the case...
-				return nil, nil, herr.BadRequest(fmt.Sprintf("Failed to link Incident. There may be no IMS #%v for the given event.", otherIncident.Number), err).From("[LinkIncidents]")
-			}
-			err = imsDBQ.LinkIncidents(ctx, dbtx,
-				imsdb.LinkIncidentsParams{
-					Event2:          newIncident.EventID,
-					IncidentNumber2: newIncident.Number,
-					Event1:          otherIncident.EventID,
-					IncidentNumber1: otherIncident.Number,
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to link Incident", err).From("[LinkIncidents]")
-			}
-			// The other incident's representation changed too, so its version
-			// must move for clients holding its ETag to notice.
-			err = imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
-				Event:  otherIncident.EventID,
-				Number: otherIncident.Number,
-			})
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to update linked Incident", err).From("[BumpIncidentVersion]")
-			}
-			_, errHTTP := addIncidentReportEntry(
-				ctx, imsDBQ, dbtx, otherIncident.EventID, otherIncident.Number,
-				newReportEntry{
-					author:    author,
-					text:      fmt.Sprintf("Incident linked: %v #%v", eventNameById[newIncident.EventID], newIncident.Number),
-					generated: true,
-				},
-			)
-			if errHTTP != nil {
-				return nil, nil, errHTTP.From("[addIncidentReportEntry]")
-			}
-		}
-	}
-	if len(sub) > 0 {
-		names := namesForLinkedIncidents(sub, eventNameById)
-		logs = append(logs, fmt.Sprintf("Incident unlinked: %v", names))
-		for _, otherIncident := range sub {
-			err := imsDBQ.UnlinkIncidents(ctx, dbtx,
-				imsdb.UnlinkIncidentsParams{
-					Event1:          newIncident.EventID,
-					IncidentNumber1: newIncident.Number,
-					Event2:          otherIncident.EventID,
-					IncidentNumber2: otherIncident.Number,
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
-			}
-			err = imsDBQ.UnlinkIncidents(ctx, dbtx,
-				imsdb.UnlinkIncidentsParams{
-					Event2:          newIncident.EventID,
-					IncidentNumber2: newIncident.Number,
-					Event1:          otherIncident.EventID,
-					IncidentNumber1: otherIncident.Number,
-				},
-			)
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
-			}
-			err = imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
-				Event:  otherIncident.EventID,
-				Number: otherIncident.Number,
-			})
-			if err != nil {
-				return nil, nil, herr.InternalServerError("Failed to update unlinked Incident", err).From("[BumpIncidentVersion]")
-			}
-			_, errHTTP := addIncidentReportEntry(
-				ctx, imsDBQ, dbtx, otherIncident.EventID, otherIncident.Number,
-				newReportEntry{
-					author:    author,
-					text:      fmt.Sprintf("Incident unlinked: %v #%v", eventNameById[newIncident.EventID], newIncident.Number),
-					generated: true,
-				},
-			)
-			if errHTTP != nil {
-				return nil, nil, errHTTP.From("[addIncidentReportEntry]")
-			}
-		}
-	}
-	return logs, slices.Concat(add, sub), nil
-}
-
 func namesForIncidentTypes(rows []imsdb.IncidentTypesRow, typeIDs []int32) string {
 	var names []string
 	for _, row := range rows {
@@ -921,24 +594,6 @@ func namesForIncidentTypes(rows []imsdb.IncidentTypesRow, typeIDs []int32) strin
 	return strings.Join(names, ", ")
 }
 
-func namesForLinkedIncidents(linked []imsjson.LinkedIncident, eventNamesById map[int32]string) string {
-	var names []string
-	for _, link := range linked {
-		names = append(names, fmt.Sprintf("%v #%v", eventNamesById[link.EventID], link.Number))
-	}
-	return strings.Join(names, ", ")
-}
-
-func sliceSubtract[T comparable](a, b []T) []T {
-	var ret []T
-	for _, item := range a {
-		if !slices.Contains(b, item) {
-			ret = append(ret, item)
-		}
-	}
-	return ret
-}
-
 type EditIncident struct {
 	imsDBQ    *store.DBQ
 	userStore *directory.UserStore
@@ -947,36 +602,31 @@ type EditIncident struct {
 }
 
 func (action EditIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := action.editIncident(req)
+	errHTTP := action.editIncident(req)
 	if errHTTP != nil {
 		errHTTP.From("[editIncident]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
-func (action EditIncident) editIncident(req *http.Request) (int32, *herr.HTTPError) {
+func (action EditIncident) editIncident(req *http.Request) *herr.HTTPError {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[getEventPermissions]")
+		return errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteIncidents == 0 {
-		return 0, herr.Forbidden("The requestor does not have EventWriteIncidents permission for this Event", nil)
+		return herr.Forbidden("The requestor does not have EventWriteIncidents permission for this Event", nil)
 	}
 	ctx := req.Context()
 
 	incidentNumber, err := conv.ParseInt32(req.PathValue("incidentNumber"))
 	if err != nil {
-		return 0, herr.BadRequest("Invalid Incident Number", err).From("[ParseInt32]")
-	}
-	ifMatch, errHTTP := parseIfMatch(req)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[parseIfMatch]")
+		return herr.BadRequest("Invalid Incident Number", err).From("[ParseInt32]")
 	}
 	newIncident, errHTTP := readBodyAs[imsjson.Incident](req)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[readBodyAs]")
+		return errHTTP.From("[readBodyAs]")
 	}
 	newIncident.Event = event.Name
 	newIncident.EventID = event.ID
@@ -984,10 +634,10 @@ func (action EditIncident) editIncident(req *http.Request) (int32, *herr.HTTPErr
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	version, errHTTP := updateIncident(ctx, action.imsDBQ, action.es, newIncident, author, ifMatch)
+	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[updateIncident]")
+		return errHTTP.From("[updateIncident]")
 	}
 
-	return version, nil
+	return nil
 }

--- a/api/incidentrelation.go
+++ b/api/incidentrelation.go
@@ -17,7 +17,6 @@
 package api
 
 import (
-	"cmp"
 	"context"
 	"database/sql"
 	"errors"
@@ -44,13 +43,16 @@ import (
 //     each change a different member without either losing the other's change.
 //     A replacement computed from a stale snapshot silently reverts it.
 //   - They're idempotent, so a retry is safe: a request that asks for the
-//     membership the Incident already has is a true no-op, returning the
-//     current version without moving it or writing a report entry.
-//   - They therefore need no If-Match, like the Ranger roster endpoints in
-//     ranger.go. They always report the resulting version as an ETag.
+//     membership the Incident already has is a true no-op, writing no report
+//     entry.
 //
-// The whole-list fields remain, for API compatibility and for creating an
-// Incident that arrives with its types and links already populated.
+// None of this moves the Incident's version. That counter is the CAS gate for
+// the Incident row's own columns, which nothing here writes, so bumping it would
+// only make a concurrent field edit retry for nothing — the same reason a report
+// entry append doesn't move it.
+//
+// The corresponding whole-list fields on EditIncident are response-only; see
+// rejectSetReplacement in incident.go.
 
 // incidentRelationRequest holds the validated inputs common to all four
 // endpoints: which Incident is being changed, and by whom.
@@ -96,101 +98,6 @@ func parseIncidentRelationRequest(
 	}, nil
 }
 
-// bumpIncidentVersionAndRead moves an Incident's optimistic-concurrency version
-// within the caller's transaction and returns the new value, so that clients
-// holding the old ETag notice the membership change.
-//
-// This near-duplicates bumpRosterVersion in ranger.go, which is parameterised
-// over rangerRoster because it serves both Incidents and Visits.
-func bumpIncidentVersionAndRead(
-	ctx context.Context, imsDBQ *store.DBQ, dbtx imsdb.DBTX, eventID, number int32,
-) (int32, *herr.HTTPError) {
-	err := imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
-		Event:  eventID,
-		Number: number,
-	})
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to update Incident", err).From("[BumpIncidentVersion]")
-	}
-	version, err := imsDBQ.IncidentVersion(ctx, dbtx, imsdb.IncidentVersionParams{
-		Event:  eventID,
-		Number: number,
-	})
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to fetch Incident", err).From("[IncidentVersion]")
-	}
-	return version, nil
-}
-
-// incidentRef names one Incident, for the endpoints that touch two of them.
-type incidentRef struct {
-	eventID, number int32
-}
-
-// bumpIncidentPairVersions moves both linked Incidents' versions, returning the
-// new version of the first one, which is the one the response is about.
-//
-// The pair is always locked in the same order, ascending by Event and then
-// number, whichever end of the link the request came in on. Two requests working
-// on the same pair from opposite ends would otherwise take the two row locks in
-// opposite orders, and each would sit holding the row the other was waiting for.
-func bumpIncidentPairVersions(
-	ctx context.Context, imsDBQ *store.DBQ, dbtx imsdb.DBTX, first, second incidentRef,
-) (int32, *herr.HTTPError) {
-	ordered := []incidentRef{first, second}
-	slices.SortFunc(ordered, func(a, b incidentRef) int {
-		return cmp.Or(cmp.Compare(a.eventID, b.eventID), cmp.Compare(a.number, b.number))
-	})
-	var versions [2]int32
-	for i, ref := range ordered {
-		version, errHTTP := bumpIncidentVersionAndRead(ctx, imsDBQ, dbtx, ref.eventID, ref.number)
-		if errHTTP != nil {
-			return 0, errHTTP.From("[bumpIncidentVersionAndRead]")
-		}
-		versions[i] = version
-	}
-	if ordered[0] == first {
-		return versions[0], nil
-	}
-	return versions[1], nil
-}
-
-// currentIncidentVersion reads an Incident's version without changing it, for
-// the responses that report a request as a no-op.
-func currentIncidentVersion(
-	ctx context.Context, imsDBQ *store.DBQ, eventID, number int32,
-) (int32, *herr.HTTPError) {
-	version, err := imsDBQ.IncidentVersion(ctx, imsDBQ, imsdb.IncidentVersionParams{
-		Event:  eventID,
-		Number: number,
-	})
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to fetch Incident", err).From("[IncidentVersion]")
-	}
-	return version, nil
-}
-
-// requireIncidentExists checks for an Incident that a request names but doesn't
-// otherwise read: the other end of a link. A missing one is the client's mistake,
-// so it's a 400, worded as the foreign-key failure downstream would have been.
-func requireIncidentExists(
-	ctx context.Context, imsDBQ *store.DBQ, eventID, number int32,
-) *herr.HTTPError {
-	_, err := imsDBQ.IncidentVersion(ctx, imsDBQ, imsdb.IncidentVersionParams{
-		Event:  eventID,
-		Number: number,
-	})
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return herr.BadRequest(
-				fmt.Sprintf("Failed to link Incident. There may be no IMS #%v for the given event.", number), err,
-			).From("[IncidentVersion]")
-		}
-		return herr.InternalServerError("Failed to fetch Incident", err).From("[IncidentVersion]")
-	}
-	return nil
-}
-
 // readIncidentRow fetches the Incident named in the request, reporting a 404 for
 // an Incident that doesn't exist.
 func readIncidentRow(
@@ -209,36 +116,34 @@ func readIncidentRow(
 	return row, nil
 }
 
-// setIncidentType attaches or detaches one Incident Type, per attach. It returns
-// the Incident's resulting version.
+// setIncidentType attaches or detaches one Incident Type, per attach.
 func setIncidentType(
 	req *http.Request, attach bool,
 	imsDBQ *store.DBQ, userStore *directory.UserStore, es *EventSourcerer, imsAdmins []string,
-) (int32, *herr.HTTPError) {
+) *herr.HTTPError {
 	relReq, errHTTP := parseIncidentRelationRequest(req, attach, imsDBQ, userStore, imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[parseIncidentRelationRequest]")
+		return errHTTP.From("[parseIncidentRelationRequest]")
 	}
 	typeID, err := conv.ParseInt32(req.PathValue("incidentTypeId"))
 	if err != nil {
-		return 0, herr.BadRequest("Invalid Incident Type ID", err).From("[ParseInt32]")
+		return herr.BadRequest("Invalid Incident Type ID", err).From("[ParseInt32]")
 	}
 	ctx := req.Context()
 
 	row, errHTTP := readIncidentRow(ctx, imsDBQ, relReq)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[readIncidentRow]")
+		return errHTTP.From("[readIncidentRow]")
 	}
 	currentTypeIDs, _, _, err := readExtraIncidentRowFields(row)
 	if err != nil {
-		return 0, herr.InternalServerError("Failed to read Incident details", err).From("[readExtraIncidentRowFields]")
+		return herr.InternalServerError("Failed to read Incident details", err).From("[readExtraIncidentRowFields]")
 	}
 
 	// The Incident already has the membership that was asked for, so there's
-	// nothing to record and no reason to move the version. This is what makes
-	// a repeated request safe to send.
+	// nothing to record. This is what makes a repeated request safe to send.
 	if slices.Contains(currentTypeIDs, typeID) == attach {
-		return row.Incident.Version, nil
+		return nil
 	}
 
 	// Resolve the name for the change-log line. This also rejects an unknown
@@ -246,123 +151,112 @@ func setIncidentType(
 	// Hidden types are allowed, matching the whole-list path.
 	allIncidentTypes, err := imsDBQ.IncidentTypes(ctx, imsDBQ)
 	if err != nil {
-		return 0, herr.InternalServerError("Failed to get Incident Types", err).From("[IncidentTypes]")
+		return herr.InternalServerError("Failed to get Incident Types", err).From("[IncidentTypes]")
 	}
 	typeName := namesForIncidentTypes(allIncidentTypes, []int32{typeID})
 	if typeName == "" {
-		return 0, herr.BadRequest(fmt.Sprintf("There is no Incident Type with id %v", typeID), nil)
+		return herr.BadRequest(fmt.Sprintf("There is no Incident Type with id %v", typeID), nil)
 	}
 
-	txn, err := imsDBQ.Begin()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
-
-	// Move the version before writing the membership, not after. A write to
-	// INCIDENT__INCIDENT_TYPE takes a shared lock on the Incident's own row for
-	// its foreign key, and the version bump needs that same row exclusively. In
-	// the other order two concurrent writers each hold the shared lock the other
-	// is waiting to upgrade past, which MariaDB resolves by killing one of them
-	// with a deadlock error: a 500, where this endpoint promises a commutative
-	// request that a second Ranger can send at the same time.
-	//
-	// Bumping first makes this row the one place those writers queue, since every
-	// lock the rest of the transaction wants on it is held from here on. It's the
-	// order the whole-list path already takes, where the version-guarded
-	// UpdateIncident is both the concurrency gate and the first lock acquired.
-	version, errHTTP := bumpIncidentVersionAndRead(ctx, imsDBQ, txn, relReq.event.ID, relReq.number)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[bumpIncidentVersionAndRead]")
-	}
-
-	logLine := fmt.Sprintf("Removed type: %v", typeName)
-	if attach {
-		logLine = fmt.Sprintf("Added type: %v", typeName)
-		err = imsDBQ.AttachIncidentTypeToIncident(ctx, txn, imsdb.AttachIncidentTypeToIncidentParams{
-			Event:          relReq.event.ID,
-			IncidentNumber: relReq.number,
-			IncidentType:   typeID,
-		})
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := imsDBQ.Begin()
 		if err != nil {
-			// Another writer attached this same type between the membership
-			// check above and this insert (the insert has no "on duplicate
-			// key"). The Incident is now in the state this request asked for, so
-			// this is the same no-op. Returning without committing discards this
-			// transaction's version bump along with everything else, which is
-			// what keeps the no-op one.
-			if isDuplicateKeyError(err) {
-				return currentIncidentVersion(ctx, imsDBQ, relReq.event.ID, relReq.number)
+			return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
+
+		logLine := fmt.Sprintf("Removed type: %v", typeName)
+		if attach {
+			logLine = fmt.Sprintf("Added type: %v", typeName)
+			err = imsDBQ.AttachIncidentTypeToIncident(ctx, txn, imsdb.AttachIncidentTypeToIncidentParams{
+				Event:          relReq.event.ID,
+				IncidentNumber: relReq.number,
+				IncidentType:   typeID,
+			})
+			if err != nil {
+				// Another writer attached this same type between the membership
+				// check above and this insert (the insert has no "on duplicate
+				// key"). The Incident is now in the state this request asked for,
+				// so this is the same no-op: return without committing, and this
+				// transaction's report entry goes with it.
+				if isDuplicateKeyError(err) {
+					return nil
+				}
+				return herr.InternalServerError("Failed to add Incident Type", err).From("[AttachIncidentTypeToIncident]")
 			}
-			return 0, herr.InternalServerError("Failed to add Incident Type", err).From("[AttachIncidentTypeToIncident]")
+		} else {
+			err = imsDBQ.DetachIncidentTypeFromIncident(ctx, txn, imsdb.DetachIncidentTypeFromIncidentParams{
+				Event:          relReq.event.ID,
+				IncidentNumber: relReq.number,
+				IncidentType:   typeID,
+			})
+			if err != nil {
+				return herr.InternalServerError("Failed to detach Incident Type", err).From("[DetachIncidentTypeFromIncident]")
+			}
 		}
-	} else {
-		err = imsDBQ.DetachIncidentTypeFromIncident(ctx, txn, imsdb.DetachIncidentTypeFromIncidentParams{
-			Event:          relReq.event.ID,
-			IncidentNumber: relReq.number,
-			IncidentType:   typeID,
-		})
-		if err != nil {
-			return 0, herr.InternalServerError("Failed to detach Incident Type", err).From("[DetachIncidentTypeFromIncident]")
-		}
-	}
 
-	_, errHTTP = addIncidentReportEntry(ctx, imsDBQ, txn, relReq.event.ID, relReq.number, newReportEntry{
-		author:    relReq.author,
-		text:      logLine,
-		generated: true,
+		_, errHTTP = addIncidentReportEntry(ctx, imsDBQ, txn, relReq.event.ID, relReq.number, newReportEntry{
+			author:    relReq.author,
+			text:      logLine,
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addIncidentReportEntry]")
+		}
+
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return 0, errHTTP.From("[addIncidentReportEntry]")
-	}
-
-	err = txn.Commit()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	es.notifyIncidentUpdate(relReq.event.ID, relReq.number)
 
-	return version, nil
+	return nil
 }
 
-// setIncidentLink links or unlinks one other Incident, per link. It returns the
-// path Incident's resulting version.
+// setIncidentLink links or unlinks one other Incident, per link.
 //
-// Links are symmetric, so both Incidents' rows, versions and change logs are
-// updated. Only the path Event is permission-checked, matching what the
-// whole-list path does today.
+// Links are symmetric, so both Incidents' rows and change logs are updated. Only
+// the path Event is permission-checked, matching what the whole-list path does
+// today.
 func setIncidentLink(
 	req *http.Request, link bool,
 	imsDBQ *store.DBQ, userStore *directory.UserStore, es *EventSourcerer, imsAdmins []string,
-) (int32, *herr.HTTPError) {
+) *herr.HTTPError {
 	relReq, errHTTP := parseIncidentRelationRequest(req, link, imsDBQ, userStore, imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[parseIncidentRelationRequest]")
+		return errHTTP.From("[parseIncidentRelationRequest]")
 	}
 	peerEvent, errHTTP := getEvent(req, req.PathValue("linkedEventName"), imsDBQ)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[getEvent]")
+		return errHTTP.From("[getEvent]")
 	}
 	peerNumber, err := conv.ParseInt32(req.PathValue("linkedIncidentNumber"))
 	if err != nil {
-		return 0, herr.BadRequest("Invalid linked Incident Number", err).From("[ParseInt32]")
+		return herr.BadRequest("Invalid linked Incident Number", err).From("[ParseInt32]")
 	}
 	if peerEvent.ID == relReq.event.ID && peerNumber == relReq.number {
-		return 0, herr.BadRequest("An Incident cannot be linked to itself", nil)
+		return herr.BadRequest("An Incident cannot be linked to itself", nil)
 	}
 	ctx := req.Context()
 
-	row, errHTTP := readIncidentRow(ctx, imsDBQ, relReq)
+	// Read for its 404: the path Incident has to exist before either end of the
+	// link is touched.
+	_, errHTTP = readIncidentRow(ctx, imsDBQ, relReq)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[readIncidentRow]")
+		return errHTTP.From("[readIncidentRow]")
 	}
 	currentLinks, err := imsDBQ.Incident_LinkedIncidents(ctx, imsDBQ, imsdb.Incident_LinkedIncidentsParams{
 		Event1:          relReq.event.ID,
 		IncidentNumber1: relReq.number,
 	})
 	if err != nil {
-		return 0, herr.InternalServerError("Failed to fetch linked Incidents", err).From("[Incident_LinkedIncidents]")
+		return herr.InternalServerError("Failed to fetch linked Incidents", err).From("[Incident_LinkedIncidents]")
 	}
 	alreadyLinked := slices.ContainsFunc(currentLinks, func(cli imsdb.Incident_LinkedIncidentsRow) bool {
 		return cli.LinkedEvent == peerEvent.ID && cli.LinkedIncident == peerNumber
@@ -370,124 +264,104 @@ func setIncidentLink(
 	// As in setIncidentType: the link is already in the state that was asked
 	// for, so this request has nothing to do.
 	if alreadyLinked == link {
-		return row.Incident.Version, nil
+		return nil
 	}
 
-	// Linking needs the other Incident to exist before the version bump below
-	// reaches for its row, since a bump of a row that isn't there reads back as a
-	// missing row, which is a 500 and not the client's real mistake. Unlinking
-	// needs no such check: a link on file proves both of its ends exist, and a
-	// request to remove a link that isn't on file returned above.
-	if link {
-		errHTTP = requireIncidentExists(ctx, imsDBQ, peerEvent.ID, peerNumber)
-		if errHTTP != nil {
-			return 0, errHTTP.From("[requireIncidentExists]")
-		}
-	}
-
-	txn, err := imsDBQ.Begin()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
-
-	// Both Incidents' versions move before either link row is written, for the
-	// reason given in setIncidentType: the link writes take shared foreign-key
-	// locks on both Incident rows, and taking those rows exclusively first is
-	// what stops a concurrent writer from deadlocking against this one. Both
-	// versions have to move anyway, since the link changes how both Incidents
-	// read, and so invalidates both of their ETags.
-	version, errHTTP := bumpIncidentPairVersions(ctx, imsDBQ, txn,
-		incidentRef{relReq.event.ID, relReq.number},
-		incidentRef{peerEvent.ID, peerNumber},
-	)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[bumpIncidentPairVersions]")
-	}
-
-	// The LINKED_INCIDENT table holds each link twice, once per direction, so
-	// that a lookup from either Incident finds it.
-	selfLogLine := fmt.Sprintf("Incident unlinked: %v #%v", peerEvent.Name, peerNumber)
-	peerLogLine := fmt.Sprintf("Incident unlinked: %v #%v", relReq.event.Name, relReq.number)
-	if link {
-		selfLogLine = fmt.Sprintf("Incident linked: %v #%v", peerEvent.Name, peerNumber)
-		peerLogLine = fmt.Sprintf("Incident linked: %v #%v", relReq.event.Name, relReq.number)
-		err = imsDBQ.LinkIncidents(ctx, txn, imsdb.LinkIncidentsParams{
-			Event1:          relReq.event.ID,
-			IncidentNumber1: relReq.number,
-			Event2:          peerEvent.ID,
-			IncidentNumber2: peerNumber,
-		})
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := imsDBQ.Begin()
 		if err != nil {
-			// As in setIncidentType, a concurrent identical link is a no-op
-			// rather than an error.
-			if isDuplicateKeyError(err) {
-				return currentIncidentVersion(ctx, imsDBQ, relReq.event.ID, relReq.number)
+			return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
+
+		// The LINKED_INCIDENT table holds each link twice, once per direction, so
+		// that a lookup from either Incident finds it.
+		selfLogLine := fmt.Sprintf("Incident unlinked: %v #%v", peerEvent.Name, peerNumber)
+		peerLogLine := fmt.Sprintf("Incident unlinked: %v #%v", relReq.event.Name, relReq.number)
+		if link {
+			selfLogLine = fmt.Sprintf("Incident linked: %v #%v", peerEvent.Name, peerNumber)
+			peerLogLine = fmt.Sprintf("Incident linked: %v #%v", relReq.event.Name, relReq.number)
+			err = imsDBQ.LinkIncidents(ctx, txn, imsdb.LinkIncidentsParams{
+				Event1:          relReq.event.ID,
+				IncidentNumber1: relReq.number,
+				Event2:          peerEvent.ID,
+				IncidentNumber2: peerNumber,
+			})
+			if err != nil {
+				// As in setIncidentType, a concurrent identical link is a no-op
+				// rather than an error.
+				if isDuplicateKeyError(err) {
+					return nil
+				}
+				// Otherwise the insert broke a foreign key, which means there's no
+				// such peer Incident. That's the client's mistake, not a 500.
+				return herr.BadRequest(
+					fmt.Sprintf("Failed to link Incident. There may be no IMS #%v for the given event.", peerNumber), err,
+				).From("[LinkIncidents]")
 			}
-			// Otherwise the insert broke a foreign key, which now means the peer
-			// Incident went away since the check above.
-			return 0, herr.BadRequest(
-				fmt.Sprintf("Failed to link Incident. There may be no IMS #%v for the given event.", peerNumber), err,
-			).From("[LinkIncidents]")
+			err = imsDBQ.LinkIncidents(ctx, txn, imsdb.LinkIncidentsParams{
+				Event2:          relReq.event.ID,
+				IncidentNumber2: relReq.number,
+				Event1:          peerEvent.ID,
+				IncidentNumber1: peerNumber,
+			})
+			if err != nil {
+				return herr.InternalServerError("Failed to link Incident", err).From("[LinkIncidents]")
+			}
+		} else {
+			err = imsDBQ.UnlinkIncidents(ctx, txn, imsdb.UnlinkIncidentsParams{
+				Event1:          relReq.event.ID,
+				IncidentNumber1: relReq.number,
+				Event2:          peerEvent.ID,
+				IncidentNumber2: peerNumber,
+			})
+			if err != nil {
+				return herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
+			}
+			err = imsDBQ.UnlinkIncidents(ctx, txn, imsdb.UnlinkIncidentsParams{
+				Event2:          relReq.event.ID,
+				IncidentNumber2: relReq.number,
+				Event1:          peerEvent.ID,
+				IncidentNumber1: peerNumber,
+			})
+			if err != nil {
+				return herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
+			}
 		}
-		err = imsDBQ.LinkIncidents(ctx, txn, imsdb.LinkIncidentsParams{
-			Event2:          relReq.event.ID,
-			IncidentNumber2: relReq.number,
-			Event1:          peerEvent.ID,
-			IncidentNumber1: peerNumber,
-		})
-		if err != nil {
-			return 0, herr.InternalServerError("Failed to link Incident", err).From("[LinkIncidents]")
-		}
-	} else {
-		err = imsDBQ.UnlinkIncidents(ctx, txn, imsdb.UnlinkIncidentsParams{
-			Event1:          relReq.event.ID,
-			IncidentNumber1: relReq.number,
-			Event2:          peerEvent.ID,
-			IncidentNumber2: peerNumber,
-		})
-		if err != nil {
-			return 0, herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
-		}
-		err = imsDBQ.UnlinkIncidents(ctx, txn, imsdb.UnlinkIncidentsParams{
-			Event2:          relReq.event.ID,
-			IncidentNumber2: relReq.number,
-			Event1:          peerEvent.ID,
-			IncidentNumber1: peerNumber,
-		})
-		if err != nil {
-			return 0, herr.InternalServerError("Failed to unlink Incident", err).From("[UnlinkIncidents]")
-		}
-	}
 
-	_, errHTTP = addIncidentReportEntry(ctx, imsDBQ, txn, relReq.event.ID, relReq.number, newReportEntry{
-		author:    relReq.author,
-		text:      selfLogLine,
-		generated: true,
+		_, errHTTP = addIncidentReportEntry(ctx, imsDBQ, txn, relReq.event.ID, relReq.number, newReportEntry{
+			author:    relReq.author,
+			text:      selfLogLine,
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addIncidentReportEntry]")
+		}
+
+		// The other Incident's change log should say what happened to it too.
+		_, errHTTP = addIncidentReportEntry(ctx, imsDBQ, txn, peerEvent.ID, peerNumber, newReportEntry{
+			author:    relReq.author,
+			text:      peerLogLine,
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addIncidentReportEntry]")
+		}
+
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return 0, errHTTP.From("[addIncidentReportEntry]")
-	}
-
-	// The other Incident's change log should say what happened to it too.
-	_, errHTTP = addIncidentReportEntry(ctx, imsDBQ, txn, peerEvent.ID, peerNumber, newReportEntry{
-		author:    relReq.author,
-		text:      peerLogLine,
-		generated: true,
-	})
-	if errHTTP != nil {
-		return 0, errHTTP.From("[addIncidentReportEntry]")
-	}
-
-	err = txn.Commit()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	es.notifyIncidentUpdate(relReq.event.ID, relReq.number)
 	es.notifyIncidentUpdate(peerEvent.ID, peerNumber)
 
-	return version, nil
+	return nil
 }
 
 type AttachTypeToIncident struct {
@@ -498,12 +372,11 @@ type AttachTypeToIncident struct {
 }
 
 func (action AttachTypeToIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := setIncidentType(req, true, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
+	errHTTP := setIncidentType(req, true, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[setIncidentType]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -515,12 +388,11 @@ type DetachTypeFromIncident struct {
 }
 
 func (action DetachTypeFromIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := setIncidentType(req, false, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
+	errHTTP := setIncidentType(req, false, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[setIncidentType]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -532,12 +404,11 @@ type LinkIncident struct {
 }
 
 func (action LinkIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := setIncidentLink(req, true, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
+	errHTTP := setIncidentLink(req, true, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[setIncidentLink]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -549,11 +420,10 @@ type UnlinkIncident struct {
 }
 
 func (action UnlinkIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := setIncidentLink(req, false, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
+	errHTTP := setIncidentLink(req, false, action.imsDBQ, action.userStore, action.es, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[setIncidentLink]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }

--- a/api/incidentrelation_test.go
+++ b/api/incidentrelation_test.go
@@ -17,7 +17,6 @@
 package api
 
 import (
-	"context"
 	"database/sql"
 	"net/http"
 	"testing"
@@ -39,50 +38,6 @@ func deadDBQ(t *testing.T) *store.DBQ {
 	require.NoError(t, err)
 	require.NoError(t, db.Close())
 	return store.NewDBQ(db, imsdb.New())
-}
-
-// writableDBTX accepts writes and, by way of the DBTX it wraps, fails reads.
-// bumpIncidentVersionAndRead takes its DBTX as an argument, so that it can run
-// inside its caller's transaction; that seam is what makes the "the bump landed
-// but the read-back didn't" case reachable.
-type writableDBTX struct {
-	imsdb.DBTX
-}
-
-func (writableDBTX) ExecContext(context.Context, string, ...any) (sql.Result, error) {
-	return wroteNothing{}, nil
-}
-
-type wroteNothing struct{}
-
-func (wroteNothing) LastInsertId() (int64, error) { return 0, nil }
-func (wroteNothing) RowsAffected() (int64, error) { return 0, nil }
-
-func TestBumpIncidentVersionAndReadErrors(t *testing.T) {
-	t.Parallel()
-
-	// The bump itself fails.
-	dead := deadDBQ(t)
-	_, errHTTP := bumpIncidentVersionAndRead(t.Context(), dead, dead, 1, 2)
-	require.NotNil(t, errHTTP)
-	require.Equal(t, http.StatusInternalServerError, errHTTP.Code)
-	require.Contains(t, errHTTP.ResponseMessage, "Failed to update Incident")
-
-	// The bump succeeds and the read-back of the new version fails.
-	_, errHTTP = bumpIncidentVersionAndRead(t.Context(), dead, writableDBTX{dead}, 1, 2)
-	require.NotNil(t, errHTTP)
-	require.Equal(t, http.StatusInternalServerError, errHTTP.Code)
-	require.Contains(t, errHTTP.ResponseMessage, "Failed to fetch Incident")
-}
-
-func TestCurrentIncidentVersionError(t *testing.T) {
-	t.Parallel()
-
-	dead := deadDBQ(t)
-	_, errHTTP := currentIncidentVersion(t.Context(), dead, 1, 2)
-	require.NotNil(t, errHTTP)
-	require.Equal(t, http.StatusInternalServerError, errHTTP.Code)
-	require.Contains(t, errHTTP.ResponseMessage, "Failed to fetch Incident")
 }
 
 func TestReadIncidentRowError(t *testing.T) {

--- a/api/integration/event_test.go
+++ b/api/integration/event_test.go
@@ -325,14 +325,7 @@ func TestDeleteEvent(t *testing.T) {
 
 	num1 := admin.newIncidentSuccess(ctx, sampleIncident1(child1Name))
 	num2 := admin.newIncidentSuccess(ctx, sampleIncident1(child1Name))
-	incident1, resp := admin.getIncident(ctx, child1Name, num1)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	*incident1.LinkedIncidents = append(*incident1.LinkedIncidents, imsjson.LinkedIncident{
-		EventID: incident1.EventID,
-		Number:  num2,
-	})
-	resp = admin.updateIncident(ctx, child1Name, num1, incident1)
+	resp = admin.linkIncident(ctx, child1Name, num1, child1Name, num2)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 

--- a/api/integration/fieldreport_test.go
+++ b/api/integration/fieldreport_test.go
@@ -201,31 +201,17 @@ func TestCreateAndUpdateFieldReport(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 	require.Nil(t, fieldReportAfterDetach.Incident)
 
-	// attach again, this time via the incident API
+	// The Incident API used to accept a replacement Field Report list, which
+	// silently dropped a concurrent writer's attachment. It's rejected now.
 	resp = apisAdmin.updateIncident(ctx, eventName, num, imsjson.Incident{
 		Event:        eventName,
 		Number:       incidentNumber,
 		FieldReports: &[]int32{num},
 	})
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
-	// check it attached
-	fieldReportAfterAttach, resp = apisAlice.getFieldReport(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, incidentNumber, *fieldReportAfterAttach.Incident)
-
-	// detach again, this time via the incident API
-	resp = apisAdmin.updateIncident(ctx, eventName, num, imsjson.Incident{
-		Event:        eventName,
-		Number:       incidentNumber,
-		FieldReports: &[]int32{},
-	})
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-
-	// check it detached
+	// and it left the Field Report detached, rather than half-applying
 	fieldReportAfterDetach, resp = apisAlice.getFieldReport(ctx, eventName, num)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/api/integration/helpers_test.go
+++ b/api/integration/helpers_test.go
@@ -257,8 +257,6 @@ func (a ApiHelper) attachRangerToVisit(ctx context.Context, eventName string, vi
 	return a.imsPost(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/visits/", strconv.Itoa(int(visit)), "/rangers/", handle).String())
 }
 
-// The Incident Type and linked Incident sub-resource endpoints take no If-Match
-// header, so there's no imsDeleteIfMatch counterpart to these.
 func (a ApiHelper) attachTypeToIncident(ctx context.Context, eventName string, incident, incidentTypeID int32) *http.Response {
 	a.t.Helper()
 	return a.imsPost(ctx, struct{}{}, a.incidentTypePath(eventName, incident, incidentTypeID))
@@ -557,11 +555,6 @@ func (a ApiHelper) getFieldReportAttachment(ctx context.Context, eventName strin
 
 func (a ApiHelper) imsPost(ctx context.Context, body any, path string) *http.Response {
 	a.t.Helper()
-	return a.imsPostIfMatch(ctx, body, path, "")
-}
-
-func (a ApiHelper) imsPostIfMatch(ctx context.Context, body any, path, ifMatch string) *http.Response {
-	a.t.Helper()
 	postBody, err := json.Marshal(body)
 	require.NoError(a.t, err)
 	httpPost, err := http.NewRequestWithContext(ctx, http.MethodPost, path, bytes.NewReader(postBody))
@@ -572,9 +565,6 @@ func (a ApiHelper) imsPostIfMatch(ctx context.Context, body any, path, ifMatch s
 	}
 	if a.referrer != "" {
 		httpPost.Header.Set("Referer", a.referrer)
-	}
-	if ifMatch != "" {
-		httpPost.Header.Set("If-Match", ifMatch)
 	}
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -605,21 +595,6 @@ func (a ApiHelper) imsPostContentType(ctx context.Context, path, contentType str
 	resp, err := client.Do(httpPost)
 	require.NoError(a.t, err)
 	return resp
-}
-
-func (a ApiHelper) updateIncidentIfMatch(ctx context.Context, eventName string, incident int32, req imsjson.Incident, ifMatch string) *http.Response {
-	a.t.Helper()
-	return a.imsPostIfMatch(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/incidents/", strconv.Itoa(int(incident))).String(), ifMatch)
-}
-
-func (a ApiHelper) updateFieldReportIfMatch(ctx context.Context, eventName string, fieldReport int32, req imsjson.FieldReport, ifMatch string) *http.Response {
-	a.t.Helper()
-	return a.imsPostIfMatch(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/field_reports/", conv.FormatInt(fieldReport)).String(), ifMatch)
-}
-
-func (a ApiHelper) updateVisitIfMatch(ctx context.Context, eventName string, visit int32, req imsjson.Visit, ifMatch string) *http.Response {
-	a.t.Helper()
-	return a.imsPostIfMatch(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/visits/", strconv.Itoa(int(visit))).String(), ifMatch)
 }
 
 func (a ApiHelper) imsGetBodyBytes(ctx context.Context, path string) ([]byte, *http.Response) {

--- a/api/integration/incident_test.go
+++ b/api/integration/incident_test.go
@@ -39,15 +39,13 @@ func sampleIncident1(eventName string) imsjson.Incident {
 			Address:     new("10:05 & W"),
 			Description: new("unknown"),
 		},
-		IncidentTypeIDs: &[]int32{1, 2},
-		FieldReports:    &[]int32{},
-		Visits:          &[]int32{},
-		Rangers:         &[]imsjson.IncidentRanger{{Handle: "SomeOne"}, {Handle: "SomeTwo"}},
+		// The set-valued fields are response-only, so they're absent here and
+		// ignored by requireEqualIncident; each has its own endpoint's tests.
+		Rangers: &[]imsjson.IncidentRanger{{Handle: "SomeOne"}, {Handle: "SomeTwo"}},
 		ReportEntries: []imsjson.ReportEntry{
 			{Text: "This is some report text lol"},
 			{Text: ""},
 		},
-		LinkedIncidents: &[]imsjson.LinkedIncident{},
 	}
 }
 
@@ -252,10 +250,8 @@ func TestCreateAndUpdateIncident(t *testing.T) {
 			Address:     new(""),
 			Description: new(""),
 		},
-		IncidentTypeIDs: &[]int32{},
-		FieldReports:    &[]int32{},
-		Rangers:         &[]imsjson.IncidentRanger{},
-		ReportEntries:   []imsjson.ReportEntry{},
+		Rangers:       &[]imsjson.IncidentRanger{},
+		ReportEntries: []imsjson.ReportEntry{},
 	}
 	resp = apisNonAdmin.updateIncident(ctx, eventName, num, updates)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -372,11 +368,7 @@ func TestCreateAndLinkIncidents(t *testing.T) {
 	eventID := retrievedNewIncident1.EventID
 	retrievedNewIncident2, resp := apisNonAdmin.getIncident(ctx, eventName, num2)
 	require.NoError(t, resp.Body.Close())
-	*retrievedNewIncident1.LinkedIncidents = append(*retrievedNewIncident1.LinkedIncidents, imsjson.LinkedIncident{
-		EventID: eventID,
-		Number:  num2,
-	})
-	resp = apisNonAdmin.updateIncident(ctx, eventName, num1, retrievedNewIncident1)
+	resp = apisNonAdmin.linkIncident(ctx, eventName, num1, eventName, num2)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
@@ -404,8 +396,7 @@ func TestCreateAndLinkIncidents(t *testing.T) {
 		require.Equal(t, *retrievedNewIncident1.Summary, linkedIncident.Summary)
 	}
 
-	retrievedNewIncident2.LinkedIncidents = &[]imsjson.LinkedIncident{}
-	resp = apisNonAdmin.updateIncident(ctx, eventName, num2, retrievedNewIncident2)
+	resp = apisNonAdmin.unlinkIncident(ctx, eventName, num2, eventName, num1)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
@@ -469,7 +460,7 @@ func TestAttachAndDetachIncidentType(t *testing.T) {
 	require.Equal(t, "Added type: "+typeName, lastReportEntryText(t, retrieved))
 	entriesAfterAttach := len(retrieved.ReportEntries)
 
-	// Attaching it again is a true no-op: no version bump, no report entry.
+	// Attaching it again is a true no-op: nothing written, no report entry.
 	resp = apis.attachTypeToIncident(ctx, eventName, num, *typeID)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
@@ -547,6 +538,67 @@ func TestAttachIncidentTypeIsCommutative(t *testing.T) {
 	retrieved, resp = apis.getIncident(ctx, eventName, num)
 	require.NoError(t, resp.Body.Close())
 	require.Empty(t, *retrieved.IncidentTypeIDs)
+}
+
+// The set-valued fields used to be writable on the edit endpoint, applied by
+// diffing the client's list against stored state. A client that still sends
+// one must be told, rather than getting a 204 for a change that didn't happen.
+func TestEditIncidentRejectsSetReplacement(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	num := apis.newIncidentSuccess(ctx, typelessIncident(eventName))
+	resp := apis.attachTypeToIncident(ctx, eventName, num, 1)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:           eventName,
+		Number:          num,
+		IncidentTypeIDs: &[]int32{},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:           eventName,
+		Number:          num,
+		LinkedIncidents: &[]imsjson.LinkedIncident{},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:        eventName,
+		Number:       num,
+		FieldReports: &[]int32{},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+		Event:  eventName,
+		Number: num,
+		Visits: &[]int32{},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A rejected edit changes nothing, and in particular doesn't clear the type.
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, []int32{1}, *retrieved.IncidentTypeIDs)
+
+	// Creation goes through the same path, so it's rejected too.
+	sample := typelessIncident(eventName)
+	sample.IncidentTypeIDs = &[]int32{1}
+	resp = apis.newIncident(ctx, sample)
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 }
 
 func TestLinkAndUnlinkIncidentEndpoints(t *testing.T) {
@@ -708,6 +760,12 @@ func requireEqualIncident(t *testing.T, before, after imsjson.Incident) {
 	before.LastModified, after.LastModified = time.Time{}, time.Time{}
 	before.Version, after.Version = 0, 0
 	before.ReportEntries, after.ReportEntries = nil, nil
+	// Response-only, so an edit body never carries them and there's nothing to
+	// compare against. Their own endpoints' tests cover them.
+	before.IncidentTypeIDs, after.IncidentTypeIDs = nil, nil
+	before.FieldReports, after.FieldReports = nil, nil
+	before.Visits, after.Visits = nil, nil
+	before.LinkedIncidents, after.LinkedIncidents = nil, nil
 
 	require.Equal(t, before, after)
 }

--- a/api/integration/incidentrelation_test.go
+++ b/api/integration/incidentrelation_test.go
@@ -241,11 +241,12 @@ func TestAttachHiddenIncidentType(t *testing.T) {
 	require.Equal(t, "Removed type: "+typeName, lastReportEntryText(t, retrieved))
 }
 
-// TestConcurrentIncidentTypeAttach is the regression test for the lock ordering
-// in setIncidentType. Concurrent requests against one Incident all take its row
-// exclusively before touching the membership table; with the two writes in the
-// other order they deadlocked in MariaDB and some of these requests came back
-// 500. Both shapes below reproduced that reliably at this width.
+// TestConcurrentIncidentTypeAttach is the regression test for setIncidentType
+// under concurrency. These requests only ever take shared foreign-key locks on
+// the Incident row, so there's nothing for them to deadlock on; an earlier
+// version bumped the Incident's version too, and the shared-to-exclusive upgrade
+// that took deadlocked in MariaDB, returning 500 for some of these requests.
+// Both shapes below reproduced that reliably at this width.
 func TestConcurrentIncidentTypeAttach(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -282,12 +283,13 @@ func TestConcurrentIncidentTypeAttach(t *testing.T) {
 	}
 
 	// The type is attached once, and one report entry says so: whichever requests
-	// lost the race wrote nothing at all, their version bumps included.
+	// lost the race wrote nothing at all. None of them moved the Incident's
+	// version, which guards only the Incident row's own columns.
 	retrieved, resp := apis.getIncident(ctx, eventName, num)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, []int32{1}, *retrieved.IncidentTypeIDs)
 	require.Len(t, retrieved.ReportEntries, len(before.ReportEntries)+1)
-	require.Equal(t, before.Version+1, retrieved.Version)
+	require.Equal(t, before.Version, retrieved.Version)
 
 	// Concurrent requests for *different* types all stick, which is the whole
 	// point of these endpoints: each request names only its own member, so
@@ -310,59 +312,10 @@ func TestConcurrentIncidentTypeAttach(t *testing.T) {
 	require.ElementsMatch(t, append([]int32{1}, typeIDs...), *retrieved.IncidentTypeIDs)
 }
 
-// The ETag on a link response is the path Incident's version, whichever end of
-// the pair that is. bumpIncidentPairVersions moves the two Incidents in a fixed
-// order, so it has to hand back the right one of the two versions rather than
-// just the first one it bumped.
-func TestIncidentLinkETagIsThePathIncidents(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithWriter(t, apisAdmin)
-	num1 := apis.newIncidentSuccess(ctx, typelessIncident(eventName))
-	num2 := apis.newIncidentSuccess(ctx, typelessIncident(eventName))
-	require.Less(t, num1, num2)
-
-	// Move one of the two versions, so that the two Incidents disagree about what
-	// their version is and this test can tell which one it's being handed.
-	resp := apis.attachTypeToIncident(ctx, eventName, num2, 1)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	incident1, resp := apis.getIncident(ctx, eventName, num1)
-	require.NoError(t, resp.Body.Close())
-	incident2, resp := apis.getIncident(ctx, eventName, num2)
-	require.NoError(t, resp.Body.Close())
-	require.NotEqual(t, incident1.Version, incident2.Version)
-
-	// Linking from the higher-numbered end, which is the one bumped second.
-	resp = apis.linkIncident(ctx, eventName, num2, eventName, num1)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etag := resp.Header.Get("ETag")
-	require.NoError(t, resp.Body.Close())
-
-	incident2, resp = apis.getIncident(ctx, eventName, num2)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, fmt.Sprintf("%q", conv.FormatInt(incident2.Version)), etag)
-	require.Equal(t, etag, resp.Header.Get("ETag"))
-
-	// And unlinking from the lower-numbered end, which is bumped first.
-	resp = apis.unlinkIncident(ctx, eventName, num1, eventName, num2)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etag = resp.Header.Get("ETag")
-	require.NoError(t, resp.Body.Close())
-
-	incident1, resp = apis.getIncident(ctx, eventName, num1)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, fmt.Sprintf("%q", conv.FormatInt(incident1.Version)), etag)
-	require.Equal(t, etag, resp.Header.Get("ETag"))
-}
-
-// TestConcurrentIncidentLinkAndUnlink is the regression test for the lock
-// ordering in bumpIncidentPairVersions. Requests coming in from opposite ends of
-// the same pair have to take the two Incident rows in the same order as each
-// other, or each sits holding the row the other is waiting for.
+// TestConcurrentIncidentLinkAndUnlink covers requests coming in from opposite
+// ends of the same pair at once. Each takes only shared foreign-key locks on the
+// two Incident rows, which are compatible with each other, so the order the two
+// rows are reached in doesn't matter.
 func TestConcurrentIncidentLinkAndUnlink(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()

--- a/api/integration/version_test.go
+++ b/api/integration/version_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/burningmantech/ranger-ims-go/api"
 	imsjson "github.com/burningmantech/ranger-ims-go/json"
-	"github.com/burningmantech/ranger-ims-go/lib/conv"
 	"github.com/burningmantech/ranger-ims-go/lib/rand"
 	"github.com/burningmantech/ranger-ims-go/store"
 	"github.com/burningmantech/ranger-ims-go/store/imsdb"
@@ -48,7 +47,25 @@ func newEventWithWriter(t *testing.T, apisAdmin ApiHelper) (eventName string) {
 	return eventName
 }
 
-func TestIncidentETagLifecycle(t *testing.T) {
+// incidentVersion reads an Incident's optimistic-concurrency version, which the
+// API reports in the record body.
+func incidentVersion(ctx context.Context, t *testing.T, apis ApiHelper, eventName string, number int32) int32 {
+	t.Helper()
+	retrieved, resp := apis.getIncident(ctx, eventName, number)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	return retrieved.Version
+}
+
+func fieldReportVersion(ctx context.Context, t *testing.T, apis ApiHelper, eventName string, number int32) int32 {
+	t.Helper()
+	retrieved, resp := apis.getFieldReport(ctx, eventName, number)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	return retrieved.Version
+}
+
+func TestIncidentVersionLifecycle(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -57,39 +74,27 @@ func TestIncidentETagLifecycle(t *testing.T) {
 	eventName := newEventWithWriter(t, apisAdmin)
 
 	// Creation goes through the guarded update path, so a new incident's
-	// version is 2 (insert at 1, then one bump), and the 201 carries its ETag.
-	resp := apis.newIncident(ctx, sampleIncident1(eventName))
-	require.Equal(t, http.StatusCreated, resp.StatusCode)
-	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
-	numStr := resp.Header.Get("IMS-Incident-Number")
-	require.NoError(t, resp.Body.Close())
-	num := parseInt32Required(t, numStr)
+	// version is 2: the insert lands at 1, then one bump.
+	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+	require.Equal(t, int32(2), incidentVersion(ctx, t, apis, eventName, num))
 
-	// A single GET returns the same ETag, and the version in the body.
-	retrieved, resp := apis.getIncident(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
-	require.Equal(t, int32(2), retrieved.Version)
-
-	// An edit carrying the current ETag succeeds, and the 204 carries the new ETag.
-	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
+	// A field edit moves it.
+	resp := apis.updateIncident(ctx, eventName, num, imsjson.Incident{
 		Event:   eventName,
 		Number:  num,
 		Summary: new("an updated summary"),
-	}, `"2"`)
+	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, `"3"`, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
 
-	retrieved, resp = apis.getIncident(ctx, eventName, num)
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, int32(3), retrieved.Version)
 	require.Equal(t, "an updated summary", *retrieved.Summary)
 }
 
-func TestIncidentEditWithStaleIfMatchIsRejected(t *testing.T) {
+func TestReportEntryAppendDoesNotBumpIncidentVersion(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -98,129 +103,27 @@ func TestIncidentEditWithStaleIfMatchIsRejected(t *testing.T) {
 	eventName := newEventWithWriter(t, apisAdmin)
 
 	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
-
-	// Two dispatchers read the incident at the same version...
-	_, resp := apis.getIncident(ctx, eventName, num)
-	require.NoError(t, resp.Body.Close())
-	etag := resp.Header.Get("ETag")
-	require.NotEmpty(t, etag)
-
-	// ...the first one's edit lands...
-	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("the first edit wins"),
-	}, etag)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-
-	// ...and the second one's edit, still carrying the now-stale ETag, is
-	// rejected with a 412 problem response instead of clobbering the first.
-	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("the second edit must not clobber the first"),
-	}, etag)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
-	require.NoError(t, resp.Body.Close())
-
-	retrieved, resp := apis.getIncident(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, "the first edit wins", *retrieved.Summary)
-}
-
-func TestIncidentEditWithoutIfMatchStillSucceeds(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithWriter(t, apisAdmin)
-
-	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
-
-	// A client that predates If-Match keeps working: the server does its own
-	// compare-and-swap internally instead of requiring the header.
-	resp := apis.updateIncident(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("edited without an If-Match header"),
-	})
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NotEmpty(t, resp.Header.Get("ETag"))
-	require.NoError(t, resp.Body.Close())
-
-	retrieved, resp := apis.getIncident(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, "edited without an If-Match header", *retrieved.Summary)
-}
-
-func TestIncidentEditIfMatchOnMissingIncidentIs404(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithWriter(t, apisAdmin)
-
-	// A version check against a nonexistent incident is a 404, not a 412.
-	resp := apis.updateIncidentIfMatch(ctx, eventName, 12345, imsjson.Incident{
-		Event:   eventName,
-		Number:  12345,
-		Summary: new("does not exist"),
-	}, `"1"`)
-	require.Equal(t, http.StatusNotFound, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-}
-
-func TestReportEntryAppendDoesNotBumpIncidentETag(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithWriter(t, apisAdmin)
-
-	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
-
-	_, resp := apis.getIncident(ctx, eventName, num)
-	require.NoError(t, resp.Body.Close())
-	etagBefore := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagBefore)
+	versionBefore := incidentVersion(ctx, t, apis, eventName, num)
 
 	// Appending a note can't lose data, so it must not move the version and
-	// thereby make other clients' edits spuriously conflict.
-	resp = apis.updateIncident(ctx, eventName, num, imsjson.Incident{
+	// thereby make a concurrent field edit retry for nothing.
+	resp := apis.updateIncident(ctx, eventName, num, imsjson.Incident{
 		Event:         eventName,
 		Number:        num,
 		ReportEntries: []imsjson.ReportEntry{{Text: "just a note", ID: -1}},
 	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, etagBefore, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
 
 	retrieved, resp := apis.getIncident(ctx, eventName, num)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-	require.Equal(t, etagBefore, resp.Header.Get("ETag"))
+	require.Equal(t, versionBefore, retrieved.Version)
 	lastEntry := retrieved.ReportEntries[len(retrieved.ReportEntries)-1]
 	require.Equal(t, "just a note", lastEntry.Text)
-
-	// A field edit carrying the pre-note ETag still succeeds, because the note
-	// didn't change the version.
-	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("edited after the note"),
-	}, etagBefore)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
 }
 
-func TestRangerAttachBumpsIncidentETag(t *testing.T) {
+func TestRangerRosterDoesNotBumpIncidentVersion(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -229,40 +132,28 @@ func TestRangerAttachBumpsIncidentETag(t *testing.T) {
 	eventName := newEventWithWriter(t, apisAdmin)
 
 	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+	versionBefore := incidentVersion(ctx, t, apis, eventName, num)
 
-	_, resp := apis.getIncident(ctx, eventName, num)
-	require.NoError(t, resp.Body.Close())
-	etagBefore := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagBefore)
-
-	// A roster change moves the incident's version, and the response carries
-	// the new ETag so the client can keep its cached value fresh.
-	resp = apis.attachRangerToIncident(ctx, eventName, num, "Some Dude")
+	// The roster lives in its own table, so no field edit can clobber it. Moving
+	// the version would only make a concurrent field edit retry for nothing.
+	resp := apis.attachRangerToIncident(ctx, eventName, num, "Some Dude")
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etagAfterAttach := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagAfterAttach)
-	require.NotEqual(t, etagBefore, etagAfterAttach)
 	require.NoError(t, resp.Body.Close())
+	require.Equal(t, versionBefore, incidentVersion(ctx, t, apis, eventName, num))
 
-	// An edit still carrying the pre-attach ETag is rejected.
-	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("stale after roster change"),
-	}, etagBefore)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-
-	// Detaching moves it again.
 	resp = apis.detachRangerFromIncident(ctx, eventName, num, "Some Dude")
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etagAfterDetach := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagAfterDetach)
-	require.NotEqual(t, etagAfterAttach, etagAfterDetach)
 	require.NoError(t, resp.Body.Close())
+	require.Equal(t, versionBefore, incidentVersion(ctx, t, apis, eventName, num))
+
+	// The roster changes themselves still landed.
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Empty(t, *retrieved.Rangers)
 }
 
-func TestFieldReportETagAndLinkBumpsBothVersions(t *testing.T) {
+func TestFieldReportVersionLifecycle(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -271,56 +162,46 @@ func TestFieldReportETagAndLinkBumpsBothVersions(t *testing.T) {
 	eventName := newEventWithWriter(t, apisAdmin)
 
 	// A field report is created directly, so it starts at version 1.
-	resp := apis.newFieldReport(ctx, imsjson.FieldReport{Event: eventName, Summary: new("an FR")})
-	require.Equal(t, http.StatusCreated, resp.StatusCode)
-	require.Equal(t, `"1"`, resp.Header.Get("ETag"))
-	frNum := parseInt32Required(t, resp.Header.Get("IMS-Field-Report-Number"))
-	require.NoError(t, resp.Body.Close())
+	frNum := apis.newFieldReportSuccess(ctx, imsjson.FieldReport{Event: eventName, Summary: new("an FR")})
+	require.Equal(t, int32(1), fieldReportVersion(ctx, t, apis, eventName, frNum))
 
-	fr, resp := apis.getFieldReport(ctx, eventName, frNum)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, `"1"`, resp.Header.Get("ETag"))
-	require.Equal(t, int32(1), fr.Version)
-
-	// A stale If-Match on a field report edit is rejected.
-	resp = apis.updateFieldReportIfMatch(ctx, eventName, frNum, imsjson.FieldReport{
+	resp := apis.updateFieldReport(ctx, eventName, frNum, imsjson.FieldReport{
 		Event:   eventName,
 		Number:  frNum,
 		Summary: new("edited summary"),
-	}, `"1"`)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
-	require.NoError(t, resp.Body.Close())
-	resp = apis.updateFieldReportIfMatch(ctx, eventName, frNum, imsjson.FieldReport{
-		Event:   eventName,
-		Number:  frNum,
-		Summary: new("stale edit"),
-	}, `"1"`)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-
-	// Attaching the field report to an incident bumps both records' versions.
-	incidentNum := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
-	incidentBefore, resp := apis.getIncident(ctx, eventName, incidentNum)
-	require.NoError(t, resp.Body.Close())
-
-	resp = apis.attachFieldReportToIncident(ctx, eventName, frNum, incidentNum)
+	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-
-	frAfter, resp := apis.getFieldReport(ctx, eventName, frNum)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Greater(t, frAfter.Version, fr.Version)
-
-	incidentAfter, resp := apis.getIncident(ctx, eventName, incidentNum)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Greater(t, incidentAfter.Version, incidentBefore.Version)
+	require.Equal(t, int32(2), fieldReportVersion(ctx, t, apis, eventName, frNum))
 }
 
-func TestIncidentTypeAttachBumpsIncidentETag(t *testing.T) {
+func TestFieldReportAttachDoesNotBumpIncidentVersion(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+	eventName := newEventWithWriter(t, apisAdmin)
+
+	frNum := apis.newFieldReportSuccess(ctx, imsjson.FieldReport{Event: eventName, Summary: new("an FR")})
+	incidentNum := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
+	incidentBefore := incidentVersion(ctx, t, apis, eventName, incidentNum)
+
+	// The attachment is stored on the Field Report, so the Incident's own
+	// columns don't change and its version stays put.
+	resp := apis.attachFieldReportToIncident(ctx, eventName, frNum, incidentNum)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	require.Equal(t, incidentBefore, incidentVersion(ctx, t, apis, eventName, incidentNum))
+
+	retrieved, resp := apis.getIncident(ctx, eventName, incidentNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, []int32{frNum}, *retrieved.FieldReports)
+}
+
+func TestIncidentTypeAttachDoesNotBumpIncidentVersion(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -329,53 +210,38 @@ func TestIncidentTypeAttachBumpsIncidentETag(t *testing.T) {
 	eventName := newEventWithWriter(t, apisAdmin)
 
 	num := apis.newIncidentSuccess(ctx, typelessIncident(eventName))
+	versionBefore := incidentVersion(ctx, t, apis, eventName, num)
 
-	_, resp := apis.getIncident(ctx, eventName, num)
+	// Type membership lives in its own table, so a field edit can't clobber it
+	// and the version has no reason to move.
+	resp := apis.attachTypeToIncident(ctx, eventName, num, 1)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-	etagBefore := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagBefore)
+	require.Equal(t, versionBefore, incidentVersion(ctx, t, apis, eventName, num))
 
-	// Attaching a type moves the incident's version, and the response carries
-	// the new ETag so the client can keep its cached value fresh.
+	retrieved, resp := apis.getIncident(ctx, eventName, num)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, []int32{1}, *retrieved.IncidentTypeIDs)
+
+	// A repeated attach is a no-op, as is a detach of an absent type. That is
+	// what makes these requests safe to retry.
 	resp = apis.attachTypeToIncident(ctx, eventName, num, 1)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etagAfterAttach := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagAfterAttach)
-	require.NotEqual(t, etagBefore, etagAfterAttach)
 	require.NoError(t, resp.Body.Close())
 
-	// A repeated attach is a no-op, so it leaves the version where it is. That
-	// is what makes the request safe to retry.
-	resp = apis.attachTypeToIncident(ctx, eventName, num, 1)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, etagAfterAttach, resp.Header.Get("ETag"))
-	require.NoError(t, resp.Body.Close())
-
-	// An edit still carrying the pre-attach ETag is rejected.
-	resp = apis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("stale after type change"),
-	}, etagBefore)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-
-	// The endpoint takes no If-Match of its own: it always applies.
 	resp = apis.detachTypeFromIncident(ctx, eventName, num, 1)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etagAfterDetach := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagAfterDetach)
-	require.NotEqual(t, etagAfterAttach, etagAfterDetach)
 	require.NoError(t, resp.Body.Close())
 
-	// A detach of an absent type is a no-op, so it too leaves the version alone.
 	resp = apis.detachTypeFromIncident(ctx, eventName, num, 1)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, etagAfterDetach, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
+
+	require.Equal(t, versionBefore, incidentVersion(ctx, t, apis, eventName, num))
 }
 
-func TestIncidentLinkEndpointBumpsBothETags(t *testing.T) {
+func TestIncidentLinkEndpointDoesNotBumpEitherVersion(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -385,53 +251,38 @@ func TestIncidentLinkEndpointBumpsBothETags(t *testing.T) {
 
 	num1 := apis.newIncidentSuccess(ctx, typelessIncident(eventName))
 	num2 := apis.newIncidentSuccess(ctx, typelessIncident(eventName))
+	before1 := incidentVersion(ctx, t, apis, eventName, num1)
+	before2 := incidentVersion(ctx, t, apis, eventName, num2)
 
-	before1, resp := apis.getIncident(ctx, eventName, num1)
+	// A link is stored in LINKED_INCIDENT, so neither Incident row changes and
+	// neither version moves.
+	resp := apis.linkIncident(ctx, eventName, num1, eventName, num2)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-	etagBefore1 := resp.Header.Get("ETag")
-	before2, resp := apis.getIncident(ctx, eventName, num2)
-	require.NoError(t, resp.Body.Close())
+	require.Equal(t, before1, incidentVersion(ctx, t, apis, eventName, num1))
+	require.Equal(t, before2, incidentVersion(ctx, t, apis, eventName, num2))
 
-	// A link changes both Incidents' representations, so both versions move.
+	retrieved, resp := apis.getIncident(ctx, eventName, num1)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Len(t, *retrieved.LinkedIncidents, 1)
+	require.Equal(t, num2, (*retrieved.LinkedIncidents)[0].Number)
+
+	// A repeated link is a no-op on both, and unlinking leaves the versions
+	// alone too.
 	resp = apis.linkIncident(ctx, eventName, num1, eventName, num2)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	etagAfterLink := resp.Header.Get("ETag")
-	require.NotEmpty(t, etagAfterLink)
-	require.NotEqual(t, etagBefore1, etagAfterLink)
 	require.NoError(t, resp.Body.Close())
 
-	// The response's ETag is the path Incident's.
-	after1, resp := apis.getIncident(ctx, eventName, num1)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, etagAfterLink, resp.Header.Get("ETag"))
-	require.Greater(t, after1.Version, before1.Version)
-
-	after2, resp := apis.getIncident(ctx, eventName, num2)
-	require.NoError(t, resp.Body.Close())
-	require.Greater(t, after2.Version, before2.Version)
-
-	// A repeated link is a no-op on both.
-	resp = apis.linkIncident(ctx, eventName, num1, eventName, num2)
-	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, etagAfterLink, resp.Header.Get("ETag"))
-	require.NoError(t, resp.Body.Close())
-
-	noopOn2, resp := apis.getIncident(ctx, eventName, num2)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, after2.Version, noopOn2.Version)
-
-	// Unlinking moves both again.
 	resp = apis.unlinkIncident(ctx, eventName, num1, eventName, num2)
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.NotEqual(t, etagAfterLink, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
 
-	unlinked2, resp := apis.getIncident(ctx, eventName, num2)
-	require.NoError(t, resp.Body.Close())
-	require.Greater(t, unlinked2.Version, after2.Version)
+	require.Equal(t, before1, incidentVersion(ctx, t, apis, eventName, num1))
+	require.Equal(t, before2, incidentVersion(ctx, t, apis, eventName, num2))
 }
 
-func TestVisitETagAndReassignmentBumpsIncidents(t *testing.T) {
+func TestVisitVersionLifecycleAndReassignment(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
 
@@ -447,38 +298,33 @@ func TestVisitETagAndReassignmentBumpsIncidents(t *testing.T) {
 
 	// Creation goes through the guarded update path, so a new visit's version
 	// is 2, matching incidents.
-	resp = apis.newVisit(ctx, imsjson.Visit{
+	visitNum := apis.newVisitSuccess(ctx, imsjson.Visit{
 		Event:              eventName,
 		GuestPreferredName: new("A. Guest"),
 	})
-	require.Equal(t, http.StatusCreated, resp.StatusCode)
-	require.Equal(t, `"2"`, resp.Header.Get("ETag"))
-	visitNum := parseInt32Required(t, resp.Header.Get("IMS-Visit-Number"))
+	retrieved, resp := apis.getVisit(ctx, eventName, visitNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(2), retrieved.Version)
 
-	// An edit with the current ETag succeeds; repeating it with the stale one fails.
-	resp = apis.updateVisitIfMatch(ctx, eventName, visitNum, imsjson.Visit{
+	resp = apis.updateVisit(ctx, eventName, visitNum, imsjson.Visit{
 		Event:            eventName,
 		Number:           visitNum,
 		GuestDescription: new("wearing a big hat"),
-	}, `"2"`)
+	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	require.Equal(t, `"3"`, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
-	resp = apis.updateVisitIfMatch(ctx, eventName, visitNum, imsjson.Visit{
-		Event:            eventName,
-		Number:           visitNum,
-		GuestDescription: new("stale edit"),
-	}, `"2"`)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
+	retrieved, resp = apis.getVisit(ctx, eventName, visitNum)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
+	require.Equal(t, int32(3), retrieved.Version)
 
-	// Assigning the visit to an incident bumps the incident's version too.
-	// Incident operations use the admin here: granting Alice VisitWriter above
-	// replaced her person-expression access rules, including her Writer role.
+	// Assigning the visit to an incident is stored on the visit, so the
+	// incident's version stays put. Incident operations use the admin here:
+	// granting Alice VisitWriter above replaced her person-expression access
+	// rules, including her Writer role.
 	incidentNum := apisAdmin.newIncidentSuccess(ctx, sampleIncident1(eventName))
-	incidentBefore, resp := apisAdmin.getIncident(ctx, eventName, incidentNum)
-	require.NoError(t, resp.Body.Close())
+	incidentBefore := incidentVersion(ctx, t, apisAdmin, eventName, incidentNum)
 
 	resp = apis.updateVisit(ctx, eventName, visitNum, imsjson.Visit{
 		Event:    eventName,
@@ -488,10 +334,12 @@ func TestVisitETagAndReassignmentBumpsIncidents(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 
-	incidentAfter, resp := apisAdmin.getIncident(ctx, eventName, incidentNum)
+	require.Equal(t, incidentBefore, incidentVersion(ctx, t, apisAdmin, eventName, incidentNum))
+
+	retrievedIncident, resp := apisAdmin.getIncident(ctx, eventName, incidentNum)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
-	require.Greater(t, incidentAfter.Version, incidentBefore.Version)
+	require.Equal(t, []int32{visitNum}, *retrievedIncident.Visits)
 }
 
 // casInterceptor wraps the sqlc Querier so a test can act in a race window:
@@ -548,22 +396,20 @@ func interceptedServer(t *testing.T, interceptor casInterceptor) *url.URL {
 }
 
 // The bump helpers below commit a version bump for the record being updated,
-// simulating another writer's edit landing first. They assert rather than
-// require, since they run on the server's request goroutine.
+// simulating another writer's edit landing first. No production code path bumps
+// a version on its own — only the guarded UPDATEs move it — so there are no sqlc
+// queries for these; the competing writes go out directly. They assert rather
+// than require, since they run on the server's request goroutine.
 
 func bumpIncidentVersion(ctx context.Context, t *testing.T, event, number int32) {
 	t.Helper()
-	err := shared.imsDBQ.BumpIncidentVersion(ctx, shared.imsDBQ, imsdb.BumpIncidentVersionParams{
-		Event:  event,
-		Number: number,
-	})
+	_, err := shared.imsDBQ.ExecContext(ctx,
+		"update INCIDENT set VERSION = VERSION + 1 where EVENT = ? and NUMBER = ?", event, number)
 	assert.NoError(t, err)
 }
 
 func bumpFieldReportVersion(ctx context.Context, t *testing.T, event, number int32) {
 	t.Helper()
-	// No production code path needs a bare field report bump, so there's no
-	// sqlc query for it; do the competing write directly.
 	_, err := shared.imsDBQ.ExecContext(ctx,
 		"update FIELD_REPORT set VERSION = VERSION + 1 where EVENT = ? and NUMBER = ?", event, number)
 	assert.NoError(t, err)
@@ -571,10 +417,8 @@ func bumpFieldReportVersion(ctx context.Context, t *testing.T, event, number int
 
 func bumpVisitVersion(ctx context.Context, t *testing.T, event, number int32) {
 	t.Helper()
-	err := shared.imsDBQ.BumpVisitVersion(ctx, shared.imsDBQ, imsdb.BumpVisitVersionParams{
-		Event:  event,
-		Number: number,
-	})
+	_, err := shared.imsDBQ.ExecContext(ctx,
+		"update VISIT set VERSION = VERSION + 1 where EVENT = ? and NUMBER = ?", event, number)
 	assert.NoError(t, err)
 }
 
@@ -599,16 +443,14 @@ func TestIncidentEditRetriesPastConcurrentWrite(t *testing.T) {
 	})
 	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
 
-	// Without an If-Match header, the server retries internally and the edit
-	// still lands, on the second attempt.
+	// The server retries the read-merge-write internally, so the edit still
+	// lands, on the second attempt.
 	resp := hookedApis.updateIncident(ctx, eventName, num, imsjson.Incident{
 		Event:   eventName,
 		Number:  num,
 		Summary: new("landed on the retry"),
 	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	// Version 2 at creation, 3 after the competing write, 4 after this edit.
-	require.Equal(t, `"4"`, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, int32(2), updateAttempts.Load())
 
@@ -655,50 +497,6 @@ func TestIncidentEditGivesUpAfterRepeatedConcurrentWrites(t *testing.T) {
 	require.Equal(t, *sampleIncident1(eventName).Summary, *retrieved.Summary)
 }
 
-func TestIncidentEditIfMatchLosingRaceIs412(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithWriter(t, apisAdmin)
-	num := apis.newIncidentSuccess(ctx, sampleIncident1(eventName))
-
-	_, resp := apis.getIncident(ctx, eventName, num)
-	require.NoError(t, resp.Body.Close())
-	etag := resp.Header.Get("ETag")
-	require.NotEmpty(t, etag)
-
-	// The If-Match precondition passes against the version this edit read, but
-	// a competing write commits before the guarded UPDATE runs.
-	var updateAttempts atomic.Int32
-	hookedURL := interceptedServer(t, casInterceptor{
-		beforeUpdateIncident: func(ctx context.Context, arg imsdb.UpdateIncidentParams) {
-			if updateAttempts.Add(1) == 1 {
-				bumpIncidentVersion(ctx, t, arg.Event, arg.Number)
-			}
-		},
-	})
-	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
-
-	// An edit carrying If-Match gets no retries: the conflict must be reported
-	// back as a 412 so the client can re-fetch and re-apply its change.
-	resp = hookedApis.updateIncidentIfMatch(ctx, eventName, num, imsjson.Incident{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("this edit must not land"),
-	}, etag)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, int32(1), updateAttempts.Load())
-
-	retrieved, resp := apis.getIncident(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, *sampleIncident1(eventName).Summary, *retrieved.Summary)
-}
-
 func TestFieldReportEditRetriesPastConcurrentWrite(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -720,16 +518,14 @@ func TestFieldReportEditRetriesPastConcurrentWrite(t *testing.T) {
 	})
 	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
 
-	// Without an If-Match header, the server retries internally and the edit
-	// still lands, on the second attempt.
+	// The server retries the read-merge-write internally, so the edit still
+	// lands, on the second attempt.
 	resp := hookedApis.updateFieldReport(ctx, eventName, num, imsjson.FieldReport{
 		Event:   eventName,
 		Number:  num,
 		Summary: new("landed on the retry"),
 	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	// Version 1 at creation, 2 after the competing write, 3 after this edit.
-	require.Equal(t, `"3"`, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, int32(2), updateAttempts.Load())
 
@@ -776,53 +572,6 @@ func TestFieldReportEditGivesUpAfterRepeatedConcurrentWrites(t *testing.T) {
 	require.Equal(t, "original summary", *retrieved.Summary)
 }
 
-func TestFieldReportEditIfMatchLosingRaceIs412(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithWriter(t, apisAdmin)
-	num := apis.newFieldReportSuccess(ctx, imsjson.FieldReport{Event: eventName, Summary: new("original summary")})
-
-	_, resp := apis.getFieldReport(ctx, eventName, num)
-	require.NoError(t, resp.Body.Close())
-	etag := resp.Header.Get("ETag")
-	require.NotEmpty(t, etag)
-
-	// The If-Match precondition passes against the version this edit read, but
-	// a competing write commits before the guarded UPDATE runs.
-	var updateAttempts atomic.Int32
-	hookedURL := interceptedServer(t, casInterceptor{
-		beforeUpdateFieldReport: func(ctx context.Context, arg imsdb.UpdateFieldReportParams) {
-			if updateAttempts.Add(1) == 1 {
-				bumpFieldReportVersion(ctx, t, arg.Event, arg.Number)
-			}
-		},
-	})
-	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
-
-	// An edit carrying If-Match gets no retries: the conflict must be reported
-	// back as a 412 so the client can re-fetch and re-apply its change.
-	resp = hookedApis.updateFieldReportIfMatch(ctx, eventName, num, imsjson.FieldReport{
-		Event:   eventName,
-		Number:  num,
-		Summary: new("this edit must not land"),
-	}, etag)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, int32(1), updateAttempts.Load())
-
-	retrieved, resp := apis.getFieldReport(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, "original summary", *retrieved.Summary)
-}
-
-// newEventWithVisitWriter makes a fresh event and gives Alice the VisitWriter
-// role on it. That role is granted instead of Writer, not in addition: setting
-// it replaces Alice's person-expression access rules for the event.
 func newEventWithVisitWriter(t *testing.T, apisAdmin ApiHelper) (eventName string) {
 	t.Helper()
 	ctx := t.Context()
@@ -860,16 +609,14 @@ func TestVisitEditRetriesPastConcurrentWrite(t *testing.T) {
 	})
 	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
 
-	// Without an If-Match header, the server retries internally and the edit
-	// still lands, on the second attempt.
+	// The server retries the read-merge-write internally, so the edit still
+	// lands, on the second attempt.
 	resp := hookedApis.updateVisit(ctx, eventName, num, imsjson.Visit{
 		Event:            eventName,
 		Number:           num,
 		GuestDescription: new("landed on the retry"),
 	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
-	// Version 2 at creation, 3 after the competing write, 4 after this edit.
-	require.Equal(t, `"4"`, resp.Header.Get("ETag"))
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, int32(2), updateAttempts.Load())
 
@@ -917,60 +664,4 @@ func TestVisitEditGivesUpAfterRepeatedConcurrentWrites(t *testing.T) {
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, "original description", *retrieved.GuestDescription)
-}
-
-func TestVisitEditIfMatchLosingRaceIs412(t *testing.T) {
-	t.Parallel()
-	ctx := t.Context()
-
-	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
-	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
-	eventName := newEventWithVisitWriter(t, apisAdmin)
-	num := apis.newVisitSuccess(ctx, imsjson.Visit{
-		Event:            eventName,
-		GuestDescription: new("original description"),
-	})
-
-	_, resp := apis.getVisit(ctx, eventName, num)
-	require.NoError(t, resp.Body.Close())
-	etag := resp.Header.Get("ETag")
-	require.NotEmpty(t, etag)
-
-	// The If-Match precondition passes against the version this edit read, but
-	// a competing write commits before the guarded UPDATE runs.
-	var updateAttempts atomic.Int32
-	hookedURL := interceptedServer(t, casInterceptor{
-		beforeUpdateVisit: func(ctx context.Context, arg imsdb.UpdateVisitParams) {
-			if updateAttempts.Add(1) == 1 {
-				bumpVisitVersion(ctx, t, arg.Event, arg.Number)
-			}
-		},
-	})
-	hookedApis := ApiHelper{t: t, serverURL: hookedURL, jwt: apis.jwt}
-
-	// An edit carrying If-Match gets no retries: the conflict must be reported
-	// back as a 412 so the client can re-fetch and re-apply its change.
-	resp = hookedApis.updateVisitIfMatch(ctx, eventName, num, imsjson.Visit{
-		Event:            eventName,
-		Number:           num,
-		GuestDescription: new("this edit must not land"),
-	}, etag)
-	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode)
-	require.Equal(t, "application/problem+json", resp.Header.Get("Content-Type"))
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, int32(1), updateAttempts.Load())
-
-	retrieved, resp := apis.getVisit(ctx, eventName, num)
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.NoError(t, resp.Body.Close())
-	require.Equal(t, "original description", *retrieved.GuestDescription)
-}
-
-func parseInt32Required(t *testing.T, s string) int32 {
-	t.Helper()
-	require.NotEmpty(t, s)
-	num, err := conv.ParseInt32(s)
-	require.NoError(t, err)
-	require.Positive(t, num)
-	return num
 }

--- a/api/integration/visit_test.go
+++ b/api/integration/visit_test.go
@@ -305,10 +305,10 @@ func TestCreateAndUpdateVisit(t *testing.T) {
 	incidentNumber := apisAdmin.newIncidentSuccess(ctx, imsjson.Incident{
 		Event: eventName,
 	})
-	resp = apisAdmin.updateIncident(ctx, eventName, num, imsjson.Incident{
-		Event:  eventName,
-		Number: incidentNumber,
-		Visits: &[]int32{num},
+	resp = apisAdmin.updateVisit(ctx, eventName, num, imsjson.Visit{
+		Event:    eventName,
+		Number:   num,
+		Incident: &incidentNumber,
 	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
@@ -319,11 +319,21 @@ func TestCreateAndUpdateVisit(t *testing.T) {
 	require.NoError(t, resp.Body.Close())
 	require.Equal(t, incidentNumber, *visitAfterAttach.Incident)
 
-	// detach
-	resp = apisAdmin.updateIncident(ctx, eventName, num, imsjson.Incident{
+	// The Incident API used to accept a replacement Visit list, which silently
+	// dropped a concurrent writer's attachment. It's rejected now.
+	resp = apisAdmin.updateIncident(ctx, eventName, incidentNumber, imsjson.Incident{
 		Event:  eventName,
 		Number: incidentNumber,
 		Visits: &[]int32{},
+	})
+	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// detach
+	resp = apisAdmin.updateVisit(ctx, eventName, num, imsjson.Visit{
+		Event:    eventName,
+		Number:   num,
+		Incident: new(int32(0)),
 	})
 	require.Equal(t, http.StatusNoContent, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())

--- a/api/ranger.go
+++ b/api/ranger.go
@@ -42,12 +42,7 @@ type rangerRoster struct {
 	detach         func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, rangerHandle string) error
 	attach         func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, rangerHandle string, role sql.NullString) error
 	addReportEntry func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, entry newReportEntry) (int32, *herr.HTTPError)
-	// bumpVersion moves the parent record's optimistic-concurrency version, so
-	// that clients holding its ETag notice the roster change. getVersion reads
-	// the resulting version for the response's ETag header.
-	bumpVersion  func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) error
-	getVersion   func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) (int32, error)
-	notifyUpdate func(eventID, number int32)
+	notifyUpdate   func(eventID, number int32)
 }
 
 func incidentRangerRoster(imsDBQ *store.DBQ, es *EventSourcerer) rangerRoster {
@@ -73,18 +68,6 @@ func incidentRangerRoster(imsDBQ *store.DBQ, es *EventSourcerer) rangerRoster {
 		},
 		addReportEntry: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, entry newReportEntry) (int32, *herr.HTTPError) {
 			return addIncidentReportEntry(ctx, imsDBQ, dbtx, eventID, number, entry)
-		},
-		bumpVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) error {
-			return imsDBQ.BumpIncidentVersion(ctx, dbtx, imsdb.BumpIncidentVersionParams{
-				Event:  eventID,
-				Number: number,
-			})
-		},
-		getVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) (int32, error) {
-			return imsDBQ.IncidentVersion(ctx, dbtx, imsdb.IncidentVersionParams{
-				Event:  eventID,
-				Number: number,
-			})
 		},
 		notifyUpdate: es.notifyIncidentUpdate,
 	}
@@ -113,18 +96,6 @@ func visitRangerRoster(imsDBQ *store.DBQ, es *EventSourcerer) rangerRoster {
 		},
 		addReportEntry: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32, entry newReportEntry) (int32, *herr.HTTPError) {
 			return addVisitReportEntry(ctx, imsDBQ, dbtx, eventID, number, entry)
-		},
-		bumpVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) error {
-			return imsDBQ.BumpVisitVersion(ctx, dbtx, imsdb.BumpVisitVersionParams{
-				Event:  eventID,
-				Number: number,
-			})
-		},
-		getVersion: func(ctx context.Context, dbtx imsdb.DBTX, eventID, number int32) (int32, error) {
-			return imsDBQ.VisitVersion(ctx, dbtx, imsdb.VisitVersionParams{
-				Event:  eventID,
-				Number: number,
-			})
 		},
 		notifyUpdate: es.notifyVisitUpdate,
 	}
@@ -181,133 +152,106 @@ type rangerRosterBody struct {
 func attachRanger(
 	req *http.Request, roster rangerRoster,
 	imsDBQ *store.DBQ, userStore *directory.UserStore, imsAdmins []string,
-) (int32, *herr.HTTPError) {
+) *herr.HTTPError {
 	rosterReq, errHTTP := parseRangerRosterRequest(req, roster, imsDBQ, userStore, imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[parseRangerRosterRequest]")
+		return errHTTP.From("[parseRangerRosterRequest]")
 	}
 	body, errHTTP := readBodyAs[rangerRosterBody](req)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[readBodyAs]")
+		return errHTTP.From("[readBodyAs]")
 	}
 	ctx := req.Context()
 
-	txn, err := imsDBQ.Begin()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
+	// The whole transaction is retried if it loses a deadlock, so nothing here
+	// may escape the database before the commit.
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := imsDBQ.Begin()
+		if err != nil {
+			return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
 
-	// The version moves before the roster is written, not after. See the note on
-	// bumpRosterVersion: this is what keeps two Rangers editing the same roster
-	// at once from deadlocking each other.
-	version, errHTTP := bumpRosterVersion(ctx, txn, roster, rosterReq)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[bumpRosterVersion]")
-	}
+		// Detach first, so that attaching a Ranger who is already on the roster
+		// updates their role rather than failing.
+		err = roster.detach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName)
+		if err != nil {
+			return herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
+		}
 
-	// Detach first, so that attaching a Ranger who is already on the roster
-	// updates their role rather than failing.
-	err = roster.detach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName)
-	if err != nil {
-		return 0, herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
-	}
+		err = roster.attach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName, conv.StringToSql(body.Role, 128))
+		if err != nil {
+			return herr.InternalServerError(fmt.Sprintf("Failed to attach Ranger to %v", roster.noun), err).From("[attach]")
+		}
 
-	err = roster.attach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName, conv.StringToSql(body.Role, 128))
-	if err != nil {
-		return 0, herr.InternalServerError(fmt.Sprintf("Failed to attach Ranger to %v", roster.noun), err).From("[attach]")
-	}
-
-	_, errHTTP = roster.addReportEntry(ctx, txn, rosterReq.event.ID, rosterReq.number, newReportEntry{
-		author:    rosterReq.author,
-		text:      fmt.Sprintf("Added Ranger: %v", rosterReq.rangerName),
-		generated: true,
+		_, errHTTP := roster.addReportEntry(ctx, txn, rosterReq.event.ID, rosterReq.number, newReportEntry{
+			author:    rosterReq.author,
+			text:      fmt.Sprintf("Added Ranger: %v", rosterReq.rangerName),
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addReportEntry]")
+		}
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return 0, errHTTP.From("[addReportEntry]")
-	}
-	err = txn.Commit()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	roster.notifyUpdate(rosterReq.event.ID, rosterReq.number)
 
-	return version, nil
-}
-
-// bumpRosterVersion moves the parent record's version within the roster
-// transaction and returns the new version for the response's ETag.
-//
-// Both callers run this first, before touching the roster itself. A write to the
-// roster table takes a shared lock on the parent Incident or Visit row for its
-// foreign key, and this bump needs that same row exclusively; in the other order
-// two concurrent writers each hold the shared lock the other is waiting to
-// upgrade past, and MariaDB resolves that by killing one of them with a deadlock
-// error, which reaches the client as a 500. Bumping first makes the parent row
-// the one place those writers queue, and every lock the rest of the transaction
-// wants on it is held from then on.
-//
-// This mirrors setIncidentType and setIncidentLink in incidentrelation.go, which
-// write set memberships hanging off an Incident the same way.
-func bumpRosterVersion(
-	ctx context.Context, txn *sql.Tx, roster rangerRoster, rosterReq rangerRosterRequest,
-) (int32, *herr.HTTPError) {
-	err := roster.bumpVersion(ctx, txn, rosterReq.event.ID, rosterReq.number)
-	if err != nil {
-		return 0, herr.InternalServerError(fmt.Sprintf("Failed to update %v", roster.noun), err).From("[bumpVersion]")
-	}
-	version, err := roster.getVersion(ctx, txn, rosterReq.event.ID, rosterReq.number)
-	if err != nil {
-		return 0, herr.InternalServerError(fmt.Sprintf("Failed to fetch %v", roster.noun), err).From("[getVersion]")
-	}
-	return version, nil
+	return nil
 }
 
 func detachRanger(
 	req *http.Request, roster rangerRoster,
 	imsDBQ *store.DBQ, userStore *directory.UserStore, imsAdmins []string,
-) (int32, *herr.HTTPError) {
+) *herr.HTTPError {
 	rosterReq, errHTTP := parseRangerRosterRequest(req, roster, imsDBQ, userStore, imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[parseRangerRosterRequest]")
+		return errHTTP.From("[parseRangerRosterRequest]")
 	}
 	ctx := req.Context()
 
-	txn, err := imsDBQ.Begin()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
+	// Retried on deadlock, as in attachRanger.
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := imsDBQ.Begin()
+		if err != nil {
+			return herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
 
-	// Bumped before the roster write, as in attachRanger.
-	version, errHTTP := bumpRosterVersion(ctx, txn, roster, rosterReq)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[bumpRosterVersion]")
-	}
+		err = roster.detach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName)
+		if err != nil {
+			return herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
+		}
 
-	err = roster.detach(ctx, txn, rosterReq.event.ID, rosterReq.number, rosterReq.rangerName)
-	if err != nil {
-		return 0, herr.InternalServerError(fmt.Sprintf("Failed to detach Ranger from %v", roster.noun), err).From("[detach]")
-	}
+		_, errHTTP := roster.addReportEntry(ctx, txn, rosterReq.event.ID, rosterReq.number, newReportEntry{
+			author:    rosterReq.author,
+			text:      fmt.Sprintf("Removed Ranger: %v", rosterReq.rangerName),
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addReportEntry]")
+		}
 
-	_, errHTTP = roster.addReportEntry(ctx, txn, rosterReq.event.ID, rosterReq.number, newReportEntry{
-		author:    rosterReq.author,
-		text:      fmt.Sprintf("Removed Ranger: %v", rosterReq.rangerName),
-		generated: true,
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return 0, errHTTP.From("[addReportEntry]")
-	}
-
-	err = txn.Commit()
-	if err != nil {
-		return 0, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	roster.notifyUpdate(rosterReq.event.ID, rosterReq.number)
 
-	return version, nil
+	return nil
 }
 
 type AttachRangerToIncident struct {
@@ -318,12 +262,11 @@ type AttachRangerToIncident struct {
 }
 
 func (action AttachRangerToIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := attachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	errHTTP := attachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[attachRanger]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -335,12 +278,11 @@ type DetachRangerFromIncident struct {
 }
 
 func (action DetachRangerFromIncident) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := detachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	errHTTP := detachRanger(req, incidentRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[detachRanger]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -352,12 +294,11 @@ type AttachRangerToVisit struct {
 }
 
 func (action AttachRangerToVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := attachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	errHTTP := attachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[attachRanger]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
@@ -369,11 +310,10 @@ type DetachRangerFromVisit struct {
 }
 
 func (action DetachRangerFromVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := detachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
+	errHTTP := detachRanger(req, visitRangerRoster(action.imsDBQ, action.es), action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
 		errHTTP.From("[detachRanger]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }

--- a/api/reportentry.go
+++ b/api/reportentry.go
@@ -160,10 +160,9 @@ func addChangeReportEntries(
 	return nil
 }
 
-// The strike/unstrike handlers below deliberately do not bump the parent
-// record's VERSION/ETag: like appends, strikes cannot silently lose data,
-// so they are exempt from optimistic concurrency (see the VERSION column
-// comment in store/schema/current.sql).
+// The strike/unstrike handlers below do not move the parent record's VERSION.
+// Report entries are their own table, so no edit of the parent can clobber
+// them; see the VERSION column comment in store/schema/current.sql.
 
 type EditFieldReportReportEntry struct {
 	imsDBQ      *store.DBQ
@@ -220,38 +219,44 @@ func (action EditFieldReportReportEntry) editFieldReportEntry(req *http.Request)
 		return nil
 	}
 
-	txn, err := action.imsDBQ.Begin()
-	if err != nil {
-		return herr.InternalServerError("Error beginning transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := action.imsDBQ.Begin()
+		if err != nil {
+			return herr.InternalServerError("Error beginning transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
 
-	err = action.imsDBQ.SetFieldReportReportEntryStricken(ctx, txn,
-		imsdb.SetFieldReportReportEntryStrickenParams{
-			Stricken:          *re.Stricken,
-			Event:             event.ID,
-			FieldReportNumber: fieldReportNumber,
-			ReportEntry:       reportEntryId,
-		},
-	)
-	if err != nil {
-		return herr.InternalServerError("Error setting field report entry", err).From("[SetFieldReportReportEntryStricken]")
-	}
-	struckVerb := "Struck"
-	if !*re.Stricken {
-		struckVerb = "Unstruck"
-	}
-	_, errHTTP = addFRReportEntry(ctx, action.imsDBQ, txn, event.ID, fieldReportNumber, newReportEntry{
-		author:    author,
-		text:      fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId),
-		generated: true,
+		err = action.imsDBQ.SetFieldReportReportEntryStricken(ctx, txn,
+			imsdb.SetFieldReportReportEntryStrickenParams{
+				Stricken:          *re.Stricken,
+				Event:             event.ID,
+				FieldReportNumber: fieldReportNumber,
+				ReportEntry:       reportEntryId,
+			},
+		)
+		if err != nil {
+			return herr.InternalServerError("Error setting field report entry", err).From("[SetFieldReportReportEntryStricken]")
+		}
+		struckVerb := "Struck"
+		if !*re.Stricken {
+			struckVerb = "Unstruck"
+		}
+		_, errHTTP := addFRReportEntry(ctx, action.imsDBQ, txn, event.ID, fieldReportNumber, newReportEntry{
+			author:    author,
+			text:      fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId),
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addFRReportEntry]")
+		}
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Error committing transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return errHTTP.From("[addFRReportEntry]")
-	}
-	err = txn.Commit()
-	if err != nil {
-		return herr.InternalServerError("Error committing transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	defer action.eventSource.notifyFieldReportUpdate(event.ID, fieldReportNumber)
@@ -306,38 +311,44 @@ func (action EditIncidentReportEntry) editIncidentReportEntry(req *http.Request)
 		return nil
 	}
 
-	txn, err := action.imsDBQ.Begin()
-	if err != nil {
-		return herr.InternalServerError("Error beginning transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := action.imsDBQ.Begin()
+		if err != nil {
+			return herr.InternalServerError("Error beginning transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
 
-	err = action.imsDBQ.SetIncidentReportEntryStricken(ctx, txn,
-		imsdb.SetIncidentReportEntryStrickenParams{
-			Stricken:       *re.Stricken,
-			Event:          event.ID,
-			IncidentNumber: incidentNumber,
-			ReportEntry:    reportEntryId,
-		},
-	)
-	if err != nil {
-		return herr.InternalServerError("Error setting incident report entry", err).From("[SetIncidentReportEntryStricken]")
-	}
-	struckVerb := "Struck"
-	if !*re.Stricken {
-		struckVerb = "Unstruck"
-	}
-	_, errHTTP = addIncidentReportEntry(ctx, action.imsDBQ, txn, event.ID, incidentNumber, newReportEntry{
-		author:    author,
-		text:      fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId),
-		generated: true,
+		err = action.imsDBQ.SetIncidentReportEntryStricken(ctx, txn,
+			imsdb.SetIncidentReportEntryStrickenParams{
+				Stricken:       *re.Stricken,
+				Event:          event.ID,
+				IncidentNumber: incidentNumber,
+				ReportEntry:    reportEntryId,
+			},
+		)
+		if err != nil {
+			return herr.InternalServerError("Error setting incident report entry", err).From("[SetIncidentReportEntryStricken]")
+		}
+		struckVerb := "Struck"
+		if !*re.Stricken {
+			struckVerb = "Unstruck"
+		}
+		_, errHTTP := addIncidentReportEntry(ctx, action.imsDBQ, txn, event.ID, incidentNumber, newReportEntry{
+			author:    author,
+			text:      fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId),
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addIncidentReportEntry]")
+		}
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Error committing transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return errHTTP.From("[addIncidentReportEntry]")
-	}
-	err = txn.Commit()
-	if err != nil {
-		return herr.InternalServerError("Error committing transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	defer action.eventSource.notifyIncidentUpdate(event.ID, incidentNumber)
@@ -399,38 +410,44 @@ func (action EditVisitReportEntry) editVisitReportEntry(req *http.Request) *herr
 		return nil
 	}
 
-	txn, err := action.imsDBQ.Begin()
-	if err != nil {
-		return herr.InternalServerError("Error beginning transaction", err).From("[Begin]")
-	}
-	defer rollback(txn)
+	errHTTP = retryOnDeadlockErr(func() *herr.HTTPError {
+		txn, err := action.imsDBQ.Begin()
+		if err != nil {
+			return herr.InternalServerError("Error beginning transaction", err).From("[Begin]")
+		}
+		defer rollback(txn)
 
-	err = action.imsDBQ.SetVisitReportEntryStricken(ctx, txn,
-		imsdb.SetVisitReportEntryStrickenParams{
-			Stricken:    *re.Stricken,
-			Event:       event.ID,
-			VisitNumber: visitNumber,
-			ReportEntry: reportEntryId,
-		},
-	)
-	if err != nil {
-		return herr.InternalServerError("Error setting visit report entry", err).From("[SetVisitReportEntryStricken]")
-	}
-	struckVerb := "Struck"
-	if !*re.Stricken {
-		struckVerb = "Unstruck"
-	}
-	_, errHTTP = addVisitReportEntry(ctx, action.imsDBQ, txn, event.ID, visitNumber, newReportEntry{
-		author:    author,
-		text:      fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId),
-		generated: true,
+		err = action.imsDBQ.SetVisitReportEntryStricken(ctx, txn,
+			imsdb.SetVisitReportEntryStrickenParams{
+				Stricken:    *re.Stricken,
+				Event:       event.ID,
+				VisitNumber: visitNumber,
+				ReportEntry: reportEntryId,
+			},
+		)
+		if err != nil {
+			return herr.InternalServerError("Error setting visit report entry", err).From("[SetVisitReportEntryStricken]")
+		}
+		struckVerb := "Struck"
+		if !*re.Stricken {
+			struckVerb = "Unstruck"
+		}
+		_, errHTTP := addVisitReportEntry(ctx, action.imsDBQ, txn, event.ID, visitNumber, newReportEntry{
+			author:    author,
+			text:      fmt.Sprintf("%v reportEntry %v", struckVerb, reportEntryId),
+			generated: true,
+		})
+		if errHTTP != nil {
+			return errHTTP.From("[addVisitReportEntry]")
+		}
+		err = txn.Commit()
+		if err != nil {
+			return herr.InternalServerError("Error committing transaction", err).From("[Commit]")
+		}
+		return nil
 	})
 	if errHTTP != nil {
-		return errHTTP.From("[addVisitReportEntry]")
-	}
-	err = txn.Commit()
-	if err != nil {
-		return herr.InternalServerError("Error committing transaction", err).From("[Commit]")
+		return errHTTP
 	}
 
 	defer action.eventSource.notifyVisitUpdate(event.ID, visitNumber)

--- a/api/visit.go
+++ b/api/visit.go
@@ -148,7 +148,6 @@ func (action GetVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		errHTTP.From("[getVisit]").WriteResponse(w)
 		return
 	}
-	setETag(w, resp.Version)
 	mustWriteJSON(w, req, resp)
 }
 
@@ -298,7 +297,7 @@ type NewVisit struct {
 }
 
 func (action NewVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	number, version, location, errHTTP := action.newVisit(req)
+	number, location, errHTTP := action.newVisit(req)
 	if errHTTP != nil {
 		errHTTP.From("[newVisit]").WriteResponse(w)
 		return
@@ -306,21 +305,20 @@ func (action NewVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 
 	w.Header().Set("IMS-Visit-Number", strconv.Itoa(int(number)))
 	w.Header().Set("Location", location)
-	setETag(w, version)
 	herr.WriteCreatedResponse(w, http.StatusText(http.StatusCreated))
 }
-func (action NewVisit) newVisit(req *http.Request) (visitNumber, version int32, location string, errHTTP *herr.HTTPError) {
+func (action NewVisit) newVisit(req *http.Request) (visitNumber int32, location string, errHTTP *herr.HTTPError) {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, 0, "", errHTTP.From("[getEventPermissions]")
+		return 0, "", errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteVisits == 0 {
-		return 0, 0, "", herr.Forbidden("The requestor does not have EventWriteVisits permission on this Event", nil)
+		return 0, "", herr.Forbidden("The requestor does not have EventWriteVisits permission on this Event", nil)
 	}
 	ctx := req.Context()
 	newVisit, errHTTP := readBodyAs[imsjson.Visit](req)
 	if errHTTP != nil {
-		return 0, 0, "", errHTTP.From("[readBodyAs]")
+		return 0, "", errHTTP.From("[readBodyAs]")
 	}
 
 	author := jwtCtx.Claims.RangerHandle()
@@ -333,7 +331,7 @@ func (action NewVisit) newVisit(req *http.Request) (visitNumber, version int32, 
 		var err error
 		newVisitNumber, err = action.imsDBQ.NextVisitNumber(ctx, action.imsDBQ, event.ID)
 		if err != nil {
-			return 0, 0, "", herr.InternalServerError("Failed to find next Visit number", err).From("[NextVisitNumber]")
+			return 0, "", herr.InternalServerError("Failed to find next Visit number", err).From("[NextVisitNumber]")
 		}
 		_, err = action.imsDBQ.CreateVisit(ctx, action.imsDBQ, imsdb.CreateVisitParams{
 			Event:   event.ID,
@@ -344,51 +342,42 @@ func (action NewVisit) newVisit(req *http.Request) (visitNumber, version int32, 
 			break
 		}
 		if !isDuplicateKeyError(err) {
-			return 0, 0, "", herr.InternalServerError("Failed to create visit", err).From("[CreateVisit]")
+			return 0, "", herr.InternalServerError("Failed to create visit", err).From("[CreateVisit]")
 		}
 		if attempt == maxNumberAllocAttempts {
-			return 0, 0, "", herr.Conflict("Visits are being created concurrently. Please try again.", err).From("[CreateVisit]")
+			return 0, "", herr.Conflict("Visits are being created concurrently. Please try again.", err).From("[CreateVisit]")
 		}
 	}
 	newVisit.EventID = event.ID
 	newVisit.Event = event.Name
 	newVisit.Number = newVisitNumber
 
-	version, errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author, nil)
+	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author)
 	if errHTTP != nil {
-		return 0, 0, "", errHTTP.From("[updateVisit]")
+		return 0, "", errHTTP.From("[updateVisit]")
 	}
 
-	return newVisit.Number, version, fmt.Sprintf("/ims/api/events/%v/visits/%d", event.Name, newVisit.Number), nil
+	return newVisit.Number, fmt.Sprintf("/ims/api/events/%v/visits/%d", event.Name, newVisit.Number), nil
 }
 
 func updateVisit(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newVisit imsjson.Visit, author string,
-	ifMatch *int32,
-) (newVersion int32, errHTTP *herr.HTTPError) {
-	attempts := maxCASAttempts
-	if ifMatch != nil {
-		attempts = 1
-	}
-	for range attempts {
-		version, conflict, errHTTP := updateVisitAttempt(ctx, imsDBQ, es, newVisit, author, ifMatch)
+) *herr.HTTPError {
+	for range maxCASAttempts {
+		conflict, errHTTP := retryOnDeadlock(func() (bool, *herr.HTTPError) {
+			return updateVisitAttempt(ctx, imsDBQ, es, newVisit, author)
+		})
 		if errHTTP != nil {
-			return 0, errHTTP.From("[updateVisitAttempt]")
+			return errHTTP.From("[updateVisitAttempt]")
 		}
 		if !conflict {
-			return version, nil
-		}
-		if ifMatch != nil {
-			return 0, herr.PreconditionFailed(
-				"This visit was changed by someone else while you were editing it", nil,
-			).SetExpectedError()
+			return nil
 		}
 	}
-	return 0, herr.Conflict("The visit is being modified concurrently. Please try again.", nil)
+	return herr.Conflict("The visit is being modified concurrently. Please try again.", nil)
 }
 
 func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newVisit imsjson.Visit, author string,
-	ifMatch *int32,
-) (newVersion int32, conflict bool, errHTTP *herr.HTTPError) {
+) (conflict bool, errHTTP *herr.HTTPError) {
 	storedVisitRow, err := imsDBQ.Visit(ctx, imsDBQ,
 		imsdb.VisitParams{
 			Event:  newVisit.EventID,
@@ -397,32 +386,26 @@ func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcer
 	)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return 0, false, herr.NotFound("Visit not found", err).From("[Visit]")
+			return false, herr.NotFound("Visit not found", err).From("[Visit]")
 		}
-		return 0, false, herr.InternalServerError("Failed to fetch visit", err).From("[Visit]")
+		return false, herr.InternalServerError("Failed to fetch visit", err).From("[Visit]")
 	}
 	storedVisit := storedVisitRow.Visit
-	expectedVersion := storedVisit.Version
-	if ifMatch != nil && *ifMatch != expectedVersion {
-		return 0, true, nil
-	}
 
 	txn, err := imsDBQ.Begin()
 	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
+		return false, herr.InternalServerError("Failed to start transaction", err).From("[Begin]")
 	}
 	defer rollback(txn)
 
 	update, logs, errHTTP := buildVisitUpdate(storedVisit, newVisit)
 	if errHTTP != nil {
-		return 0, false, errHTTP.From("[buildVisitUpdate]")
+		return false, errHTTP.From("[buildVisitUpdate]")
 	}
 
 	// A request that only appends report entries is applied without the
 	// guarded update below; see updateIncidentAttempt.
-	changesVisit := len(logs) > 0
-	newVersion = expectedVersion
-	if changesVisit {
+	if len(logs) > 0 {
 		// The version-guarded update is the concurrency gate; see updateIncidentAttempt.
 		rows, err := imsDBQ.UpdateVisit(ctx, txn, update)
 		if err != nil {
@@ -431,9 +414,9 @@ func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcer
 			if ok && mysqlErr.Number == mySQLErNoReferencedRow2 {
 				// This is probably the source of the error, because there are no other foreign
 				// keys updates within this function.
-				return 0, false, herr.NotFound("No such Incident", err).From("[UpdateVisit]")
+				return false, herr.NotFound("No such Incident", err).From("[UpdateVisit]")
 			}
-			return 0, false, herr.InternalServerError("Failed to update visit", err).From("[UpdateVisit]")
+			return false, herr.InternalServerError("Failed to update visit", err).From("[UpdateVisit]")
 		}
 		if rows == 0 {
 			// Stale version or vanished row; re-read to tell which.
@@ -443,47 +426,29 @@ func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcer
 			})
 			if err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
-					return 0, false, herr.NotFound("Visit not found", err).From("[VisitVersion]")
+					return false, herr.NotFound("Visit not found", err).From("[VisitVersion]")
 				}
-				return 0, false, herr.InternalServerError("Failed to fetch visit", err).From("[VisitVersion]")
+				return false, herr.InternalServerError("Failed to fetch visit", err).From("[VisitVersion]")
 			}
-			return 0, true, nil
-		}
-		newVersion = expectedVersion + 1
-
-		// If the visit was reassigned, the affected incidents' visit lists
-		// changed, so their versions must move too.
-		if storedVisit.IncidentNumber != update.IncidentNumber {
-			for _, incidentNumber := range []sql.NullInt32{storedVisit.IncidentNumber, update.IncidentNumber} {
-				if !incidentNumber.Valid {
-					continue
-				}
-				err = imsDBQ.BumpIncidentVersion(ctx, txn, imsdb.BumpIncidentVersionParams{
-					Event:  newVisit.EventID,
-					Number: incidentNumber.Int32,
-				})
-				if err != nil {
-					return 0, false, herr.InternalServerError("Failed to update incident", err).From("[BumpIncidentVersion]")
-				}
-			}
+			return true, nil
 		}
 	}
 
 	errHTTP = addChangeReportEntries(ctx, imsDBQ, txn, newVisit.EventID, newVisit.Number, author,
 		logs, newVisit.ReportEntries, addVisitReportEntry)
 	if errHTTP != nil {
-		return 0, false, errHTTP.From("[addChangeReportEntries]")
+		return false, errHTTP.From("[addChangeReportEntries]")
 	}
 
 	err = txn.Commit()
 	if err != nil {
-		return 0, false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
+		return false, herr.InternalServerError("Failed to commit transaction", err).From("[Commit]")
 	}
 
 	es.notifyVisitUpdate(storedVisit.Event, storedVisit.Number)
 	es.notifyIncidentUpdates(storedVisit.Event, storedVisit.IncidentNumber.Int32, update.IncidentNumber.Int32)
 
-	return newVersion, false, nil
+	return false, nil
 }
 
 // buildVisitUpdate merges the client-provided fields of newVisit over the
@@ -587,36 +552,31 @@ type EditVisit struct {
 }
 
 func (action EditVisit) ServeHTTP(w http.ResponseWriter, req *http.Request) {
-	version, errHTTP := action.editVisit(req)
+	errHTTP := action.editVisit(req)
 	if errHTTP != nil {
 		errHTTP.From("[editVisit]").WriteResponse(w)
 		return
 	}
-	setETag(w, version)
 	herr.WriteNoContentResponse(w, "Success")
 }
 
-func (action EditVisit) editVisit(req *http.Request) (int32, *herr.HTTPError) {
+func (action EditVisit) editVisit(req *http.Request) *herr.HTTPError {
 	event, jwtCtx, eventPermissions, errHTTP := getEventPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[getEventPermissions]")
+		return errHTTP.From("[getEventPermissions]")
 	}
 	if eventPermissions&authz.EventWriteVisits == 0 {
-		return 0, herr.Forbidden("The requestor does not have EventWriteVisits permission for this Event", nil)
+		return herr.Forbidden("The requestor does not have EventWriteVisits permission for this Event", nil)
 	}
 	ctx := req.Context()
 
 	visitNumber, err := conv.ParseInt32(req.PathValue("visitNumber"))
 	if err != nil {
-		return 0, herr.BadRequest("Invalid Visit Number", err).From("[ParseInt32]")
-	}
-	ifMatch, errHTTP := parseIfMatch(req)
-	if errHTTP != nil {
-		return 0, errHTTP.From("[parseIfMatch]")
+		return herr.BadRequest("Invalid Visit Number", err).From("[ParseInt32]")
 	}
 	newVisit, errHTTP := readBodyAs[imsjson.Visit](req)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[readBodyAs]")
+		return errHTTP.From("[readBodyAs]")
 	}
 	newVisit.Event = event.Name
 	newVisit.EventID = event.ID
@@ -624,10 +584,10 @@ func (action EditVisit) editVisit(req *http.Request) (int32, *herr.HTTPError) {
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	version, errHTTP := updateVisit(ctx, action.imsDBQ, action.es, newVisit, author, ifMatch)
+	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author)
 	if errHTTP != nil {
-		return 0, errHTTP.From("[updateVisit]")
+		return errHTTP.From("[updateVisit]")
 	}
 
-	return version, nil
+	return nil
 }

--- a/json/incident.go
+++ b/json/incident.go
@@ -43,21 +43,28 @@ type Incident struct {
 	Number       int32     `json:"number"`
 	Created      time.Time `json:"created,omitzero"`
 	LastModified time.Time `json:"last_modified,omitzero"`
-	// Version is the optimistic-concurrency counter, surfaced as an ETag on
-	// single-Incident endpoints. Stored versions start at 1, so omitzero only
-	// elides it from client-sent edit bodies, never from server responses.
-	Version         int32             `json:"version,omitzero"`
-	State           string            `json:"state"`
-	Started         time.Time         `json:"started,omitzero"`
-	Closed          time.Time         `json:"closed,omitzero"`
-	Priority        int8              `json:"priority"`
-	Summary         *string           `json:"summary"`
-	Location        Location          `json:"location"`
+	// Version is the optimistic-concurrency counter guarding an edit's
+	// read-merge-write of the fields below. It moves only when those fields
+	// do: not for report entries, and not for the response-only sets, which
+	// live in their own tables and so can't be clobbered by an edit. It's
+	// reported here, but clients don't send it back. Stored versions start at
+	// 1, so omitzero only elides it from client-sent edit bodies, never from
+	// server responses.
+	Version  int32     `json:"version,omitzero"`
+	State    string    `json:"state"`
+	Started  time.Time `json:"started,omitzero"`
+	Closed   time.Time `json:"closed,omitzero"`
+	Priority int8      `json:"priority"`
+	Summary  *string   `json:"summary"`
+	Location Location  `json:"location"`
+	// These five are response-only. Each is mutated one member at a time
+	// through its own endpoint, so that concurrent writers don't undo each
+	// other; sending any of the first four on an edit is a 400.
 	IncidentTypeIDs *[]int32          `json:"incident_type_ids"`
 	FieldReports    *[]int32          `json:"field_reports"`
 	Visits          *[]int32          `json:"visits"`
-	Rangers         *[]IncidentRanger `json:"rangers"`
 	LinkedIncidents *[]LinkedIncident `json:"linked_incidents,omitzero"`
+	Rangers         *[]IncidentRanger `json:"rangers"`
 	ReportEntries   []ReportEntry     `json:"report_entries"`
 }
 

--- a/lib/rand/jitter.go
+++ b/lib/rand/jitter.go
@@ -18,12 +18,24 @@ package rand
 
 import (
 	cryptorand "crypto/rand"
+	"encoding/binary"
+	"time"
 )
 
-// NonCryptoText generates a random string comprised of 26 bytes (128 bits).
+// Jitter returns a random duration in [d/2, d). It's for spreading out retries
+// that would otherwise all fire at the same moment and collide again, so it
+// uses the same fast non-cryptographic source as NonCryptoText.
 //
-// This currently uses a cryptographically secure generation function underneath,
-// but that's an implementation detail.
-func NonCryptoText() string {
-	return cryptorand.Text()
+// A non-positive d returns 0.
+func Jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	var buf [8]byte
+	// This never returns an error.
+	_, _ = cryptorand.Read(buf[:])
+	// #nosec G115 // masked to 62 bits below, so this can't go negative
+	n := int64(binary.LittleEndian.Uint64(buf[:]) >> 2)
+	half := int64(d) / 2
+	return time.Duration(half + n%(int64(d)-half))
 }

--- a/lib/rand/jitter_test.go
+++ b/lib/rand/jitter_test.go
@@ -1,0 +1,63 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package rand_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/burningmantech/ranger-ims-go/lib/rand"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJitterStaysInRange(t *testing.T) {
+	t.Parallel()
+
+	const d = 100 * time.Millisecond
+	for range 1000 {
+		got := rand.Jitter(d)
+		require.GreaterOrEqual(t, got, d/2)
+		require.Less(t, got, d)
+	}
+}
+
+func TestJitterVaries(t *testing.T) {
+	t.Parallel()
+
+	// The point of jittering is that callers don't all wake at once, so the
+	// same input must not keep producing the same delay.
+	seen := make(map[time.Duration]bool)
+	for range 100 {
+		seen[rand.Jitter(100*time.Millisecond)] = true
+	}
+	require.Greater(t, len(seen), 1)
+}
+
+func TestJitterOfNonPositiveIsZero(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, rand.Jitter(0))
+	require.Zero(t, rand.Jitter(-time.Second))
+}
+
+// A one-nanosecond delay has no room between d/2 and d, which must not panic
+// with a division by zero or a modulus of zero.
+func TestJitterOfSmallestDurationIsSafe(t *testing.T) {
+	t.Parallel()
+
+	require.Zero(t, rand.Jitter(1))
+}

--- a/lib/rand/text_test.go
+++ b/lib/rand/text_test.go
@@ -17,9 +17,10 @@
 package rand
 
 import (
-	"github.com/stretchr/testify/assert"
-	mathrand "math/rand/v2"
+	"crypto/rand"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNonCryptoText(t *testing.T) {
@@ -27,11 +28,16 @@ func TestNonCryptoText(t *testing.T) {
 	someVal := NonCryptoText()
 	// for an unknown seed, all we can say is that this is a 26-byte string
 	assert.Len(t, someVal, 26)
+}
 
-	// with a known seed, we get consistent values
-	dummySeed := []byte("this is thirty two bytes of nada")
-	chacha = mathrand.NewChaCha8(([32]byte)(dummySeed))
-	assert.Equal(t, "GYEZQNJ3T4KGVFD6SHQDDXOF6P", NonCryptoText())
-	assert.Equal(t, "4557VJCAULCJTN4NA3PKDWRI7H", NonCryptoText())
-	assert.Equal(t, "W5PPJS5D6SP4YTN7NVYEIBDYNG", NonCryptoText())
+func BenchmarkNonCryptoText(b *testing.B) {
+	for b.Loop() {
+		NonCryptoText()
+	}
+}
+
+func BenchmarkCryptoText(b *testing.B) {
+	for b.Loop() {
+		rand.Text()
+	}
 }

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -153,14 +153,6 @@ where
     and VERSION = ?
 ;
 
--- BumpIncidentVersion is for mutations that change an incident's representation
--- without going through the version-guarded UpdateIncident query (Ranger
--- assignments, the peer of a link/unlink, field-report/visit reassignment).
--- name: BumpIncidentVersion :exec
-update INCIDENT
-set VERSION = VERSION + 1
-where EVENT = ? and NUMBER = ?;
-
 -- name: IncidentVersion :one
 select VERSION
 from INCIDENT
@@ -584,14 +576,6 @@ where
     and NUMBER = ?
     and VERSION = ?
 ;
-
--- BumpVisitVersion is for mutations that change a visit's representation
--- without going through the version-guarded UpdateVisit query (Ranger
--- assignments).
--- name: BumpVisitVersion :exec
-update VISIT
-set VERSION = VERSION + 1
-where EVENT = ? and NUMBER = ?;
 
 -- name: VisitVersion :one
 select VERSION

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -72,12 +72,12 @@ create table INCIDENT (
     LOCATION_ADDRESS        varchar(1024),
     LOCATION_DESCRIPTION    varchar(1024),
 
-    -- Optimistic-concurrency version counter, surfaced to clients as an ETag.
-    -- Bumped on every change to the incident's representation other than
-    -- report-entry changes. Report entries are append-only except for the
-    -- STRICKEN flag, a reversible boolean toggle that is audited via generated
-    -- entries — neither appends nor strikes can silently lose data, so neither
-    -- moves the version.
+    -- Optimistic-concurrency version counter, guarding the read-merge-write an
+    -- edit performs on the columns of this table. Reported to clients, but not
+    -- sent back by them. Only the guarded UPDATE moves it; nothing that writes
+    -- another table does, because no edit here can clobber a row over there.
+    -- That covers report entries, the Ranger roster, incident types, links, and
+    -- field-report/visit assignment.
     `VERSION` integer not null default 1,
 
     foreign key (`EVENT`) references `EVENT`(ID),

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -36,10 +36,6 @@ let fieldReport: ims.FieldReport|null = null;
 // while it's open, which is otherwise a silent redraw of the page.
 const remoteUpdates = ims.newRemoteUpdateAnnouncer("This Field Report was updated");
 
-// The ETag from the last read of this field report, sent back as If-Match on
-// edits so that the server can reject an edit based on stale data (HTTP 412).
-let fieldReportETag: string|null = null;
-
 //
 // Initialize UI
 //
@@ -192,9 +188,8 @@ async function loadFieldReport(): Promise<{err: string|null}> {
             "number": null,
             "created": null,
         };
-        fieldReportETag = null;
     } else {
-        const {resp, json, err} = await ims.fetchNoThrow<ims.FieldReport>(
+        const {json, err} = await ims.fetchNoThrow<ims.FieldReport>(
             `${ims.urlReplace(url_fieldReports)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -204,7 +199,6 @@ async function loadFieldReport(): Promise<{err: string|null}> {
             return {err: message};
         }
         fieldReport = json;
-        fieldReportETag = ims.etagOf(resp);
     }
     return {err: null};
 }
@@ -350,8 +344,7 @@ function drawSummary(): void {
 // Editing
 //
 
-// Sequences frSendEdits calls, so that rapid autosaves don't race one another:
-// each edit must carry the ETag produced by the previous one.
+// Sequences frSendEdits calls, so that rapid autosaves don't race one another.
 const chainMutation = ims.newMutationChain(remoteUpdates.noteLocalEdit);
 
 function frSendEdits(edits: ims.FieldReport): Promise<{err:string|null}> {
@@ -373,30 +366,16 @@ async function frSendEditsNow(edits: ims.FieldReport): Promise<{err:string|null}
         url += `/${number}`;
     }
 
-    // Report-entry appends can't lose data, so they're sent unconditionally
-    // rather than failing on a stale ETag when someone else edits a field.
-    const noteOnly = Object.keys(edits).every(
-        (key) => key === "report_entries" || key === "number");
-    const headers: HeadersInit = {};
-    if (number != null && fieldReportETag != null && !noteOnly) {
-        headers["If-Match"] = fieldReportETag;
-    }
     const {resp, err} = await ims.fetchNoThrow(url, {
-        headers: headers,
         body: JSON.stringify(edits),
     });
     if (err != null) {
-        let message = `Failed to apply edit: ${err}`;
-        if (resp?.status === 412) {
-            message = "Someone else has edited this field report. " +
-                "The page has been refreshed with their changes; please retry your edit.";
-        }
+        const message = `Failed to apply edit: ${err}`;
         console.log(message);
         await loadAndDisplayFieldReport();
         ims.setErrorMessage(message);
         return {err: message};
     }
-    fieldReportETag = ims.etagOf(resp) ?? fieldReportETag;
     if (number == null) {
         // We created a new field report.
         // We need to find out the created field report number so that

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -215,15 +215,6 @@ export async function fetchNoThrow<T>(url: string, init: RequestInit|null): Prom
     return {resp: response, json: json, err: err};
 }
 
-// etagOf reads the ETag header from a response, for optimistic concurrency:
-// pages remember the ETag from the last read of a record and send it back as
-// If-Match on edits, and the server rejects the edit with a 412 if the record
-// has changed in the meantime.
-export function etagOf(resp: Response|null): string|null {
-    return resp?.headers.get("ETag") ?? null;
-}
-
-
 //
 // Generic string formatting
 //
@@ -1651,11 +1642,10 @@ export function newRemoteUpdateAnnouncer(msg: string, debounceMs: number = 3000)
 // newMutationChain returns a function that runs the mutations handed to it one
 // at a time, in the order they were handed over.
 //
-// A detail page's mutations all share one chain, because they all share the
-// record's ETag: an edit must carry the ETag produced by the previous edit, and
-// that value only exists once the previous response has come back. Running them
-// concurrently means the later one sends a stale ETag and is rejected with a
-// 412 — a spurious conflict, since both edits came from this one user.
+// A detail page's mutations all share one chain, because each one refetches and
+// redraws the record when it completes. Run concurrently, the redraws race, and
+// whichever response lands last wins — which may be the older of the two, so the
+// page settles on state the server has already moved past.
 //
 // A mutation that fails doesn't stall the ones queued behind it. onMutate, if
 // given, is called as each mutation is enqueued; pass a

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -49,10 +49,6 @@ let incident: ims.Incident|null = null;
 // while it's open, which is otherwise a silent redraw of the page.
 const remoteUpdates = ims.newRemoteUpdateAnnouncer("This Incident was updated");
 
-// The ETag from the last read of this incident, sent back as If-Match on
-// edits so that the server can reject an edit based on stale data (HTTP 412).
-let incidentETag: string|null = null;
-
 let allIncidentTypes: ims.IncidentType[] = [];
 
 let allEvents: ims.EventData[]|null = null;
@@ -331,9 +327,8 @@ async function loadIncident(): Promise<{err: string|null}> {
             "priority": 3,
             "summary": "",
         };
-        incidentETag = null;
     } else {
-        const {resp, json, err} = await ims.fetchNoThrow<ims.Incident>(
+        const {json, err} = await ims.fetchNoThrow<ims.Incident>(
             `${ims.urlReplace(url_incidents)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -343,7 +338,6 @@ async function loadIncident(): Promise<{err: string|null}> {
             return {err: message};
         }
         incident = json;
-        incidentETag = ims.etagOf(resp);
     }
     return {err: null};
 }
@@ -1109,8 +1103,7 @@ function drawFieldReportsToAttach() {
 //
 
 // Sequences every mutation this page makes — field edits, roster changes, type
-// and link changes — so that rapid changes don't race one another: each carries
-// the ETag produced by the previous one.
+// and link changes — so that their redraws don't race one another.
 const chainMutation = ims.newMutationChain(remoteUpdates.noteLocalEdit);
 
 function sendEdits(edits: ims.Incident): Promise<{err:string|null}> {
@@ -1136,31 +1129,16 @@ async function sendEditsNow(edits: ims.Incident): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
-    // Report-entry appends can't lose data, so they're sent unconditionally
-    // rather than failing on a stale ETag when someone else edits a field.
-    const noteOnly = Object.keys(edits).every(
-        (key) => key === "report_entries" || key === "number");
-    const headers: HeadersInit = {};
-    if (number != null && incidentETag != null && !noteOnly) {
-        headers["If-Match"] = incidentETag;
-    }
     const {resp, err} = await ims.fetchNoThrow(url, {
-        headers: headers,
         body: JSON.stringify(edits),
     });
 
     if (err != null) {
-        let message = `Failed to apply edit: ${err}`;
-        if (resp?.status === 412) {
-            message = "Someone else has edited this incident. " +
-                "The page has been refreshed with their changes; please retry your edit.";
-        }
+        const message = `Failed to apply edit: ${err}`;
         await loadAndDisplayIncident();
         ims.setErrorMessage(message);
         return {err: message};
     }
-
-    incidentETag = ims.etagOf(resp) ?? incidentETag;
 
     if (number == null && resp != null) {
         // We created a new incident.
@@ -1298,11 +1276,9 @@ async function removeRanger(sender: HTMLElement): Promise<void> {
                 .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
                 .replace("<ranger_name>", encodeURIComponent(rangerHandle))
         );
-        const {resp} = await ims.fetchNoThrow(url, {
+        await ims.fetchNoThrow(url, {
             method: "DELETE",
         });
-        // The roster change moved the incident's version on the server.
-        incidentETag = ims.etagOf(resp) ?? incidentETag;
     });
 }
 
@@ -1319,7 +1295,7 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
                 .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
                 .replace("<ranger_name>", encodeURIComponent(handle))
         );
-        const {resp, err} = await ims.fetchNoThrow(url, {
+        const {err} = await ims.fetchNoThrow(url, {
             body: JSON.stringify({
                 handle: handle,
                 role: sender.value,
@@ -1329,7 +1305,6 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
             ims.controlHasError(sender);
             return;
         }
-        incidentETag = ims.etagOf(resp) ?? incidentETag;
         ims.controlHasSuccess(sender);
     });
 }
@@ -1362,7 +1337,7 @@ async function detachIncidentType(incidentTypeId: number): Promise<string|null> 
             .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
             .replace("<incident_type_id>", incidentTypeId.toString())
     );
-    const {resp, err} = await ims.fetchNoThrow(url, {
+    const {err} = await ims.fetchNoThrow(url, {
         method: "DELETE",
     });
     if (err != null) {
@@ -1371,7 +1346,6 @@ async function detachIncidentType(incidentTypeId: number): Promise<string|null> 
         ims.setErrorMessage(message);
         return message;
     }
-    incidentETag = ims.etagOf(resp) ?? incidentETag;
     await loadAndDisplayIncident();
     return null;
 }
@@ -1382,7 +1356,7 @@ async function attachIncidentType(incidentTypeId: number): Promise<string|null> 
             .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
             .replace("<incident_type_id>", incidentTypeId.toString())
     );
-    const {resp, err} = await ims.fetchNoThrow(url, {
+    const {err} = await ims.fetchNoThrow(url, {
         body: JSON.stringify({}),
     });
     if (err != null) {
@@ -1391,7 +1365,6 @@ async function attachIncidentType(incidentTypeId: number): Promise<string|null> 
         ims.setErrorMessage(message);
         return message;
     }
-    incidentETag = ims.etagOf(resp) ?? incidentETag;
     await loadAndDisplayIncident();
     return null;
 }
@@ -1448,7 +1421,7 @@ async function addRanger(): Promise<void> {
                 .replace("<incident_number>", ims.pathIds.incidentNumber!.toString())
                 .replace("<ranger_name>", encodeURIComponent(handle))
         );
-        const {resp, err} = await ims.fetchNoThrow(url, {
+        const {err} = await ims.fetchNoThrow(url, {
             body: JSON.stringify({
                 handle: handle,
             }),
@@ -1456,7 +1429,6 @@ async function addRanger(): Promise<void> {
         if (err !== null) {
             return err;
         }
-        incidentETag = ims.etagOf(resp) ?? incidentETag;
         return null;
     });
     if (err !== null) {
@@ -1562,8 +1534,6 @@ async function detachFieldReport(sender: HTMLElement): Promise<void> {
         ims.setErrorMessage(message);
         return;
     }
-    // The detachment moved this incident's version on the server, and the
-    // response's ETag belongs to the field report/visit, not the incident.
     await loadIncident();
     await loadAllVisits();
     await loadAllFieldReports();
@@ -1612,8 +1582,6 @@ async function attachFieldReport(): Promise<void> {
         ims.controlHasError(el.attachedFieldReportAdd);
         return;
     }
-    // The attachment moved this incident's version on the server, and the
-    // response's ETag belongs to the field report/visit, not the incident.
     await loadIncident();
     await loadAllVisits();
     await loadAllFieldReports();
@@ -1652,7 +1620,7 @@ async function setIncidentLink(
             .replace("<linked_event_name>", encodeURIComponent(linkedEventName))
             .replace("<linked_incident_number>", linkedIncidentNumber.toString())
     );
-    const {resp, err} = await ims.fetchNoThrow(url, method === "DELETE"
+    const {err} = await ims.fetchNoThrow(url, method === "DELETE"
         ? {method: "DELETE"}
         : {body: JSON.stringify({})},
     );
@@ -1663,7 +1631,6 @@ async function setIncidentLink(
         ims.setErrorMessage(message);
         return message;
     }
-    incidentETag = ims.etagOf(resp) ?? incidentETag;
     await loadAndDisplayIncident();
     return null;
 }

--- a/web/typescript/sanctuary_visit.ts
+++ b/web/typescript/sanctuary_visit.ts
@@ -64,10 +64,6 @@ let visit: ims.Visit|null = null;
 // it's open, which is otherwise a silent redraw of the page.
 const remoteUpdates = ims.newRemoteUpdateAnnouncer("This Visit was updated");
 
-// The ETag from the last read of this visit, sent back as If-Match on edits
-// so that the server can reject an edit based on stale data (HTTP 412).
-let visitETag: string|null = null;
-
 //
 // Initialize UI
 //
@@ -294,9 +290,8 @@ async function loadVisit(): Promise<{err: string|null}> {
         visit = {
             "number": null,
         };
-        visitETag = null;
     } else {
-        const {resp, json, err} = await ims.fetchNoThrow<ims.Visit>(
+        const {json, err} = await ims.fetchNoThrow<ims.Visit>(
             `${ims.urlReplace(url_visits)}/${number}`, null);
         if (err != null) {
             ims.disableEditing();
@@ -306,7 +301,6 @@ async function loadVisit(): Promise<{err: string|null}> {
             return {err: message};
         }
         visit = json;
-        visitETag = ims.etagOf(resp);
     }
     return {err: null};
 }
@@ -416,8 +410,7 @@ function drawVisitTitle(mode: "for_display"|"for_print_to_pdf"): void {
 
 
 // Sequences every mutation this page makes — field edits and roster changes —
-// so that rapid changes don't race one another: each carries the ETag produced
-// by the previous one.
+// so that their redraws don't race one another.
 const chainMutation = ims.newMutationChain(remoteUpdates.noteLocalEdit);
 
 function sendEdits(edits: ims.Visit): Promise<{err:string|null}> {
@@ -437,31 +430,16 @@ async function sendEditsNow(edits: ims.Visit): Promise<{err:string|null}> {
         url += `/${number}`;
     }
 
-    // Report-entry appends can't lose data, so they're sent unconditionally
-    // rather than failing on a stale ETag when someone else edits a field.
-    const noteOnly = Object.keys(edits).every(
-        (key) => key === "report_entries" || key === "number");
-    const headers: HeadersInit = {};
-    if (number != null && visitETag != null && !noteOnly) {
-        headers["If-Match"] = visitETag;
-    }
     const {resp, err} = await ims.fetchNoThrow(url, {
-        headers: headers,
         body: JSON.stringify(edits),
     });
 
     if (err != null) {
-        let message = `Failed to apply edit: ${err}`;
-        if (resp?.status === 412) {
-            message = "Someone else has edited this visit. " +
-                "The page has been refreshed with their changes; please retry your edit.";
-        }
+        const message = `Failed to apply edit: ${err}`;
         await loadAndDisplayVisit();
         ims.setErrorMessage(message);
         return {err: message};
     }
-
-    visitETag = ims.etagOf(resp) ?? visitETag;
 
     if (number == null && resp != null) {
         // We created a new visit.
@@ -731,7 +709,7 @@ async function addRanger(): Promise<void> {
                 .replace("<visit_number>", ims.pathIds.visitNumber!.toString())
                 .replace("<ranger_name>", encodeURIComponent(handle))
         );
-        const {resp, err} = await ims.fetchNoThrow(url, {
+        const {err} = await ims.fetchNoThrow(url, {
             body: JSON.stringify({
                 handle: handle,
             }),
@@ -739,8 +717,6 @@ async function addRanger(): Promise<void> {
         if (err !== null) {
             return err;
         }
-        // The roster change moved the visit's version on the server.
-        visitETag = ims.etagOf(resp) ?? visitETag;
         return null;
     });
     if (err !== null) {
@@ -768,11 +744,9 @@ async function removeRanger(sender: HTMLElement): Promise<void> {
                 .replace("<visit_number>", ims.pathIds.visitNumber!.toString())
                 .replace("<ranger_name>", encodeURIComponent(rangerHandle))
         );
-        const {resp} = await ims.fetchNoThrow(url, {
+        await ims.fetchNoThrow(url, {
             method: "DELETE",
         });
-        // The roster change moved the visit's version on the server.
-        visitETag = ims.etagOf(resp) ?? visitETag;
     });
 }
 
@@ -790,7 +764,7 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
                 .replace("<visit_number>", ims.pathIds.visitNumber!.toString())
                 .replace("<ranger_name>", encodeURIComponent(handle))
         );
-        const {resp, err} = await ims.fetchNoThrow(url, {
+        const {err} = await ims.fetchNoThrow(url, {
             body: JSON.stringify({
                 handle: handle,
                 role: sender.value,
@@ -800,7 +774,6 @@ async function setRangerRole(sender: HTMLInputElement): Promise<void> {
             ims.controlHasError(sender);
             return;
         }
-        visitETag = ims.etagOf(resp) ?? visitETag;
         ims.controlHasSuccess(sender);
     });
 }

--- a/web/typescripttest/field_report.test.ts
+++ b/web/typescripttest/field_report.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, mockFetch, problemResponse } from "./helpers.ts";
+import { jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -28,9 +28,6 @@ const frUrl = `/ims/api/events/${eventName}/field_reports`;
 let serverEventAccess: ims.AuthInfoEventAccess;
 let serverFieldReport: ims.FieldReport;
 let serverEvents: ims.EventData[];
-// The field report's current ETag; edits through frRoutes bump it, the way
-// the server's version counter would.
-let serverETag: string;
 
 beforeEach((): void => {
     vi.resetModules();
@@ -64,7 +61,6 @@ beforeEach((): void => {
         ],
     };
     serverEvents = [{ id: eventId, name: eventName }];
-    serverETag = `"3"`;
 });
 
 function frRoutes(url: string, init?: RequestInit): Response | undefined {
@@ -81,12 +77,11 @@ function frRoutes(url: string, init?: RequestInit): Response | undefined {
         return jsonResponse(serverEvents);
     }
     if (url === `${frUrl}/7` && !hasBody) {
-        return jsonResponse(serverFieldReport, 200, { "ETag": serverETag });
+        return jsonResponse(serverFieldReport, 200);
     }
     if (url.startsWith(`${frUrl}/7`) && hasBody) {
         // Edits and attach/detach.
-        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     if (url === `/ims/api/events/${eventName}/incidents` && hasBody) {
         return new Response(null, { status: 201, headers: { "IMS-Incident-Number": "42" } });
@@ -161,55 +156,6 @@ test("a viewer without field-report read access sees an authorization error", as
 
     expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
     expect(document.getElementById("error_text")!.textContent).toContain("not currently authorized");
-});
-
-test("summary edits carry If-Match from the loaded ETag; note appends do not", async (): Promise<void> => {
-    const mock = await initFieldReportPage();
-
-    // A summary edit sends the ETag captured when the field report was loaded.
-    const summary = document.getElementById("field_report_summary") as HTMLInputElement;
-    summary.value = "Found the child";
-    await window.editSummary();
-    let posts = mock.mock.calls.filter(([u, init]) => u === `${frUrl}/7` && init?.body != null);
-    expect(posts).toHaveLength(1);
-    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBe(`"3"`);
-
-    // A report-entry append is unconditional.
-    mock.mockClear();
-    const textarea = document.getElementById("report_entry_add") as HTMLTextAreaElement;
-    textarea.value = "an update from the field";
-    window.reportEntryEdited();
-    await window.submitReportEntry();
-    posts = mock.mock.calls.filter(([u, init]) => u === `${frUrl}/7` && init?.body != null);
-    expect(posts).toHaveLength(1);
-    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBeNull();
-});
-
-test("a 412 conflict shows the conflict banner and refetches the field report", async (): Promise<void> => {
-    const mock = await initFieldReportPage();
-
-    const conflictRoutes = (url: string, init?: RequestInit): Response | undefined => {
-        if (url === `${frUrl}/7` && init?.body != null) {
-            return problemResponse("Someone else got here first", 412);
-        }
-        return frRoutes(url, init);
-    };
-    mock.mockImplementation(async (url: string, init?: RequestInit): Promise<Response> => {
-        const response = conflictRoutes(url, init);
-        if (response == null) {
-            throw new Error(`no mocked fetch route for ${url}`);
-        }
-        return response;
-    });
-
-    serverFieldReport.summary = "Their conflicting summary";
-    const summary = document.getElementById("field_report_summary") as HTMLInputElement;
-    summary.value = "My rejected summary";
-    await window.editSummary();
-
-    expect(document.getElementById("error_text")!.textContent).toContain(
-        "Someone else has edited this field report");
-    expect(inputValue("field_report_summary")).toBe("Their conflicting summary");
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {

--- a/web/typescripttest/helpers.ts
+++ b/web/typescripttest/helpers.ts
@@ -46,7 +46,7 @@ export function loadFixture(name: string): void {
 
 // Make a JSON Response like the IMS API would return. fetchNoThrow only
 // parses the body when the content-type is exactly "application/json".
-// Extra headers (e.g. an ETag) are merged over the content-type.
+// Extra headers are merged over the content-type.
 export function jsonResponse(body: unknown, status: number = 200, headers?: Record<string, string>): Response {
     return new Response(JSON.stringify(body), {
         status: status,

--- a/web/typescripttest/incident.test.ts
+++ b/web/typescripttest/incident.test.ts
@@ -19,16 +19,13 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, MockFlatpickr, mockFetch, problemResponse } from "./helpers.ts";
+import { jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
 
 let serverEventAccess: ims.AuthInfoEventAccess;
 let serverIncident: ims.Incident;
-// The incident's current ETag; edits through incidentRoutes bump it, the way
-// the server's version counter would.
-let serverETag: string;
 let serverPersonnel: ims.Personnel[];
 let serverTypes: ims.IncidentType[];
 let serverEvents: ims.EventData[];
@@ -51,7 +48,6 @@ beforeEach((): void => {
         value: { request: (): Promise<undefined> => new Promise<undefined>((): void => {}) },
     });
 
-    serverETag = `"5"`;
     serverEventAccess = {
         event_id: eventId,
         readIncidents: true,
@@ -124,11 +120,6 @@ beforeEach((): void => {
     ];
 });
 
-// Increment a quoted-integer ETag, e.g. `"5"` -> `"6"`.
-function bumpETag(etag: string): string {
-    return `"${Number(etag.replaceAll(`"`, "")) + 1}"`;
-}
-
 function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
     const hasBody = init?.body != null;
     if (url === `/ims/api/auth?event_id=${eventName}`) {
@@ -158,8 +149,7 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
         return jsonResponse(serverVisits);
     }
     if (url.startsWith(`/ims/api/events/${eventName}/incidents/1/rangers/`)) {
-        serverETag = bumpETag(serverETag);
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     // The type and link sub-resources apply their one change to serverIncident,
     // rather than replacing a list, so a test can see whether two mutations in
@@ -171,8 +161,7 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
         serverIncident.incident_type_ids = init?.method === "DELETE"
             ? current.filter((t: number): boolean => t !== typeId)
             : current.concat(current.includes(typeId) ? [] : [typeId]);
-        serverETag = bumpETag(serverETag);
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     const linkMatch = url.match(
         new RegExp(`^/ims/api/events/${eventName}/incidents/\\d+/linked_incidents/([^/]+)/(\\d+)$`));
@@ -188,8 +177,7 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
                 event_name: linkedEventName,
                 number: linkedNumber,
             }]);
-        serverETag = bumpETag(serverETag);
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     if (url.startsWith(`/ims/api/events/${eventName}/incidents/1/report_entries/`) && hasBody) {
         return new Response(null, { status: 204 });
@@ -203,11 +191,10 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
         return new Response(null, { status: 201, headers: { "IMS-Incident-Number": "42" } });
     }
     if ((url === `/ims/api/events/${eventName}/incidents/1` || url === `/ims/api/events/${eventName}/incidents/42`) && !hasBody) {
-        return jsonResponse(serverIncident, 200, { "ETag": serverETag });
+        return jsonResponse(serverIncident, 200);
     }
     if ((url === `/ims/api/events/${eventName}/incidents/1` || url === `/ims/api/events/${eventName}/incidents/42`) && hasBody) {
-        serverETag = bumpETag(serverETag);
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     if (url === `/ims/api/events/${eventName}/field_reports/8` && !hasBody) {
         return jsonResponse(serverFieldReports.find((fr: ims.FieldReport): boolean => fr.number === 8));
@@ -243,18 +230,9 @@ function postedBodies(mock: ReturnType<typeof mockFetch>, url: string): unknown[
         .map(([, init]): unknown => JSON.parse(init!.body as string));
 }
 
-// The If-Match header of each POST to the given URL, oldest first
-// (null for a POST that carried no If-Match).
-function postedIfMatches(mock: ReturnType<typeof mockFetch>, url: string): (string|null)[] {
-    return mock.mock.calls
-        .filter(([u, init]): boolean => u === url && init?.body != null)
-        .map(([, init]): string|null => new Headers(init!.headers).get("If-Match"));
-}
-
 interface RecordedRequest {
     method: string;
     url: string;
-    ifMatch: string|null;
 }
 
 // Every request to a URL matching the pattern, oldest first. Unlike
@@ -265,7 +243,6 @@ function requestsMatching(mock: ReturnType<typeof mockFetch>, pattern: RegExp): 
         .map(([url, init]): RecordedRequest => ({
             method: init?.method ?? "GET",
             url: url,
-            ifMatch: new Headers(init?.headers).get("If-Match"),
         }));
 }
 
@@ -419,67 +396,6 @@ test("editing the summary sends the edit and reloads the incident", async (): Pr
     expect(summary.classList.contains("is-valid")).toBe(true);
 });
 
-test("field edits carry If-Match from the loaded ETag; note appends do not", async (): Promise<void> => {
-    const mock = await initIncidentPage();
-    const incidentURL = "/ims/api/events/2025/incidents/1";
-
-    // A field edit sends the ETag captured when the incident was loaded.
-    const summary = document.getElementById("incident_summary") as HTMLInputElement;
-    summary.value = "Bigger dust storm";
-    await window.editIncidentSummary();
-    expect(postedIfMatches(mock, incidentURL)).toEqual([`"5"`]);
-
-    // After the edit round-trip, the stored ETag is the server's new one.
-    mock.mockClear();
-    summary.value = "Even bigger dust storm";
-    await window.editIncidentSummary();
-    expect(postedIfMatches(mock, incidentURL)).toEqual([`"6"`]);
-
-    // A report-entry append is unconditional: it can't lose data, and it must
-    // not fail just because someone else edited a field.
-    mock.mockClear();
-    const textarea = document.getElementById("report_entry_add") as HTMLTextAreaElement;
-    textarea.value = "saw a thing";
-    window.reportEntryEdited();
-    await window.submitReportEntry();
-    expect(postedBodies(mock, incidentURL)).toEqual([
-        { report_entries: [{ text: "saw a thing", id: -1 }], number: 1 },
-    ]);
-    expect(postedIfMatches(mock, incidentURL)).toEqual([null]);
-});
-
-test("a 412 conflict shows the conflict banner and refetches the incident", async (): Promise<void> => {
-    const mock = await initIncidentPage();
-    const incidentURL = "/ims/api/events/2025/incidents/1";
-
-    // Someone else edited the incident: the next edit is rejected with a 412.
-    const conflictRoutes = (url: string, init?: RequestInit): Response | undefined => {
-        if (url === incidentURL && init?.body != null) {
-            return problemResponse("Someone else got here first", 412);
-        }
-        return incidentRoutes(url, init);
-    };
-    mock.mockImplementation(async (url: string, init?: RequestInit): Promise<Response> => {
-        const response = conflictRoutes(url, init);
-        if (response == null) {
-            throw new Error(`no mocked fetch route for ${url}`);
-        }
-        return response;
-    });
-
-    serverIncident.summary = "Their conflicting edit";
-    const summary = document.getElementById("incident_summary") as HTMLInputElement;
-    summary.value = "My rejected edit";
-    const { err } = await window.editIncidentSummary().then((): {err: string|null} => ({err: null}), (e: Error): {err: string} => ({err: e.message}));
-    expect(err).toBeNull();
-
-    // The user is told what happened, and the page refetched the other
-    // person's version of the incident.
-    expect(document.getElementById("error_text")!.textContent).toContain(
-        "Someone else has edited this incident");
-    expect(inputValue("incident_summary")).toBe("Their conflicting edit");
-});
-
 test("editState warns when closing an incident that has no incident types", async (): Promise<void> => {
     serverIncident.incident_type_ids = [];
     const mock = await initIncidentPage();
@@ -600,7 +516,7 @@ test("addIncidentType and removeIncidentType hit the per-type endpoint", async (
     typeAdd.value = " lost child ";
     await window.addIncidentType();
     expect(requestsMatching(mock, /\/incidents\/\d+\/incident_types\//)).toEqual([
-        { method: "POST", url: "/ims/api/events/2025/incidents/1/incident_types/2", ifMatch: null },
+        { method: "POST", url: "/ims/api/events/2025/incidents/1/incident_types/2" },
     ]);
     expect(typeAdd.value).toBe("");
     expect(typeAdd.disabled).toBe(false);
@@ -611,7 +527,7 @@ test("addIncidentType and removeIncidentType hit the per-type endpoint", async (
     const junkLi = document.querySelector<HTMLLIElement>('#incident_types_list li[data-incident-type-id="1"]')!;
     await window.removeIncidentType(junkLi.querySelector("button")!);
     expect(requestsMatching(mock, /\/incidents\/\d+\/incident_types\//)).toEqual([
-        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/1", ifMatch: null },
+        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/1" },
     ]);
     expect(postedBodies(mock, "/ims/api/events/2025/incidents/1")).toEqual([]);
 
@@ -642,8 +558,8 @@ test("two rapid type removals both stick", async (): Promise<void> => {
     await Promise.all([first, second]);
 
     expect(requestsMatching(mock, /\/incidents\/\d+\/incident_types\//)).toEqual([
-        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/1", ifMatch: null },
-        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/2", ifMatch: null },
+        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/1" },
+        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/2" },
     ]);
     // Neither removal resurrected the other's type.
     expect(serverIncident.incident_type_ids).toEqual([]);
@@ -726,7 +642,7 @@ test("linkIncident links incidents in other events and rejects bad input", async
     input.value = "2015#2";
     await window.linkIncident(input);
     expect(requestsMatching(mock, /\/incidents\/\d+\/linked_incidents\//)).toEqual([
-        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2015/2", ifMatch: null },
+        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2015/2" },
     ]);
     expect(input.value).toBe("");
     // The pre-existing link was left alone rather than resent as part of a list.
@@ -767,9 +683,9 @@ test("a batched link input sends one request per entry, in order", async (): Pro
     await window.linkIncident(input);
 
     expect(requestsMatching(mock, /\/incidents\/\d+\/linked_incidents\//)).toEqual([
-        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2025/7", ifMatch: null },
-        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2015/2", ifMatch: null },
-        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2025/9", ifMatch: null },
+        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2025/7" },
+        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2015/2" },
+        { method: "POST", url: "/ims/api/events/2025/incidents/1/linked_incidents/2025/9" },
     ]);
     expect(input.value).toBe("");
 });
@@ -780,7 +696,7 @@ test("unlinkIncident removes just the one linked incident", async (): Promise<vo
     const linkedLi = document.querySelector<HTMLElement>('#linked_incidents [data-incident-number="5"]')!;
     await window.unlinkIncident(linkedLi.querySelector("button")!);
     expect(requestsMatching(mock, /\/incidents\/\d+\/linked_incidents\//)).toEqual([
-        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/linked_incidents/2025/5", ifMatch: null },
+        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/linked_incidents/2025/5" },
     ]);
     expect(postedBodies(mock, "/ims/api/events/2025/incidents/1")).toEqual([]);
     expect(serverIncident.linked_incidents).toEqual([]);
@@ -789,8 +705,7 @@ test("unlinkIncident removes just the one linked incident", async (): Promise<vo
 test("a summary edit and a type removal don't conflict", async (): Promise<void> => {
     const mock = await initIncidentPage();
 
-    // Both mutations go through one chain, so the summary edit's If-Match is the
-    // ETag it read at load time and the type removal doesn't race it.
+    // Both mutations go through one chain, so their reloads can't race.
     const summary = document.getElementById("incident_summary") as HTMLInputElement;
     summary.value = "Bigger dust storm";
     const junkLi = document.querySelector<HTMLLIElement>('#incident_types_list li[data-incident-type-id="1"]')!;
@@ -799,10 +714,12 @@ test("a summary edit and a type removal don't conflict", async (): Promise<void>
         window.removeIncidentType(junkLi.querySelector("button")!),
     ]);
 
-    expect(postedIfMatches(mock, "/ims/api/events/2025/incidents/1")).toEqual([`"5"`]);
+    expect(postedBodies(mock, "/ims/api/events/2025/incidents/1")).toEqual([
+        { summary: "Bigger dust storm", number: 1 },
+    ]);
     expect(document.getElementById("error_text")!.textContent).toBe("");
     expect(requestsMatching(mock, /\/incidents\/\d+\/incident_types\//)).toEqual([
-        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/1", ifMatch: null },
+        { method: "DELETE", url: "/ims/api/events/2025/incidents/1/incident_types/1" },
     ]);
 });
 

--- a/web/typescripttest/sanctuary_visit.test.ts
+++ b/web/typescripttest/sanctuary_visit.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, MockFlatpickr, mockFetch, problemResponse } from "./helpers.ts";
+import { jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -29,9 +29,6 @@ let serverEventAccess: ims.AuthInfoEventAccess;
 let serverVisit: ims.Visit;
 let serverPersonnel: ims.Personnel[];
 let serverEvents: ims.EventData[];
-// The visit's current ETag; edits through visitRoutes bump it, the way the
-// server's version counter would.
-let serverETag: string;
 
 beforeEach((): void => {
     vi.resetModules();
@@ -68,7 +65,6 @@ beforeEach((): void => {
         { handle: "Tool", status: "active", directory_id: 2 },
     ];
     serverEvents = [{ id: eventId, name: eventName }];
-    serverETag = `"4"`;
 });
 
 function visitRoutes(url: string, init?: RequestInit): Response | undefined {
@@ -88,19 +84,16 @@ function visitRoutes(url: string, init?: RequestInit): Response | undefined {
         return jsonResponse(serverPersonnel);
     }
     if (url === `${visitsUrl}/2` && !hasBody) {
-        return jsonResponse(serverVisit, 200, { "ETag": serverETag });
+        return jsonResponse(serverVisit, 200);
     }
     if (url === `${visitsUrl}/2` && hasBody) {
-        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     if (url.startsWith(`${visitsUrl}/2/rangers/`) && hasBody) {
-        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     if (url.startsWith(`${visitsUrl}/2/rangers/`) && init?.method === "DELETE") {
-        serverETag = `"${Number(serverETag.replaceAll(`"`, "")) + 1}"`;
-        return new Response(null, { status: 204, headers: { "ETag": serverETag } });
+        return new Response(null, { status: 204 });
     }
     if (url === `${visitsUrl}/2/attachments` && hasBody) {
         return new Response(null, { status: 200 });
@@ -163,53 +156,6 @@ test("editing the guest's preferred name posts the change to the visit", async (
 
     const editCall = mock.mock.calls.find(([url, init]) => url === `${visitsUrl}/2` && init?.body != null)!;
     expect(JSON.parse(editCall[1]!.body as string)).toMatchObject({ guest_preferred_name: "Stardust" });
-});
-
-test("field edits carry If-Match from the loaded ETag and refresh it from the response", async (): Promise<void> => {
-    const mock = await initVisitPage();
-
-    const nameField = document.getElementById("guest_preferred_name") as HTMLInputElement;
-    nameField.value = "Stardust";
-    await window.editGuestPreferredName();
-
-    let posts = mock.mock.calls.filter(([u, init]) => u === `${visitsUrl}/2` && init?.body != null);
-    expect(posts).toHaveLength(1);
-    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBe(`"4"`);
-
-    // The next edit carries the ETag produced by the first one.
-    mock.mockClear();
-    nameField.value = "Moonbeam";
-    await window.editGuestPreferredName();
-    posts = mock.mock.calls.filter(([u, init]) => u === `${visitsUrl}/2` && init?.body != null);
-    expect(posts).toHaveLength(1);
-    expect(new Headers(posts[0]![1]!.headers).get("If-Match")).toBe(`"5"`);
-});
-
-test("a 412 conflict shows the conflict banner and refetches the visit", async (): Promise<void> => {
-    const mock = await initVisitPage();
-
-    const conflictRoutes = (url: string, init?: RequestInit): Response | undefined => {
-        if (url === `${visitsUrl}/2` && init?.body != null) {
-            return problemResponse("Someone else got here first", 412);
-        }
-        return visitRoutes(url, init);
-    };
-    mock.mockImplementation(async (url: string, init?: RequestInit): Promise<Response> => {
-        const response = conflictRoutes(url, init);
-        if (response == null) {
-            throw new Error(`no mocked fetch route for ${url}`);
-        }
-        return response;
-    });
-
-    serverVisit.guest_preferred_name = "Their Conflicting Name";
-    const nameField = document.getElementById("guest_preferred_name") as HTMLInputElement;
-    nameField.value = "My Rejected Name";
-    await window.editGuestPreferredName();
-
-    expect(document.getElementById("error_text")!.textContent).toContain(
-        "Someone else has edited this visit");
-    expect(inputValue("guest_preferred_name")).toBe("Their Conflicting Name");
 });
 
 test("adding a known ranger posts to that visit's ranger endpoint", async (): Promise<void> => {
@@ -504,26 +450,6 @@ test("setting a ranger's role posts the handle and the role", async (): Promise<
         handle: "Hot Slots",
         role: "sitter",
     });
-});
-
-test("roster changes refresh the ETag used by the next field edit", async (): Promise<void> => {
-    const mock = await initVisitPage();
-
-    // The roster endpoint bumps the visit's version, so a later field edit must
-    // send the bumped ETag rather than the one loaded with the page.
-    const roleInput = document
-        .getElementById("visit_rangers_list")!
-        .querySelector("li input") as HTMLInputElement;
-    roleInput.value = "sitter";
-    await window.setRangerRole(roleInput);
-
-    mock.mockClear();
-    const nameField = document.getElementById("guest_legal_name") as HTMLInputElement;
-    nameField.value = "Pat Q. Doe";
-    await window.editGuestLegalName();
-
-    const post = mock.mock.calls.find(([u, init]) => u === `${visitsUrl}/2` && init?.body != null)!;
-    expect(new Headers(post[1]!.headers).get("If-Match")).toBe(`"5"`);
 });
 
 // The arrival/departure pickers post through flatpickr's onChange rather than an


### PR DESCRIPTION
Clients no longer send If-Match or see a 412; the server reads, merges and retries against each record's VERSION. That counter guards only the record's own columns, so report entries, rosters, types, links and field-report/visit assignment don't move it — they're in their own tables, where no edit can clobber them.