### PR TITLE
feat(nav): have IMS logo link to table for entity in scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,25 @@ Each month below should look like the following, using the same ordering for the
 ### Fixed
 
 This page accounts for changes up until:
-https://github.com/burningmantech/ranger-ims-go/pull/708
+https://github.com/burningmantech/ranger-ims-go/commit/f5409ac
 -->
+
+## 2026-08
+
+### Changed
+
+- Dropped the ETag/If-Match handshake that clients used to guard their edits. The server now does the concurrency check itself: it re-reads the record, merges the change, and retries if someone else got there first, so a client no longer has to track a version or handle a "your copy is stale" rejection. Report entries, Ranger rosters, Incident Types, links, and Field Report/Visit assignment live in their own tables, so none of them can clobber (or be clobbered by) an edit to the record's own fields. https://github.com/burningmantech/ranger-ims-go/pull/732
+- Made the IMS logo in the navbar link to the table for whatever you're looking at, so that from a Field Report it goes to that event's Field Reports table rather than to the home page. The user dropdown also gained a "Home" link (and some emoji). https://github.com/burningmantech/ranger-ims-go/commit/f5409ac
+- Started saying "Set role for X" in the change log when a Ranger's role within an Incident or Sanctuary Visit changes, rather than describing it as a removal and re-addition. https://github.com/burningmantech/ranger-ims-go/commit/9ae0919
+
+### Added
+
+- Added server-side error logging, surfaced on a new Error Logs admin page. This makes it much easier to spot problems during the event. https://github.com/burningmantech/ranger-ims-go/pull/737
+- Added normalization of Black Rock City addresses, so that an Incident location or a Sanctuary Visit guest camp address typed as "7+e" is saved as "7:00 & E". It's opt-in per event, toggled from the Admin Events page, so it can be turned on or off without a server restart. https://github.com/burningmantech/ranger-ims-go/pull/736
+
+### Fixed
+
+- Stopped the Incident location autocomplete from putting the whole "Name (address)" string into the name field. Picking a place now fills in just the name, and the address goes in the address field, where it belongs. https://github.com/burningmantech/ranger-ims-go/commit/70bc5d7
 
 ## 2026-07
 
@@ -29,10 +46,15 @@ https://github.com/burningmantech/ranger-ims-go/pull/708
 - Reorganized how event permissions are displayed on the Admin Events page, grouping the grants so that they're much easier to read and manage. Rule badges now count matching expressions rather than people, grant dates show as a bare date (with the full datetime on hover), a bare `*` who-expression is spelled out as "(ALL authenticated users)", and a grant's description appears on its own line above its terms. https://github.com/burningmantech/ranger-ims-go/pull/704 https://github.com/burningmantech/ranger-ims-go/pull/707 https://github.com/burningmantech/ranger-ims-go/commit/34c5781
 - Stopped using flatpickr for the date inputs on the Admin Events page. There were enough of them that the page got noticeably slow to render, and it's an admin-only page, so manual datetime entry is a fair trade. https://github.com/burningmantech/ranger-ims-go/pull/703
 - Replaced the event name text input on the Admin Places page with a real dropdown of events, newest first. https://github.com/burningmantech/ranger-ims-go/pull/708
-- Changed how the Incident page adds and removes an Incident Type or a link to another Incident: each of those gestures is now its own request against a new per-item endpoint, rather than a rewrite of the whole list. Such a request says only "attach this one" or "remove this one", so it can't undo a change someone else made, it's safe to repeat, and it never conflicts with a concurrent edit to the Incident's other fields. The whole-list fields on the Incident API still work as before.
+- Made the Admin Places page keep the selected event in the URL, so a filtered view can be bookmarked or shared and comes back with that event's places already loaded. https://github.com/burningmantech/ranger-ims-go/commit/6c2c0b8
+- Expanded the help page considerably, linked to it from the home page, and replaced the Incident page's "Link IMS #" placeholder with a clearer hint. https://github.com/burningmantech/ranger-ims-go/commit/34df1dc
+- Changed how the Incident page adds and removes an Incident Type or a link to another Incident: each of those gestures is now its own request against a new per-item endpoint, rather than a rewrite of the whole list. Such a request says only "attach this one" or "remove this one", so it can't undo a change someone else made, it's safe to repeat, and it never conflicts with a concurrent edit to the Incident's other fields. The whole-list fields on the Incident API still work as before. https://github.com/burningmantech/ranger-ims-go/pull/729
 
 ### Added
 
+- Allowed an event permission expression to carry more than one access mode for the same event, e.g. so that `person:Hardware` can be a reader of Incidents while also being a writer of Sanctuary Visits. https://github.com/burningmantech/ranger-ims-go/commit/ff87508
+- Added a Places link to the navbar's user dropdown. https://github.com/burningmantech/ranger-ims-go/pull/711
+- Added `hammer`, a standalone load-testing tool under `bin/`, for putting a local or test IMS server under load. https://github.com/burningmantech/ranger-ims-go/commit/b275e9d
 - Added an IMS-native user store, allowing IMS to run without a Clubhouse database. This includes a new admin page for managing users in the IMS-native user tables. https://github.com/burningmantech/ranger-ims-go/commit/7be7b05
 - Added versioning of Incidents, Field Reports, and Sanctuary Visits. Each is now served with a version (as an HTTP ETag), and a write that's based on a stale version is rejected rather than silently stomping someone else's concurrent change. https://github.com/burningmantech/ranger-ims-go/pull/680
 - Added a proper multi-event search page, which also supports regular expression searches across all the events a user can read. https://github.com/burningmantech/ranger-ims-go/pull/678 https://github.com/burningmantech/ranger-ims-go/commit/a7e1d2e
@@ -52,11 +74,12 @@ https://github.com/burningmantech/ranger-ims-go/pull/708
 - Pointed the Incident page's "On-Duty" link at the incident's start time, so it shows who was on duty then rather than now. https://github.com/burningmantech/ranger-ims-go/pull/708
 - Added cachebusting for style.css, as we already did for our JavaScript files. https://github.com/burningmantech/ranger-ims-go/pull/706
 - Avoided database contention over the next number to assign when creating Incidents, Field Reports, and Sanctuary Visits. https://github.com/burningmantech/ranger-ims-go/commit/93bde89
-- Fixed a data-loss bug on the Incident page: clicking two Incident Types' (or two linked Incidents') X buttons in quick succession would remove one and put the other one back, because the second request was built from the list as it looked before the first click.
-- Stopped a Ranger roster change on the Incident or Sanctuary Visit page from spuriously rejecting a field edit that was in flight at the same time.
-- Stopped allowing an Incident Type to be created or renamed with an empty name. A nameless type can't be shown to anyone, and it's indistinguishable from a type that doesn't exist to anything that looks one up by name.
+- Fixed a data-loss bug on the Incident page: clicking two Incident Types' (or two linked Incidents') X buttons in quick succession would remove one and put the other one back, because the second request was built from the list as it looked before the first click. https://github.com/burningmantech/ranger-ims-go/pull/729
+- Stopped a Ranger roster change on the Incident or Sanctuary Visit page from spuriously rejecting a field edit that was in flight at the same time. https://github.com/burningmantech/ranger-ims-go/pull/729
+- Stopped allowing an Incident Type to be created or renamed with an empty name. A nameless type can't be shown to anyone, and it's indistinguishable from a type that doesn't exist to anything that looks one up by name. https://github.com/burningmantech/ranger-ims-go/pull/729
 - Stopped the Incident page's "Link IMS #" field from sending a link to Incident #0 when what was typed wasn't a number. It now says so, and an emptied field no longer tries to link anything (or, on an unsaved Incident, to create one).
 - Told password managers to ignore another field that isn't a password. https://github.com/burningmantech/ranger-ims-go/pull/671
+- Made the "don't autofill this" hints consistent across the web UI. Blocking autofill takes several attributes, and only a handful of the ~34 fields that opted out had all of them, so some still drew fill and save prompts. https://github.com/burningmantech/ranger-ims-go/commit/147d0ca
 
 ## 2026-06
 

--- a/web/template/adminactionlogs.templ
+++ b/web/template/adminactionlogs.templ
@@ -24,7 +24,7 @@ templ AdminActionLogs(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Action Logs</h1>
 

--- a/web/template/admindebug.templ
+++ b/web/template/admindebug.templ
@@ -24,7 +24,7 @@ templ AdminDebug(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Server Debugging Details</h1>
 

--- a/web/template/admindirectory.templ
+++ b/web/template/admindirectory.templ
@@ -24,7 +24,7 @@ templ AdminDirectory(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">User Directory</h1>
 @LoadingOverlay()

--- a/web/template/adminerrorlogs.templ
+++ b/web/template/adminerrorlogs.templ
@@ -24,7 +24,7 @@ templ AdminErrorLogs(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Error Logs</h1>
 

--- a/web/template/adminevents.templ
+++ b/web/template/adminevents.templ
@@ -24,7 +24,7 @@ templ AdminEvents(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Events and Permissions</h1>
 @LoadingOverlay()

--- a/web/template/adminplaces.templ
+++ b/web/template/adminplaces.templ
@@ -24,7 +24,7 @@ templ AdminPlaces(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Event Places</h1>
 

--- a/web/template/adminroot.templ
+++ b/web/template/adminroot.templ
@@ -24,7 +24,7 @@ templ AdminRoot(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Administration Tools</h1>
 

--- a/web/template/admintypes.templ
+++ b/web/template/admintypes.templ
@@ -24,7 +24,7 @@ templ AdminTypes(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Incident Types</h1>
 @LoadingOverlay()

--- a/web/template/field_report.templ
+++ b/web/template/field_report.templ
@@ -24,7 +24,7 @@ templ FieldReport(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "field_reports")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Field Report Details</h1>
 

--- a/web/template/field_reports.templ
+++ b/web/template/field_reports.templ
@@ -24,7 +24,7 @@ templ FieldReports(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "field_reports")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Field Reports</h1>
 

--- a/web/template/help.templ
+++ b/web/template/help.templ
@@ -24,7 +24,7 @@ templ Help(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">IMS Help</h1>
 

--- a/web/template/incident.templ
+++ b/web/template/incident.templ
@@ -24,7 +24,7 @@ templ Incident(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "incidents")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Incident Details</h1>
 

--- a/web/template/incidents.templ
+++ b/web/template/incidents.templ
@@ -26,7 +26,7 @@ templ Incidents(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "incidents")
 <main id="main" tabindex="-1">
 
 <div class="d-flex justify-content-between">

--- a/web/template/login.templ
+++ b/web/template/login.templ
@@ -26,7 +26,7 @@ templ Login(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Incident Management System</h1>
 

--- a/web/template/nav.templ
+++ b/web/template/nav.templ
@@ -16,10 +16,19 @@
 
 package template
 
-templ Nav(eventName string) {
+// eventSection, when set, is the event-scoped URL segment of the current page
+// ("incidents", "field_reports" or "visits"). It sends the logo link to that
+// section's root rather than to the event's home page.
+templ Nav(eventName, eventSection string) {
 {{
   eventSet := eventName != ""
-  if !eventSet {
+  logoHref := "/ims/app"
+  if eventSet {
+    logoHref = "/ims/app/events/" + eventName
+    if eventSection != "" {
+      logoHref += "/" + eventSection
+    }
+  } else {
     eventName = "Event"
   }
 }}
@@ -92,7 +101,7 @@ templ Nav(eventName string) {
   </template>
 
   <div class="container-fluid">
-    <a class="navbar-brand" href="/ims/app">
+    <a id="ims-logo" class="navbar-brand" href={ logoHref }>
       <svg class="logo-icon me-1" aria-hidden="true" focusable="false">
         <use href="#brr" />
       </svg>
@@ -193,7 +202,7 @@ templ Nav(eventName string) {
 
       <!-- Not logged in: offer to log in -->
       <ul class="navbar-nav if-not-logged-in hidden no-print">
-        <li id="nav_login"><a class="nav-link" href="/ims/auth/login">Log In</a></li>
+        <li id="nav_login"><a class="nav-link" href="/ims/auth/login">🚪 Log In</a></li>
       </ul>
 
       <!-- Logged in: show user menu -->
@@ -204,8 +213,9 @@ templ Nav(eventName string) {
             <span class="logged-in-user"/>
           </a>
           <ul class="dropdown-menu">
-            <li class="if-admin hidden"><a href="/ims/app/admin" class="dropdown-item">Admin</a></li>
-            <li><a href="/ims/app/search" class="dropdown-item">Search</a></li>
+            <li class="if-admin hidden"><a href="/ims/app/admin" class="dropdown-item">🛡️ Admin</a></li>
+            <li><a href="/ims/app" class="dropdown-item">🏠 Home</a></li>
+            <li><a href="/ims/app/search" class="dropdown-item">🔍 Search</a></li>
             <li class="nav-item">
               <a id="active-event-places"
                  if eventSet {
@@ -213,12 +223,12 @@ templ Nav(eventName string) {
                  } else {
                    class="dropdown-item hidden"
                  }
-                 href="">Places
+                 href="">⛺ Places
                </a>
             </li>
-            <li><a href="/ims/app/settings" class="dropdown-item">Settings</a></li>
-            <li><a href="/ims/app/help" class="dropdown-item">Help</a></li>
-            <li><a href="/ims/auth/logout" class="dropdown-item">Log out</a></li>
+            <li><a href="/ims/app/settings" class="dropdown-item">⚙️ Settings</a></li>
+            <li><a href="/ims/app/help" class="dropdown-item">❔ Help</a></li>
+            <li><a href="/ims/auth/logout" class="dropdown-item">🚪 Log out</a></li>
           </ul>
         </li>
       </ul>

--- a/web/template/nav_test.go
+++ b/web/template/nav_test.go
@@ -1,0 +1,64 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package template_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/burningmantech/ranger-ims-go/web/template"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNavLogoLink(t *testing.T) {
+	t.Parallel()
+
+	logoLink := func(t *testing.T, eventName, eventSection string) string {
+		t.Helper()
+		var sb strings.Builder
+		require.NoError(t, template.Nav(eventName, eventSection).Render(t.Context(), &sb))
+		match := regexp.MustCompile(`<a id="ims-logo"[^>]*href="([^"]*)"`).FindStringSubmatch(sb.String())
+		require.NotNil(t, match, "no ims-logo link found")
+		return match[1]
+	}
+
+	t.Run("no event", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "/ims/app", logoLink(t, "", ""))
+	})
+
+	t.Run("event, no section", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "/ims/app/events/2026", logoLink(t, "2026", ""))
+	})
+
+	t.Run("incidents", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "/ims/app/events/2026/incidents", logoLink(t, "2026", "incidents"))
+	})
+
+	t.Run("field reports", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "/ims/app/events/2026/field_reports", logoLink(t, "2026", "field_reports"))
+	})
+
+	t.Run("visits", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "/ims/app/events/2026/visits", logoLink(t, "2026", "visits"))
+	})
+}

--- a/web/template/places.templ
+++ b/web/template/places.templ
@@ -24,7 +24,7 @@ templ Places(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Places</h1>
 

--- a/web/template/root.templ
+++ b/web/template/root.templ
@@ -24,7 +24,7 @@ templ Root(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Incident Management System</h1>
 

--- a/web/template/sanctuary_visit.templ
+++ b/web/template/sanctuary_visit.templ
@@ -24,7 +24,7 @@ templ SanctuaryVisit(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "visits")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Sanctuary Visit</h1>
 

--- a/web/template/sanctuary_visits.templ
+++ b/web/template/sanctuary_visits.templ
@@ -24,7 +24,7 @@ templ SanctuaryVisits(deployment, versionName, versionRef, eventName string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav(eventName)
+@Nav(eventName, "visits")
 <main id="main" tabindex="-1">
 
 <div class="d-flex justify-content-between">

--- a/web/template/search.templ
+++ b/web/template/search.templ
@@ -24,7 +24,7 @@ templ Search(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Search Anywhere</h1>
 

--- a/web/template/settings.templ
+++ b/web/template/settings.templ
@@ -24,7 +24,7 @@ templ Settings(deployment, versionName, versionRef string) {
 <body>
 <div class="container-fluid">
 @Header(deployment)
-@Nav("")
+@Nav("", "")
 <main id="main" tabindex="-1">
 <h1 id="doc-title">Settings</h1>
 


### PR DESCRIPTION
e.g. if you're viewing a Field Report, clicking the logo will take you to the Field Reports table for the event in scope.

This also adds some fun emoji to the items in the username dropdown, because why not?