### PR TITLE
feat: normalize BRC addresses, opt-in per event

### DIFF
--- a/api/address_test.go
+++ b/api/address_test.go
@@ -1,0 +1,82 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package api
+
+import (
+	"testing"
+
+	imsjson "github.com/burningmantech/ranger-ims-go/json"
+	"github.com/burningmantech/ranger-ims-go/store/imsdb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildIncidentUpdateNormalizesLocationAddress(t *testing.T) {
+	t.Parallel()
+
+	address := "4&esp"
+	update, logs := buildIncidentUpdate(imsdb.Incident{}, imsjson.Incident{
+		Location: imsjson.Location{Address: &address},
+	}, true)
+	assert.Equal(t, "4:00 & Esplanade", update.LocationAddress.String)
+	assert.Contains(t, logs, "Changed location address: 4:00 & Esplanade")
+
+	freeform := "behind the porta potties"
+	update, _ = buildIncidentUpdate(imsdb.Incident{}, imsjson.Incident{
+		Location: imsjson.Location{Address: &freeform},
+	}, true)
+	assert.Equal(t, "behind the porta potties", update.LocationAddress.String)
+
+	// An absent address leaves the stored one alone.
+	stored := imsdb.Incident{}
+	stored.LocationAddress.String = "9:00 & A"
+	stored.LocationAddress.Valid = true
+	update, logs = buildIncidentUpdate(stored, imsjson.Incident{}, true)
+	assert.Equal(t, "9:00 & A", update.LocationAddress.String)
+	assert.Empty(t, logs)
+}
+
+func TestBuildVisitUpdateNormalizesGuestCampAddress(t *testing.T) {
+	t.Parallel()
+
+	address := "e+7"
+	update, logs, errHTTP := buildVisitUpdate(imsdb.Visit{}, imsjson.Visit{
+		GuestCampAddress: &address,
+	}, true)
+	require.Nil(t, errHTTP)
+	assert.Equal(t, "E & 7:00", update.GuestCampAddress.String)
+	assert.Contains(t, logs, "Changed GuestCampAddress: E & 7:00")
+}
+
+func TestBuildUpdatesLeaveAddressesAloneWhenTheEventDoesNotNormalize(t *testing.T) {
+	t.Parallel()
+
+	address := "4&esp"
+	incidentUpdate, logs := buildIncidentUpdate(imsdb.Incident{}, imsjson.Incident{
+		Location: imsjson.Location{Address: &address},
+	}, false)
+	assert.Equal(t, "4&esp", incidentUpdate.LocationAddress.String)
+	assert.Contains(t, logs, "Changed location address: 4&esp")
+
+	campAddress := "e+7"
+	visitUpdate, logs, errHTTP := buildVisitUpdate(imsdb.Visit{}, imsjson.Visit{
+		GuestCampAddress: &campAddress,
+	}, false)
+	require.Nil(t, errHTTP)
+	assert.Equal(t, "e+7", visitUpdate.GuestCampAddress.String)
+	assert.Contains(t, logs, "Changed GuestCampAddress: e+7")
+}

--- a/api/event.go
+++ b/api/event.go
@@ -96,6 +96,8 @@ func (action GetEvents) getEvents(req *http.Request) (imsjson.Events, *herr.HTTP
 			IsGroup:     &eve.Event.IsGroup,
 			ParentGroup: conv.SqlToInt32(eve.Event.ParentGroup),
 			MapURL:      conv.SqlToString(eve.Event.MapUrl),
+
+			NormalizeAddresses: &eve.Event.NormalizeAddresses,
 		})
 	}
 
@@ -178,6 +180,8 @@ func (action EditEvent) editEvents(req *http.Request) (newEventID *int32, errHTT
 		IsGroup:     existingEventRow.Event.IsGroup,
 		ParentGroup: existingEventRow.Event.ParentGroup,
 		MapUrl:      existingEventRow.Event.MapUrl,
+
+		NormalizeAddresses: existingEventRow.Event.NormalizeAddresses,
 	}
 
 	if editRequest.Name != nil {
@@ -214,6 +218,12 @@ func (action EditEvent) editEvents(req *http.Request) (newEventID *int32, errHTT
 			return nil, herr.BadRequest("An event group cannot have a map URL", nil)
 		}
 		updateParams.MapUrl = conv.StringToSql(editRequest.MapURL, 1024)
+	}
+	if editRequest.NormalizeAddresses != nil {
+		if updateParams.IsGroup && *editRequest.NormalizeAddresses {
+			return nil, herr.BadRequest("An event group cannot normalize addresses", nil)
+		}
+		updateParams.NormalizeAddresses = *editRequest.NormalizeAddresses
 	}
 
 	err = action.imsDBQ.UpdateEvent(req.Context(), action.imsDBQ, updateParams)

--- a/api/helpers.go
+++ b/api/helpers.go
@@ -32,6 +32,7 @@ import (
 	"github.com/burningmantech/ranger-ims-go/directory"
 	"github.com/burningmantech/ranger-ims-go/lib/authz"
 	"github.com/burningmantech/ranger-ims-go/lib/conv"
+	"github.com/burningmantech/ranger-ims-go/lib/format"
 	"github.com/burningmantech/ranger-ims-go/lib/herr"
 	"github.com/burningmantech/ranger-ims-go/lib/rand"
 	"github.com/burningmantech/ranger-ims-go/store"
@@ -128,6 +129,17 @@ func applyStringChange(dst *sql.NullString, newVal *string, label string, logs *
 	}
 	*dst = conv.StringToSql(newVal, 0)
 	*logs = append(*logs, fmt.Sprintf("Changed %v: %v", label, dst.String))
+}
+
+// normalizedAddress puts a client-supplied Black Rock City address into
+// canonical form, e.g. "7+e" into "7:00 & E". Text that doesn't parse as an
+// address is left as the client sent it.
+func normalizedAddress(address *string, normalize bool) *string {
+	if address == nil || !normalize {
+		return address
+	}
+	normalized := format.NormalizeAddress(*address)
+	return &normalized
 }
 
 func readBodyAs[T any](req *http.Request) (T, *herr.HTTPError) {

--- a/api/incident.go
+++ b/api/incident.go
@@ -383,7 +383,7 @@ func (action NewIncident) newIncident(req *http.Request) (incidentNumber int32, 
 	newIncident.Event = event.Name
 	newIncident.Number = newIncidentNumber
 
-	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author)
+	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author, event.NormalizeAddresses)
 	if errHTTP != nil {
 		return 0, "", errHTTP.From("[updateIncident]")
 	}
@@ -451,6 +451,7 @@ func rejectSetReplacement(newIncident imsjson.Incident) *herr.HTTPError {
 }
 
 func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
+	normalizeAddresses bool,
 ) *herr.HTTPError {
 	errHTTP := rejectSetReplacement(newIncident)
 	if errHTTP != nil {
@@ -458,7 +459,7 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 	}
 	for range maxCASAttempts {
 		conflict, errHTTP := retryOnDeadlock(func() (bool, *herr.HTTPError) {
-			return updateIncidentAttempt(ctx, imsDBQ, es, newIncident, author)
+			return updateIncidentAttempt(ctx, imsDBQ, es, newIncident, author, normalizeAddresses)
 		})
 		if errHTTP != nil {
 			return errHTTP.From("[updateIncidentAttempt]")
@@ -471,6 +472,7 @@ func updateIncident(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, 
 }
 
 func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newIncident imsjson.Incident, author string,
+	normalizeAddresses bool,
 ) (conflict bool, errHTTP *herr.HTTPError) {
 	storedIncidentRow, err := imsDBQ.Incident(ctx, imsDBQ,
 		imsdb.IncidentParams{
@@ -492,7 +494,7 @@ func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSour
 	}
 	defer rollback(txn)
 
-	update, logs := buildIncidentUpdate(storedIncident, newIncident)
+	update, logs := buildIncidentUpdate(storedIncident, newIncident, normalizeAddresses)
 
 	// A request that only appends report entries is applied without the guarded
 	// update below: appends can't lose data, so they must not conflict with
@@ -542,7 +544,8 @@ func updateIncidentAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSour
 // buildIncidentUpdate merges the client-provided fields of newIncident over the
 // stored Incident, returning the update parameters along with change-log lines
 // describing each modified field.
-func buildIncidentUpdate(stored imsdb.Incident, newIncident imsjson.Incident) (imsdb.UpdateIncidentParams, []string) {
+func buildIncidentUpdate(stored imsdb.Incident, newIncident imsjson.Incident, normalizeAddresses bool,
+) (imsdb.UpdateIncidentParams, []string) {
 	update := imsdb.UpdateIncidentParams{
 		Event:               stored.Event,
 		Number:              stored.Number,
@@ -578,7 +581,7 @@ func buildIncidentUpdate(stored imsdb.Incident, newIncident imsjson.Incident) (i
 	}
 	applyStringChange(&update.Summary, newIncident.Summary, "summary", &logs)
 	applyStringChange(&update.LocationName, newIncident.Location.Name, "location name", &logs)
-	applyStringChange(&update.LocationAddress, newIncident.Location.Address, "location address", &logs)
+	applyStringChange(&update.LocationAddress, normalizedAddress(newIncident.Location.Address, normalizeAddresses), "location address", &logs)
 	applyStringChange(&update.LocationDescription, newIncident.Location.Description, "location description", &logs)
 
 	return update, logs
@@ -634,7 +637,7 @@ func (action EditIncident) editIncident(req *http.Request) *herr.HTTPError {
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author)
+	errHTTP = updateIncident(ctx, action.imsDBQ, action.es, newIncident, author, event.NormalizeAddresses)
 	if errHTTP != nil {
 		return errHTTP.From("[updateIncident]")
 	}

--- a/api/integration/event_test.go
+++ b/api/integration/event_test.go
@@ -96,6 +96,88 @@ func TestGetAndEditEvent(t *testing.T) {
 	require.NotZero(t, foundEvent.ID)
 }
 
+func TestEventNormalizeAddresses(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+
+	eventName := rand.NonCryptoText()
+	eventID, resp := apisAdmin.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	adminExpr := "person:" + userAdminHandle
+	resp = apisAdmin.editAccess(ctx, imsjson.EventsAccess{
+		eventName: {
+			Writers:      []imsjson.AccessRule{{Expression: adminExpr, Validity: "always"}},
+			VisitWriters: []imsjson.AccessRule{{Expression: adminExpr, Validity: "always"}},
+		},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// A new event doesn't normalize addresses.
+	events, resp := apisAdmin.getEvents(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	event := findEvent(events, eventID)
+	require.NotNil(t, event)
+	require.NotNil(t, event.NormalizeAddresses)
+	require.False(t, *event.NormalizeAddresses)
+
+	// So the address is stored exactly as sent.
+	incidentNumber := apisAdmin.newIncidentSuccess(ctx, imsjson.Incident{
+		Event:    eventName,
+		Location: imsjson.Location{Address: new("7+e")},
+	})
+	incident, resp := apisAdmin.getIncident(ctx, eventName, incidentNumber)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, incident.Location.Address)
+	require.Equal(t, "7+e", *incident.Location.Address)
+
+	// Turn normalization on.
+	status, body := editEventBody(ctx, t, apisAdmin, imsjson.Event{
+		ID:                 eventID,
+		NormalizeAddresses: new(true),
+	})
+	require.Equal(t, http.StatusNoContent, status, body)
+
+	events, resp = apisAdmin.getEvents(ctx)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	event = findEvent(events, eventID)
+	require.NotNil(t, event)
+	require.NotNil(t, event.NormalizeAddresses)
+	require.True(t, *event.NormalizeAddresses)
+
+	// Now the same edit gets canonicalized on the way in.
+	resp = apisAdmin.updateIncident(ctx, eventName, incidentNumber, imsjson.Incident{
+		Event:    eventName,
+		Number:   incidentNumber,
+		Location: imsjson.Location{Address: new("7+e")},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	incident, resp = apisAdmin.getIncident(ctx, eventName, incidentNumber)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, incident.Location.Address)
+	require.Equal(t, "7:00 & E", *incident.Location.Address)
+
+	// The same flag covers a Visit's guest camp address.
+	visitNumber := apisAdmin.newVisitSuccess(ctx, imsjson.Visit{
+		Event:            eventName,
+		GuestCampAddress: new("e+7"),
+	})
+	visit, resp := apisAdmin.getVisit(ctx, eventName, visitNumber)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.NotNil(t, visit.GuestCampAddress)
+	require.Equal(t, "E & 7:00", *visit.GuestCampAddress)
+}
+
 func TestEditEvent_errors(t *testing.T) {
 	t.Parallel()
 	ctx := t.Context()
@@ -253,6 +335,15 @@ func TestEventGroups_errors(t *testing.T) {
 	})
 	require.Equal(t, http.StatusBadRequest, status)
 	require.Contains(t, body, "cannot have a map URL")
+
+	// An event group holds no incidents or visits, so it can't normalize addresses.
+	status, body = editEventBody(ctx, t, apisAdmin, imsjson.Event{
+		ID:                 groupID,
+		NormalizeAddresses: new(true),
+		IsGroup:            new(true),
+	})
+	require.Equal(t, http.StatusBadRequest, status)
+	require.Contains(t, body, "cannot normalize addresses")
 }
 
 // findEvent returns a pointer to the event with the given ID, or nil if not present.

--- a/api/visit.go
+++ b/api/visit.go
@@ -352,7 +352,7 @@ func (action NewVisit) newVisit(req *http.Request) (visitNumber int32, location 
 	newVisit.Event = event.Name
 	newVisit.Number = newVisitNumber
 
-	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author)
+	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author, event.NormalizeAddresses)
 	if errHTTP != nil {
 		return 0, "", errHTTP.From("[updateVisit]")
 	}
@@ -361,10 +361,11 @@ func (action NewVisit) newVisit(req *http.Request) (visitNumber int32, location 
 }
 
 func updateVisit(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newVisit imsjson.Visit, author string,
+	normalizeAddresses bool,
 ) *herr.HTTPError {
 	for range maxCASAttempts {
 		conflict, errHTTP := retryOnDeadlock(func() (bool, *herr.HTTPError) {
-			return updateVisitAttempt(ctx, imsDBQ, es, newVisit, author)
+			return updateVisitAttempt(ctx, imsDBQ, es, newVisit, author, normalizeAddresses)
 		})
 		if errHTTP != nil {
 			return errHTTP.From("[updateVisitAttempt]")
@@ -377,6 +378,7 @@ func updateVisit(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, new
 }
 
 func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcerer, newVisit imsjson.Visit, author string,
+	normalizeAddresses bool,
 ) (conflict bool, errHTTP *herr.HTTPError) {
 	storedVisitRow, err := imsDBQ.Visit(ctx, imsDBQ,
 		imsdb.VisitParams{
@@ -398,7 +400,7 @@ func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcer
 	}
 	defer rollback(txn)
 
-	update, logs, errHTTP := buildVisitUpdate(storedVisit, newVisit)
+	update, logs, errHTTP := buildVisitUpdate(storedVisit, newVisit, normalizeAddresses)
 	if errHTTP != nil {
 		return false, errHTTP.From("[buildVisitUpdate]")
 	}
@@ -455,7 +457,8 @@ func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcer
 // stored Visit, returning the update parameters along with change-log lines
 // describing each modified field. It rejects updates that would put the
 // arrival time after the departure time.
-func buildVisitUpdate(stored imsdb.Visit, newVisit imsjson.Visit) (imsdb.UpdateVisitParams, []string, *herr.HTTPError) {
+func buildVisitUpdate(stored imsdb.Visit, newVisit imsjson.Visit, normalizeAddresses bool,
+) (imsdb.UpdateVisitParams, []string, *herr.HTTPError) {
 	update := imsdb.UpdateVisitParams{
 		Event:                stored.Event,
 		Number:               stored.Number,
@@ -508,7 +511,7 @@ func buildVisitUpdate(stored imsdb.Visit, newVisit imsjson.Visit) (imsdb.UpdateV
 	applyStringChange(&update.GuestActionPlan, newVisit.GuestActionPlan, "GuestActionPlan", &logs)
 	applyStringChange(&update.ResourceBedID, newVisit.ResourceBedID, "ResourceBedID", &logs)
 	applyStringChange(&update.GuestCampName, newVisit.GuestCampName, "GuestCampName", &logs)
-	applyStringChange(&update.GuestCampAddress, newVisit.GuestCampAddress, "GuestCampAddress", &logs)
+	applyStringChange(&update.GuestCampAddress, normalizedAddress(newVisit.GuestCampAddress, normalizeAddresses), "GuestCampAddress", &logs)
 	applyStringChange(&update.GuestCampDescription, newVisit.GuestCampDescription, "GuestCampDescription", &logs)
 	applyStringChange(&update.GuestCampContacts, newVisit.GuestCampContacts, "GuestCampContacts", &logs)
 	applyStringChange(&update.ResourceSitter, newVisit.ResourceSitter, "ResourceSitter", &logs)
@@ -584,7 +587,7 @@ func (action EditVisit) editVisit(req *http.Request) *herr.HTTPError {
 
 	author := jwtCtx.Claims.RangerHandle()
 
-	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author)
+	errHTTP = updateVisit(ctx, action.imsDBQ, action.es, newVisit, author, event.NormalizeAddresses)
 	if errHTTP != nil {
 		return errHTTP.From("[updateVisit]")
 	}

--- a/json/event.go
+++ b/json/event.go
@@ -23,4 +23,7 @@ type Event struct {
 	IsGroup     *bool   `json:"is_group"`
 	ParentGroup *int32  `json:"parent_group"`
 	MapURL      *string `json:"map_url"`
+	// NormalizeAddresses turns on canonicalization of the BRC addresses
+	// clients send for this event's Incidents and Visits.
+	NormalizeAddresses *bool `json:"normalize_addresses"`
 }

--- a/lib/format/address.go
+++ b/lib/format/address.go
@@ -1,0 +1,112 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package format
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Patterns for the pieces of a Black Rock City address. All are used within
+// case-insensitive expressions.
+const (
+	// e.g. "7", "7:00", "0:15", or colonless "813" and "1015".
+	radialPat = `(?:(\d{1,2})(?::(\d{1,2}))?|(\d{3,4}))`
+	// e.g. "E", "esp", "Esplanade".
+	concentricPat = `([A-L]|ESPLANADE|ESPL|ESP)\.?`
+	// distance from the Man, e.g. "2500'", "2500 ft", "500".
+	distancePat = `(\d{1,5})\s*('|’|FT\.?|FEET)?`
+	// e.g. "&", " + ", ", ", " and ".
+	separatorPat = `(?:\s*[&+/,]\s*|\s+AND\s+|\s+)`
+)
+
+var (
+	radialConcentricRE = regexp.MustCompile(`(?i)^` + radialPat + separatorPat + concentricPat + `$`)
+	concentricRadialRE = regexp.MustCompile(`(?i)^` + concentricPat + separatorPat + radialPat + `$`)
+	radialDistanceRE   = regexp.MustCompile(`(?i)^` + radialPat + separatorPat + distancePat + `$`)
+)
+
+// NormalizeAddress rewrites a Black Rock City address into its canonical form:
+// "7:00 & E" for a radial/concentric intersection (in whichever order the
+// author wrote it), or "12:00 2500'" for an open-playa address given as a
+// radial and a distance from the Man. Anything that doesn't parse with
+// confidence, such as "behind the porta potties", is returned unchanged.
+func NormalizeAddress(address string) string {
+	trimmed := strings.TrimSpace(address)
+
+	if m := radialConcentricRE.FindStringSubmatch(trimmed); m != nil {
+		if radial, ok := formatRadial(m[1], m[2], m[3]); ok {
+			return radial + " & " + formatConcentric(m[4])
+		}
+	}
+	if m := concentricRadialRE.FindStringSubmatch(trimmed); m != nil {
+		if radial, ok := formatRadial(m[2], m[3], m[4]); ok {
+			return formatConcentric(m[1]) + " & " + radial
+		}
+	}
+	if m := radialDistanceRE.FindStringSubmatch(trimmed); m != nil {
+		radial, radialOK := formatRadial(m[1], m[2], m[3])
+		distance, distanceOK := formatDistance(m[4], m[5])
+		if radialOK && distanceOK {
+			return radial + " " + distance
+		}
+	}
+
+	return address
+}
+
+// formatRadial takes either an hour and minute or a colonless radial such as
+// "813", exactly one of which the radial pattern captures.
+func formatRadial(hour, minute, colonless string) (string, bool) {
+	if colonless != "" {
+		hour, minute = colonless[:len(colonless)-2], colonless[len(colonless)-2:]
+	}
+	h, err := strconv.Atoi(hour)
+	if err != nil || h > 12 {
+		return "", false
+	}
+	m := 0
+	if minute != "" {
+		m, err = strconv.Atoi(minute)
+		if err != nil || m > 59 {
+			return "", false
+		}
+	}
+	return fmt.Sprintf("%d:%02d", h, m), true
+}
+
+func formatConcentric(street string) string {
+	if len(street) == 1 {
+		return strings.ToUpper(street)
+	}
+	return "Esplanade"
+}
+
+func formatDistance(feet, unit string) (string, bool) {
+	// Without a unit, a short number is more likely a typo than a distance,
+	// so leave those alone rather than guessing.
+	if unit == "" && len(feet) < 3 {
+		return "", false
+	}
+	f, err := strconv.Atoi(feet)
+	if err != nil || f == 0 {
+		return "", false
+	}
+	return strconv.Itoa(f) + "'", true
+}

--- a/lib/format/address_test.go
+++ b/lib/format/address_test.go
@@ -1,0 +1,112 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package format_test
+
+import (
+	"testing"
+
+	"github.com/burningmantech/ranger-ims-go/lib/format"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNormalizeAddress_radialThenConcentric(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7+e"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7:00&e"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7 and e"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7 & E"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7, e"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7/e"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("7 e"))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("  7:00  &  e.  "))
+	assert.Equal(t, "7:00 & E", format.NormalizeAddress("07:00 & E"))
+	assert.Equal(t, "7:15 & K", format.NormalizeAddress("7:15+k"))
+	assert.Equal(t, "7:05 & A", format.NormalizeAddress("7:5 & a"))
+	assert.Equal(t, "12:00 & L", format.NormalizeAddress("12&l"))
+	assert.Equal(t, "0:15 & B", format.NormalizeAddress("0:15 b"))
+}
+
+func TestNormalizeAddress_colonlessRadial(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "8:13 & G", format.NormalizeAddress("813&g"))
+	assert.Equal(t, "8:13 & G", format.NormalizeAddress("813 g"))
+	assert.Equal(t, "10:15 & G", format.NormalizeAddress("1015 + g"))
+	assert.Equal(t, "12:30 & Esplanade", format.NormalizeAddress("1230 esp"))
+	assert.Equal(t, "0:15 & B", format.NormalizeAddress("015 and b"))
+	assert.Equal(t, "G & 8:13", format.NormalizeAddress("g,813"))
+	assert.Equal(t, "8:13 500'", format.NormalizeAddress("813 500'"))
+
+	// The hour and minute still have to be real ones.
+	assert.Equal(t, "999 & G", format.NormalizeAddress("999 & G"))
+	assert.Equal(t, "1330 & G", format.NormalizeAddress("1330 & G"))
+}
+
+func TestNormalizeAddress_concentricThenRadial(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "E & 7:00", format.NormalizeAddress("e+7"))
+	assert.Equal(t, "E & 7:00", format.NormalizeAddress("E & 7:00"))
+	assert.Equal(t, "E & 7:30", format.NormalizeAddress("e and 7:30"))
+	assert.Equal(t, "C & 3:00", format.NormalizeAddress("c,3"))
+}
+
+func TestNormalizeAddress_esplanade(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "4:00 & Esplanade", format.NormalizeAddress("4&esp"))
+	assert.Equal(t, "4:00 & Esplanade", format.NormalizeAddress("4:00 & Esplanade"))
+	assert.Equal(t, "4:00 & Esplanade", format.NormalizeAddress("4 espl"))
+	assert.Equal(t, "4:00 & Esplanade", format.NormalizeAddress("4 + ESP."))
+	assert.Equal(t, "Esplanade & 4:00", format.NormalizeAddress("esp&4"))
+}
+
+func TestNormalizeAddress_artAddresses(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "12:00 2500'", format.NormalizeAddress("12:00 2500'"))
+	assert.Equal(t, "12:00 2500'", format.NormalizeAddress("12 2500'"))
+	assert.Equal(t, "12:00 2500'", format.NormalizeAddress("12, 2500ft"))
+	assert.Equal(t, "12:00 2500'", format.NormalizeAddress("12 & 2500 feet"))
+	assert.Equal(t, "12:00 2500'", format.NormalizeAddress("12:00 2500"))
+	assert.Equal(t, "0:15 500'", format.NormalizeAddress("0:15 500'"))
+	assert.Equal(t, "0:15 500'", format.NormalizeAddress("0:15 0500"))
+	assert.Equal(t, "6:00 80'", format.NormalizeAddress("6 80ft"))
+}
+
+func TestNormalizeAddress_leavesUnrecognizedTextAlone(t *testing.T) {
+	t.Parallel()
+
+	assert.Empty(t, format.NormalizeAddress(""))
+	assert.Equal(t, "  ", format.NormalizeAddress("  "))
+	assert.Equal(t, "behind the porta potties", format.NormalizeAddress("behind the porta potties"))
+	assert.Equal(t, "Center Camp", format.NormalizeAddress("Center Camp"))
+	assert.Equal(t, "7:00 Plaza", format.NormalizeAddress("7:00 Plaza"))
+	assert.Equal(t, "7 & Bacon", format.NormalizeAddress("7 & Bacon"))
+	// M is past the last concentric street the normalizer knows.
+	assert.Equal(t, "7 & M", format.NormalizeAddress("7 & M"))
+	// Hours and minutes out of range.
+	assert.Equal(t, "13:00 & E", format.NormalizeAddress("13:00 & E"))
+	assert.Equal(t, "7:60 & E", format.NormalizeAddress("7:60 & E"))
+	// Too short to be a distance without a unit, and no unit given.
+	assert.Equal(t, "12 30", format.NormalizeAddress("12 30"))
+	// Not an address at all.
+	assert.Equal(t, "7", format.NormalizeAddress("7"))
+	assert.Equal(t, "E", format.NormalizeAddress("E"))
+	assert.Equal(t, "7:00 & E & 7:00", format.NormalizeAddress("7:00 & E & 7:00"))
+}

--- a/store/fakeimsdb/seed.sql
+++ b/store/fakeimsdb/seed.sql
@@ -1,12 +1,12 @@
 insert into EVENT (ID, NAME, IS_GROUP, PARENT_GROUP)
 values  (6, 'TestBRC', true, null);
 
-insert into EVENT (ID, NAME, IS_GROUP, PARENT_GROUP)
-values  (2, '2025', false, 6),
-        (1, '2026', false, 6),
-        (3, '2031', false, 6),
-        (4, '2032', false, 6),
-        (5, 'Test', false, null);
+insert into EVENT (ID, NAME, IS_GROUP, PARENT_GROUP, NORMALIZE_ADDRESSES)
+values  (2, '2025', false, 6, true),
+        (1, '2026', false, 6, true),
+        (3, '2031', false, 6, true),
+        (4, '2032', false, 6, true),
+        (5, 'Test', false, null, true);
 
 insert into EVENT_ACCESS (ID, EVENT, EXPRESSION, MODE, VALIDITY)
 values  (1, 6, '*', 'write', 'always'),

--- a/store/queries.sql
+++ b/store/queries.sql
@@ -19,7 +19,8 @@ set
     NAME = ?,
     IS_GROUP = ?,
     PARENT_GROUP = ?,
-    MAP_URL = ?
+    MAP_URL = ?,
+    NORMALIZE_ADDRESSES = ?
 where ID = ?
 ;
 

--- a/store/schema/38-from-37.sql
+++ b/store/schema/38-from-37.sql
@@ -1,0 +1,13 @@
+/* Add a per-event switch for automatic Black Rock City address normalization.
+
+   When true, addresses the client sends for an Incident's location or a
+   Visit's guest camp are rewritten into canonical form ("7+e" becomes
+   "7:00 & E") before being stored. It's a per-event column rather than a
+   config setting so that it can be flipped from the admin UI without a
+   server restart. */
+
+alter table `EVENT` add column `NORMALIZE_ADDRESSES` boolean not null default false;
+
+update `SCHEMA_INFO`
+set `VERSION` = 38
+where true;

--- a/store/schema/current.sql
+++ b/store/schema/current.sql
@@ -6,7 +6,7 @@ create table SCHEMA_INFO (
 -- This value must be updated when you make a new migration file.
 --
 
-insert into SCHEMA_INFO (VERSION) values (37);
+insert into SCHEMA_INFO (VERSION) values (38);
 
 
 create table `EVENT` (
@@ -16,6 +16,9 @@ create table `EVENT` (
     IS_GROUP        boolean not null default false,
     PARENT_GROUP    integer,
     MAP_URL         varchar(1024),
+
+    -- Whether to rewrite client-supplied addresses into canonical BRC form.
+    NORMALIZE_ADDRESSES boolean not null default false,
 
     primary key (ID),
     unique key (NAME),

--- a/web/template/adminevents.templ
+++ b/web/template/adminevents.templ
@@ -51,6 +51,13 @@ templ AdminEvents(deployment, versionName, versionRef string) {
             <label for="edit_map_url" class="control-label input-group-text">Map URL</label>
             <input id="edit_map_url" type="url" class="form-control form-control-sm" onchange="setMapURL(this);" placeholder="https://example.com/map.pdf" />
           </div>
+          <div class="input-group mb-3" id="edit_normalize_addresses_group">
+            <label for="edit_normalize_addresses" class="control-label input-group-text">Normalize Addresses</label>
+            <div class="input-group-text">
+              <input id="edit_normalize_addresses" type="checkbox" class="form-check-input mt-0" onchange="setNormalizeAddresses(this);" />
+            </div>
+            <span class="form-control form-control-sm text-smaller d-flex align-items-center">Rewrite addresses into BRC form, e.g. "7+e" becomes "7:00 &amp; E"</span>
+          </div>
         </div>
         <div class="modal-footer">
           <!-- The title tooltip goes on the wrapper span, since disabled buttons don't fire the events that show tooltips. -->

--- a/web/typescript/admin_events.ts
+++ b/web/typescript/admin_events.ts
@@ -23,6 +23,7 @@ declare global {
         addEvent: (el: HTMLInputElement, type: "group"|"not-group")=>Promise<void>;
         setParentGroup: (el: HTMLInputElement) => Promise<void>;
         setMapURL: (el: HTMLInputElement) => Promise<void>;
+        setNormalizeAddresses: (el: HTMLInputElement) => Promise<void>;
     }
 }
 
@@ -68,6 +69,7 @@ async function initAdminEventsPage(): Promise<void> {
     window.addEvent = addEvent;
     window.setParentGroup = setParentGroup;
     window.setMapURL = setMapURL;
+    window.setNormalizeAddresses = setNormalizeAddresses;
 
     el.browserTz.textContent = Intl.DateTimeFormat().resolvedOptions().timeZone;
     // Show the current time as the example, so it's useful to copy-paste from.
@@ -401,6 +403,13 @@ function eventCard(event: ims.EventData): DocumentFragment {
         // groups can't have map URLs
         mapURLInput.disabled = event.is_group??false;
         mapURLInput.value = event.map_url??"";
+
+        // Groups hold no incidents or visits, so address normalization is
+        // meaningless for them.
+        const normalizeGroup = el.editEventModal.querySelector("#edit_normalize_addresses_group") as HTMLElement;
+        normalizeGroup.classList.toggle("d-none", event.is_group??false);
+        const normalizeInput = el.editEventModal.querySelector("#edit_normalize_addresses") as HTMLInputElement;
+        normalizeInput.checked = event.normalize_addresses??false;
 
         editEventModal?.show();
     });
@@ -1173,6 +1182,32 @@ async function deleteEvent(): Promise<void> {
         return;
     }
     editEventModal?.hide();
+    await loadAccessControlList();
+    drawAccess();
+}
+
+async function setNormalizeAddresses(sender: HTMLInputElement): Promise<void> {
+    const eventId = ims.parseInt10(el.editEventModal.dataset["eventId"])!;
+
+    const requestBod: ims.EventData = {
+        id: eventId,
+        // @ts-expect-error the server is fine to receive null here. Really this field should allow null/undefined.
+        name: null,
+        normalize_addresses: sender.checked,
+    };
+    const {err} = await ims.fetchNoThrow(url_events, {
+        body: JSON.stringify(requestBod),
+    });
+    if (err != null) {
+        const message = `Failed to edit event: ${err}`;
+        console.log(message);
+        window.alert(message);
+        await loadAccessControlList();
+        drawAccess();
+        ims.controlHasError(sender);
+        return;
+    }
+    ims.controlHasSuccess(sender);
     await loadAccessControlList();
     drawAccess();
 }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -2094,6 +2094,7 @@ export type EventData = {
     is_group?: boolean,
     parent_group?: number|null,
     map_url?: string|null,
+    normalize_addresses?: boolean|null,
 }
 
 export interface Attachment {

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1260,6 +1260,10 @@ async function setLocationFromPlace(knownLoc: HTMLOptionElement): Promise<void> 
 }
 
 async function editLocationAddress(): Promise<void> {
+    // Blur the field first, so the refresh after the edit is allowed to
+    // rewrite it with the server's normalized address (e.g. "7+e" becomes
+    // "7:00 & E"). A focused field with uncommitted input isn't updated.
+    el.locationAddress.blur();
     await ims.editFromElement(el.locationAddress, "location.address");
 }
 

--- a/web/typescript/sanctuary_visit.ts
+++ b/web/typescript/sanctuary_visit.ts
@@ -512,6 +512,10 @@ async function editGuestCampName(): Promise<void> {
 }
 
 async function editGuestCampAddress(): Promise<void> {
+    // Blur the field first, so the refresh after the edit is allowed to
+    // rewrite it with the server's normalized address (e.g. "7+e" becomes
+    // "7:00 & E"). A focused field with uncommitted input isn't updated.
+    el.guestCampAddress.blur();
     await ims.editFromElement(el.guestCampAddress, "guest_camp_address");
 }
 

--- a/web/typescripttest/admin_events.test.ts
+++ b/web/typescripttest/admin_events.test.ts
@@ -74,6 +74,9 @@ async function initAdminEventsPage() {
         if ((url === url_events || url === url_events + "?include_groups=true") && init?.body == null) {
             return jsonResponse(serverEvents);
         }
+        if (url === url_events && init?.body != null) {
+            return new Response(null, { status: 204 });
+        }
         if (url === url_acl && init?.body == null) {
             return jsonResponse(serverACL);
         }
@@ -515,6 +518,33 @@ test("clicking the card header toggles the collapse, except on its buttons", asy
     (card.querySelector(".show-edit-modal") as HTMLButtonElement).click();
     (card.querySelector(".explain_button") as HTMLButtonElement).click();
     expect(toggleClicks).toHaveBeenCalledTimes(2);
+});
+
+test("the edit modal shows the event's address normalization setting, and toggling it posts the change", async (): Promise<void> => {
+    serverEvents = [{ id: 1, name: "2025", normalize_addresses: true }];
+    const mock = await initAdminEventsPage();
+
+    (eventCards()[0]!.querySelector(".show-edit-modal") as HTMLButtonElement).click();
+
+    expect(document.getElementById("edit_normalize_addresses_group")!.classList.contains("d-none")).toBe(false);
+    const normalize = document.getElementById("edit_normalize_addresses") as HTMLInputElement;
+    expect(normalize.checked).toBe(true);
+
+    normalize.checked = false;
+    await window.setNormalizeAddresses(normalize);
+
+    const call = mock.mock.calls.findLast(([url, init]) => url === url_events && init?.body != null);
+    expect(call).toBeDefined();
+    expect(JSON.parse(call![1]!.body as string)).toEqual({ id: 1, name: null, normalize_addresses: false });
+});
+
+test("the edit modal hides address normalization for event groups", async (): Promise<void> => {
+    serverEvents = [{ id: 1, name: "2025", is_group: true }];
+    await initAdminEventsPage();
+
+    (eventCards()[0]!.querySelector(".show-edit-modal") as HTMLButtonElement).click();
+
+    expect(document.getElementById("edit_normalize_addresses_group")!.classList.contains("d-none")).toBe(true);
 });
 
 test("the delete button is disabled when the server disallows event deletion", async (): Promise<void> => {

--- a/web/typescripttest/incident.test.ts
+++ b/web/typescripttest/incident.test.ts
@@ -462,6 +462,29 @@ test("choosing a known place fills the location name and address", async (): Pro
     ]);
 });
 
+test("the location address input is rewritten with the server's normalized address", async (): Promise<void> => {
+    const mock = await initIncidentPage((url: string, init?: RequestInit): Response|undefined => {
+        const body = init?.body != null ? JSON.parse(init.body as string) : null;
+        if (body?.location?.address != null) {
+            // Stand in for the server's address normalization.
+            serverIncident.location = { ...serverIncident.location, address: "7:00 & E" };
+        }
+        return incidentRoutes(url, init);
+    });
+
+    // Type into the field and save it without leaving it, as pressing Enter does.
+    const address = document.getElementById("incident_location_address") as HTMLInputElement;
+    address.focus();
+    address.value = "7+e";
+    address.dispatchEvent(new Event("input", { bubbles: true }));
+    await window.editLocationAddress();
+
+    expect(postedBodies(mock, "/ims/api/events/2025/incidents/1")).toEqual([
+        { location: { address: "7+e" }, number: 1 },
+    ]);
+    expect(address.value).toBe("7:00 & E");
+});
+
 test("addRanger fuzzy-matches handles and posts to the rangers endpoint", async (): Promise<void> => {
     const mock = await initIncidentPage();
 

--- a/web/typescripttest/sanctuary_visit.test.ts
+++ b/web/typescripttest/sanctuary_visit.test.ts
@@ -347,6 +347,26 @@ test("editing each camp field posts its own key", async (): Promise<void> => {
         .toMatchObject({ guest_camp_contacts: "Moon Dog, tent 3" });
 });
 
+test("the camp address input is rewritten with the server's normalized address", async (): Promise<void> => {
+    await initVisitPage((url: string, init?: RequestInit): Response|undefined => {
+        const body = init?.body != null ? JSON.parse(init.body as string) : null;
+        if (body?.guest_camp_address != null) {
+            // Stand in for the server's address normalization.
+            serverVisit.guest_camp_address = "7:00 & E";
+        }
+        return visitRoutes(url, init);
+    });
+
+    // Type into the field and save it without leaving it, as pressing Enter does.
+    const address = document.getElementById("guest_camp_address") as HTMLInputElement;
+    address.focus();
+    address.value = "7+e";
+    address.dispatchEvent(new Event("input", { bubbles: true }));
+    await window.editGuestCampAddress();
+
+    expect(address.value).toBe("7:00 & E");
+});
+
 test("editing each arrival field posts its own key", async (): Promise<void> => {
     const mock = await initVisitPage();
 


### PR DESCRIPTION
Incident location and Visit guest camp addresses like "7+e" are rewritten to "7:00 & E" on save. It's an EVENT column toggled from the admin events page rather than a config setting, so it can be flipped without a restart.