### PR TITLE
feat(places): set camp/art/mv places from the Burning Man API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,6 @@ IMS_ATTACHMENTS_LOCAL_DIR="ims-attachments"
 # AWS_REGION="my bucket's region"
 # IMS_ATTACHMENTS_S3_BUCKET="my bucket name"
 # IMS_ATTACHMENTS_S3_COMMON_KEY_PREFIX="ims-dev-attachments/"
+
+# IMS_BM_API_KEY=
+# IMS_BM_API_URL=https://api.burningman.org

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ https://github.com/burningmantech/ranger-ims-go/commit/f5409ac
 ### Added
 
 - Added server-side error logging, surfaced on a new Error Logs admin page. This makes it much easier to spot problems during the event. https://github.com/burningmantech/ranger-ims-go/pull/737
+- Added "Set from API" buttons to the Admin Places page for camps, art, and mutant vehicles, so that an admin can have the server pull that data from the Burning Man API for a given year rather than pasting the response in by hand. This needs a Burning Man API key in the server's config (`IMS_BM_API_KEY`); without one, the buttons stay disabled.
 - Added normalization of Black Rock City addresses, so that an Incident location or a Sanctuary Visit guest camp address typed as "7+e" is saved as "7:00 & E". It's opt-in per event, toggled from the Admin Events page, so it can be turned on or off without a server restart. https://github.com/burningmantech/ranger-ims-go/pull/736
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,9 @@ Key configuration concepts:
   or `noop` (testing only)
 - **DB store types**: `MariaDB` (persistent storage) or `noop` (no-op for testing only)
 - **Attachments stores**: `local` (filesystem) or `s3` (AWS S3)
+- **Burning Man API**: `IMS_BM_API_KEY` (and `IMS_BM_API_URL`, which defaults to the real
+  host) enable the Places admin page's "Set from API" buttons. Both are optional; without a
+  key that feature is switched off, and places must be pasted in by hand
 
 ### API Structure
 
@@ -223,6 +226,7 @@ The API (`api/` package) uses a custom middleware adapter pattern:
 - Incidents, Field Reports, and Visits carry a `VERSION` counter used as an internal concurrency gate: an edit reads the record, then applies a version-guarded `UPDATE`, and retries the read-merge-write if a concurrent writer moved the version first (`maxCASAttempts` in `api/incident.go`). The counter is reported in the record body but is not part of the request contract — clients send no precondition header. It guards only the record's own columns, so nothing else moves it: report entries, roster changes, incident types, links, and field-report/visit assignment all live in other tables, where no edit can clobber them. Set-valued fields are mutated one member at a time through their own endpoints so that concurrent writers can't undo each other
 - Cross-event search (`api/search.go`) matches a substring or regex query against Incidents, Field Reports, and Visits across all events the requestor can read
 - Burning Man doesn't publish camp and art placement until shortly before the event, so an Event carries release times (set on the Edit Event modal) that embargo that data. Until a release time arrives, only IMS admins see it: `api/embargo.go` strips camp/art Place locations out of the `GetPlaces` response and withholds the event's `MapURL` from `GetEvents`. A null release time means no embargo. The release times themselves go out to everyone, so the Places page can show a banner naming what's still embargoed and when it'll appear
+- Camp, art, and mutant vehicle Places can come straight from the public Burning Man API instead of being pasted in: `ImportPlaces` (`api/place.go`) fetches one place type for a given year through `lib/bmapi` and replaces the event's places of that type. The year is a request parameter, since an IMS event isn't necessarily named for the year whose data it wants. The API key lives only on the server, so the browser never sees it; `GetAuth` reports whether one is configured, which is what disables the admin page's buttons. An empty upstream response is rejected rather than applied, so a mistyped year can't wipe an event's places
 
 ### Web UI
 

--- a/api/auth.go
+++ b/api/auth.go
@@ -178,6 +178,7 @@ type GetAuth struct {
 	admins               []string
 	attachmentsEnabled   bool
 	eventDeletionEnabled bool
+	bmAPIEnabled         bool
 }
 
 type GetAuthResponse struct {
@@ -189,6 +190,10 @@ type GetAuthResponse struct {
 	// EventDeletionAllowed tells the admin events page whether this server
 	// permits deleting events (the EventDeletionEnabled server config).
 	EventDeletionAllowed bool `json:"event_deletion_allowed"`
+
+	// PlacesImportAllowed tells the admin places page whether this server has a
+	// Burning Man API key, and so can pull an event's places from that API.
+	PlacesImportAllowed bool `json:"places_import_allowed"`
 }
 
 type AccessForEvent struct {
@@ -231,6 +236,7 @@ func (action GetAuth) getAuth(req *http.Request) (GetAuthResponse, *herr.HTTPErr
 		User:                 handle,
 		Admin:                slices.Contains(roles, authz.Administrator),
 		EventDeletionAllowed: action.eventDeletionEnabled,
+		PlacesImportAllowed:  action.bmAPIEnabled,
 	}
 	// event_id is an optional query param for this endpoint
 	eventName := req.FormValue("event_id")

--- a/api/integration/auth_test.go
+++ b/api/integration/auth_test.go
@@ -91,6 +91,9 @@ func TestGetAuthAPIAuthorization(t *testing.T) {
 		Authenticated: true,
 		User:          userAliceHandle,
 		Admin:         false,
+		// The test server is configured with a Burning Man API key. This says
+		// nothing about whether this user may use it.
+		PlacesImportAllowed: true,
 	}, getAuth)
 	require.NoError(t, resp.Body.Close())
 
@@ -99,9 +102,10 @@ func TestGetAuthAPIAuthorization(t *testing.T) {
 	require.NotNil(t, resp)
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	require.Equal(t, api.GetAuthResponse{
-		Authenticated: true,
-		User:          userAdminHandle,
-		Admin:         true,
+		Authenticated:       true,
+		User:                userAdminHandle,
+		Admin:               true,
+		PlacesImportAllowed: true,
 	}, getAuth)
 	require.NoError(t, resp.Body.Close())
 
@@ -144,9 +148,10 @@ func TestGetAuthWithEvent(t *testing.T) {
 	eventID := authResp.EventAccess[eventName].EventID
 	require.NotZero(t, eventID)
 	require.Equal(t, api.GetAuthResponse{
-		Authenticated: true,
-		User:          userAdminHandle,
-		Admin:         true,
+		Authenticated:       true,
+		User:                userAdminHandle,
+		Admin:               true,
+		PlacesImportAllowed: true,
 		EventAccess: map[string]api.AccessForEvent{
 			eventName: {
 				EventID:           eventID,

--- a/api/integration/helpers_test.go
+++ b/api/integration/helpers_test.go
@@ -123,6 +123,16 @@ func (a ApiHelper) editPlaces(ctx context.Context, eventName string, req imsjson
 	return a.imsPost(ctx, req, a.serverURL.JoinPath("/ims/api/events/", eventName, "/places").String())
 }
 
+func (a ApiHelper) importPlaces(ctx context.Context, eventName, placeType, year string) *http.Response {
+	a.t.Helper()
+	path := a.serverURL.JoinPath("/ims/api/events/", eventName, "/places/import")
+	q := path.Query()
+	q.Set("place_type", placeType)
+	q.Set("year", year)
+	path.RawQuery = q.Encode()
+	return a.imsPost(ctx, nil, path.String())
+}
+
 func (a ApiHelper) getPlaces(ctx context.Context, eventName string) (imsjson.Places, *http.Response) {
 	a.t.Helper()
 	path := a.serverURL.JoinPath("/ims/api/events/", eventName, "/places").String()

--- a/api/integration/main_test.go
+++ b/api/integration/main_test.go
@@ -39,6 +39,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -64,6 +65,42 @@ var shared struct {
 	serverURL    *url.URL
 	actionLogger *actionlog.Logger
 	errorLogger  *errorlog.Logger
+	bmAPIServer  *httptest.Server
+}
+
+// bmAPIYearNoData and bmAPIYearBroken are the years the fake Burning Man API
+// treats specially. See fakeBMAPI.
+const (
+	bmAPIYearNoData = "1999"
+	bmAPIYearBroken = "1900"
+)
+
+// fakeBMAPI stands in for the public Burning Man API, which the places import
+// endpoint calls. It answers from the request alone, holding no state of its
+// own, so that the tests using it can still run in parallel.
+func fakeBMAPI(w http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("X-API-Key") != shared.cfg.BurningManAPI.APIKey {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	kind := strings.TrimPrefix(req.URL.Path, "/api/")
+	year := req.URL.Query().Get("year")
+	w.Header().Set("Content-Type", "application/json")
+	switch year {
+	case bmAPIYearBroken:
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"detail": "the API is having a bad day"}`))
+	case bmAPIYearNoData:
+		// What the real API gives for a year it has nothing for.
+		_, _ = w.Write([]byte(`[]`))
+	default:
+		// #nosec G705 // XSS via taint analysis. This test fake just echoes the
+		// request it was given back as JSON.
+		_, _ = fmt.Fprintf(w, `[
+			{"uid": "%[1]v-1", "name": "%[1]v One", "location_string": "3:00 & A", "year": %[2]v},
+			{"uid": "%[1]v-2", "name": "%[1]v Two", "location_string": "4:00 & B", "year": %[2]v}
+		]`, kind, year)
+	}
 }
 
 // panicPath is a test-only route that always panics, so that the error log
@@ -124,6 +161,11 @@ func setup(ctx context.Context, tempDir string) {
 	shared.cfg.Directory.ClubhouseDB.Database = "clubhouse-" + rand.NonCryptoText()
 	shared.cfg.Directory.ClubhouseDB.Username = "rangers-" + rand.NonCryptoText()
 	shared.cfg.Directory.ClubhouseDB.Password = "password-" + rand.NonCryptoText()
+	shared.bmAPIServer = httptest.NewServer(http.HandlerFunc(fakeBMAPI))
+	shared.cfg.BurningManAPI = conf.BurningManAPI{
+		URL:    shared.bmAPIServer.URL,
+		APIKey: "bmapikey-" + rand.NonCryptoText(),
+	}
 	must(shared.cfg.Validate())
 	shared.es = api.NewEventSourcerer()
 
@@ -210,6 +252,9 @@ func shutdown(ctx context.Context, tempDir string) {
 	_ = os.RemoveAll(tempDir)
 	if shared.testServer != nil {
 		shared.testServer.Close()
+	}
+	if shared.bmAPIServer != nil {
+		shared.bmAPIServer.Close()
 	}
 	if shared.imsDBQ != nil {
 		_ = shared.imsDBQ.Close()

--- a/api/integration/permissions_test.go
+++ b/api/integration/permissions_test.go
@@ -49,9 +49,10 @@ func TestAdminOnlyEndpoints(t *testing.T) {
 		{http.MethodGet, "/ims/api/actionlogs"},
 		{http.MethodGet, "/ims/api/errorlogs"},
 		{http.MethodPost, "/ims/api/events"},
-		// It doesn't matter that this event doesn't exist, because the endpoint will deny access to
-		// a non-admin before it checks whether the event even exists.
+		// It doesn't matter that this event doesn't exist, because these endpoints will deny access
+		// to a non-admin before they check whether the event even exists.
 		{http.MethodPost, "/ims/api/events/SomeFakeEvent/places"},
+		{http.MethodPost, "/ims/api/events/SomeFakeEvent/places/import"},
 		{http.MethodPost, "/ims/api/incident_types"},
 		{http.MethodGet, "/ims/api/debug/buildinfo"},
 		{http.MethodGet, "/ims/api/debug/runtimemetrics"},

--- a/api/integration/place_test.go
+++ b/api/integration/place_test.go
@@ -17,10 +17,12 @@
 package integration_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 	"time"
 
+	"github.com/burningmantech/ranger-ims-go/api"
 	imsjson "github.com/burningmantech/ranger-ims-go/json"
 	"github.com/burningmantech/ranger-ims-go/lib/rand"
 	"github.com/stretchr/testify/assert"
@@ -242,4 +244,152 @@ func TestPlaceLocationEmbargoExcludingExternalData(t *testing.T) {
 	assert.Equal(t, "Camp Fun Times", places["camp"][0].Name)
 	assert.Empty(t, places["camp"][0].LocationString)
 	assert.Nil(t, places["camp"][0].ExternalData)
+}
+
+// TestImportPlacesFromAPI covers the Places admin page's "Set from API"
+// buttons, which have the server fetch a place type from the Burning Man API
+// and store it, rather than an admin pasting the response in by hand. The
+// Burning Man API is stood in for by fakeBMAPI.
+func TestImportPlacesFromAPI(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+
+	eventName := rand.NonCryptoText()
+	_, resp := apis.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.importPlaces(ctx, eventName, "camp", "2025")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	var imported api.ImportPlacesResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&imported))
+	require.NoError(t, resp.Body.Close())
+	assert.Equal(t, 2, imported.Count)
+
+	places, resp := apis.getPlaces(ctx, eventName)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Len(t, places["camp"], 2)
+	assert.Equal(t, "camp One", places["camp"][0].Name)
+	assert.Equal(t, "3:00 & A", places["camp"][0].LocationString)
+	// The whole upstream object is kept as the Place's external data.
+	assert.Equal(t, map[string]any{
+		"uid": "camp-1", "name": "camp One", "location_string": "3:00 & A", "year": float64(2025),
+	}, places["camp"][0].ExternalData)
+
+	// Importing one type leaves the others alone.
+	resp = apis.importPlaces(ctx, eventName, "art", "2025")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	places, resp = apis.getPlaces(ctx, eventName)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	assert.Len(t, places["camp"], 2)
+	require.Len(t, places["art"], 2)
+	assert.Equal(t, "art One", places["art"][0].Name)
+}
+
+// A year the Burning Man API has no data for must not wipe out what the event
+// already has, since that's an easy typo to make in the year input.
+func TestImportPlacesEmptyResponseChangesNothing(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+
+	eventName := rand.NonCryptoText()
+	_, resp := apis.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.editPlaces(ctx, eventName, imsjson.Places{
+		"camp": {{Name: "Camp Fun Times", LocationString: "4:15 & E"}},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.importPlaces(ctx, eventName, "camp", bmAPIYearNoData)
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	places, resp := apis.getPlaces(ctx, eventName)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	require.Len(t, places["camp"], 1)
+	assert.Equal(t, "Camp Fun Times", places["camp"][0].Name)
+}
+
+func TestImportPlacesUpstreamFailure(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+
+	eventName := rand.NonCryptoText()
+	_, resp := apis.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.importPlaces(ctx, eventName, "camp", bmAPIYearBroken)
+	assert.Equal(t, http.StatusBadGateway, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	places, resp := apis.getPlaces(ctx, eventName)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	assert.Empty(t, places["camp"])
+}
+
+func TestImportPlacesBadRequests(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apis := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+
+	eventName := rand.NonCryptoText()
+	_, resp := apis.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// "Other" places are hand-written in IMS, with no upstream API to pull from.
+	resp = apis.importPlaces(ctx, eventName, "other", "2025")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.importPlaces(ctx, eventName, "camp", "not a year")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apis.importPlaces(ctx, "no-such-event", "camp", "2025")
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+// Importing places rewrites an event's data wholesale, so it takes the same
+// admin-only permission that saving them by hand does.
+func TestImportPlacesRequiresAdmin(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apisAlice := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+
+	eventName := rand.NonCryptoText()
+	_, resp := apisAdmin.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apisAdmin.editAccess(ctx, imsjson.EventsAccess{
+		eventName: imsjson.EventAccess{
+			Writers: []imsjson.AccessRule{{Expression: "person:" + userAliceHandle, Validity: "always"}},
+		},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	resp = apisAlice.importPlaces(ctx, eventName, "camp", "2025")
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
 }

--- a/api/mux.go
+++ b/api/mux.go
@@ -113,6 +113,7 @@ func AddToMux(
 			cfg.Core.Admins,
 			attachmentsEnabled,
 			cfg.Core.EventDeletionEnabled,
+			cfg.BurningManAPI.Enabled(),
 		}, true, OptionalAuthN(jwter))
 
 	// This endpoint does not require authentication, nor does it even consider
@@ -160,6 +161,7 @@ func AddToMux(
 
 	authed("GET /ims/api/events/{eventName}/places", GetPlaces{db, userStore, cfg.Core.Admins, cfg.Core.CacheControlShort}, true)
 	authed("POST /ims/api/events/{eventName}/places", UpdatePlaces{db, userStore, cfg.Core.Admins, cfg.Core.CacheControlShort}, true)
+	authed("POST /ims/api/events/{eventName}/places/import", ImportPlaces{db, userStore, cfg.Core.Admins, cfg.BurningManAPI}, true)
 
 	authed("GET /ims/api/events", GetEvents{db, userStore, cfg.Core.Admins, cfg.Core.CacheControlShort}, false)
 	authed("POST /ims/api/events", EditEvent{db, userStore, cfg.Core.Admins}, true)

--- a/api/place.go
+++ b/api/place.go
@@ -17,11 +17,15 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/burningmantech/ranger-ims-go/conf"
 	"github.com/burningmantech/ranger-ims-go/directory"
 	imsjson "github.com/burningmantech/ranger-ims-go/json"
 	"github.com/burningmantech/ranger-ims-go/lib/authz"
+	"github.com/burningmantech/ranger-ims-go/lib/bmapi"
+	"github.com/burningmantech/ranger-ims-go/lib/conv"
 	"github.com/burningmantech/ranger-ims-go/lib/herr"
 	"github.com/burningmantech/ranger-ims-go/store"
 	"github.com/burningmantech/ranger-ims-go/store/imsdb"
@@ -139,36 +143,137 @@ func (action UpdatePlaces) run(req *http.Request) *herr.HTTPError {
 	// for each type supplied, delete everything we have currently for that type
 	// before adding in everything from the request.
 	for dType, dests := range destByType {
-		err := action.imsDBQ.RemovePlaces(ctx, action.imsDBQ,
-			imsdb.RemovePlacesParams{
-				Event: event.ID,
-				Type:  imsdb.PlaceType(dType),
-			},
-		)
-		if err != nil {
-			return herr.InternalServerError("Failed to remove places", err).From("[RemovePlaces]")
-		}
-
-		for i, d := range dests {
-			marshal, err := json.Marshal(d.ExternalData)
-			if err != nil {
-				return herr.InternalServerError("Failed to marshal place", err).From("[Marshal]")
-			}
-			err = action.imsDBQ.CreatePlace(ctx, action.imsDBQ,
-				imsdb.CreatePlaceParams{
-					Event:          event.ID,
-					Number:         int32(i),
-					Type:           imsdb.PlaceType(dType),
-					Name:           d.Name,
-					LocationString: d.LocationString,
-					ExternalData:   marshal,
-				},
-			)
-			if err != nil {
-				return herr.InternalServerError("Failed to create place", err).From("[UpdatePlace]")
-			}
+		errHTTP = replacePlaces(ctx, action.imsDBQ, event.ID, imsdb.PlaceType(dType), dests)
+		if errHTTP != nil {
+			return errHTTP.From("[replacePlaces]")
 		}
 	}
 
 	return nil
+}
+
+// replacePlaces swaps out everything the event has of one place type for the
+// places provided.
+func replacePlaces(
+	ctx context.Context, imsDBQ *store.DBQ, eventID int32, placeType imsdb.PlaceType, places []imsjson.Place,
+) *herr.HTTPError {
+	err := imsDBQ.RemovePlaces(ctx, imsDBQ,
+		imsdb.RemovePlacesParams{
+			Event: eventID,
+			Type:  placeType,
+		},
+	)
+	if err != nil {
+		return herr.InternalServerError("Failed to remove places", err).From("[RemovePlaces]")
+	}
+
+	for i, d := range places {
+		marshal, err := json.Marshal(d.ExternalData)
+		if err != nil {
+			return herr.InternalServerError("Failed to marshal place", err).From("[Marshal]")
+		}
+		err = imsDBQ.CreatePlace(ctx, imsDBQ,
+			imsdb.CreatePlaceParams{
+				Event:          eventID,
+				Number:         int32(i),
+				Type:           placeType,
+				Name:           d.Name,
+				LocationString: d.LocationString,
+				ExternalData:   marshal,
+			},
+		)
+		if err != nil {
+			return herr.InternalServerError("Failed to create place", err).From("[UpdatePlace]")
+		}
+	}
+	return nil
+}
+
+// ImportPlaces replaces one place type's places for an event with what the
+// Burning Man API has for a given year. The year is a request parameter rather
+// than something derived from the event, since an IMS event isn't necessarily
+// named for the year whose data it wants.
+type ImportPlaces struct {
+	imsDBQ    *store.DBQ
+	userStore *directory.UserStore
+	imsAdmins []string
+	bmAPI     conf.BurningManAPI
+}
+
+type ImportPlacesResponse struct {
+	// Count is how many places were stored.
+	Count int `json:"count"`
+}
+
+func (action ImportPlaces) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	resp, errHTTP := action.run(req)
+	if errHTTP != nil {
+		errHTTP.From("[run]").WriteResponse(w)
+		return
+	}
+	mustWriteJSON(w, req, resp)
+}
+
+func (action ImportPlaces) run(req *http.Request) (ImportPlacesResponse, *herr.HTTPError) {
+	ctx := req.Context()
+	var resp ImportPlacesResponse
+	_, globalPermissions, errHTTP := getGlobalPermissions(req, action.imsDBQ, action.userStore, action.imsAdmins)
+	if errHTTP != nil {
+		return resp, errHTTP.From("[getGlobalPermissions]")
+	}
+	if globalPermissions&authz.GlobalAdministratePlaces == 0 {
+		return resp, herr.Forbidden("The requestor does not have GlobalAdministratePlaces permission", nil)
+	}
+	if !action.bmAPI.Enabled() {
+		return resp, herr.New(http.StatusServiceUnavailable,
+			"This server has no Burning Man API key configured", nil)
+	}
+	event, errHTTP := getEvent(req, req.PathValue("eventName"), action.imsDBQ)
+	if errHTTP != nil {
+		return resp, errHTTP.From("[getEvent]")
+	}
+	err := req.ParseForm()
+	if err != nil {
+		return resp, herr.BadRequest("Failed to parse form", err)
+	}
+	kind, err := bmapi.ParseKind(req.Form.Get("place_type"))
+	if err != nil {
+		return resp, herr.BadRequest(err.Error(), err)
+	}
+	year, err := conv.ParseInt32(req.Form.Get("year"))
+	if err != nil {
+		return resp, herr.BadRequest("The year must be a number", err)
+	}
+
+	records, err := bmapi.NewClient(action.bmAPI.URL, action.bmAPI.APIKey).Fetch(ctx, kind, year)
+	if err != nil {
+		return resp, herr.New(http.StatusBadGateway,
+			fmt.Sprintf("Failed to fetch %v data for %v from the Burning Man API: %v", kind, year, err),
+			err,
+		).From("[Fetch]")
+	}
+	// A year the API has no data for comes back as an empty array, which would
+	// otherwise silently wipe out whatever the event already had.
+	if len(records) == 0 {
+		return resp, herr.New(http.StatusBadGateway,
+			fmt.Sprintf("The Burning Man API has no %v data for %v. Nothing was changed.", kind, year),
+			nil,
+		)
+	}
+
+	places := make([]imsjson.Place, 0, len(records))
+	for _, r := range records {
+		places = append(places, imsjson.Place{
+			Name:           r.Name,
+			LocationString: r.LocationString,
+			ExternalData:   r.Raw,
+		})
+	}
+	errHTTP = replacePlaces(ctx, action.imsDBQ, event.ID, imsdb.PlaceType(kind), places)
+	if errHTTP != nil {
+		return resp, errHTTP.From("[replacePlaces]")
+	}
+
+	resp.Count = len(places)
+	return resp, nil
 }

--- a/cmd/serveconfig.go
+++ b/cmd/serveconfig.go
@@ -96,6 +96,12 @@ func mustApplyEnvConfig(baseCfg *conf.IMSConfig, envFileName string) *conf.IMSCo
 	if v, ok := lookupEnv("IMS_EVENT_DELETION_ENABLED"); ok {
 		baseCfg.Core.EventDeletionEnabled = strings.EqualFold(v, "true")
 	}
+	if v, ok := lookupEnv("IMS_BM_API_URL"); ok {
+		baseCfg.BurningManAPI.URL = strings.TrimSuffix(v, "/")
+	}
+	if v, ok := lookupEnv("IMS_BM_API_KEY"); ok {
+		baseCfg.BurningManAPI.APIKey = v
+	}
 	if v, ok := lookupEnv("IMS_DIRECTORY"); ok {
 		baseCfg.Directory.Directory = conf.DirectoryType(strings.ToLower(v))
 	}

--- a/conf/imsconfig.go
+++ b/conf/imsconfig.go
@@ -71,6 +71,9 @@ func DefaultIMS() *IMSConfig {
 		AttachmentsStore: AttachmentsStore{
 			Type: AttachmentsStoreNone,
 		},
+		BurningManAPI: BurningManAPI{
+			URL: "https://api.burningman.org",
+		},
 	}
 }
 
@@ -143,6 +146,7 @@ type IMSConfig struct {
 	AttachmentsStore AttachmentsStore
 	Store            DBStore
 	Directory        Directory
+	BurningManAPI    BurningManAPI
 }
 
 type DirectoryType string
@@ -243,6 +247,22 @@ type ConfigCore struct {
 	// test events. It should stay false in production, where such a destructive operation
 	// shouldn't be needed.
 	EventDeletionEnabled bool
+}
+
+// BurningManAPI configures IMS's access to the public Burning Man API, which
+// is where the Places admin page can pull an event's camp, art, and mutant
+// vehicle data from instead of having an admin paste it in by hand. It's
+// optional: without an APIKey, that feature is just switched off.
+type BurningManAPI struct {
+	// URL is the API's base URL, without a trailing slash.
+	URL string
+	// #nosec G117 // Exported secret struct field
+	APIKey string `redact:"true"`
+}
+
+// Enabled reports whether the server can call the Burning Man API.
+func (b BurningManAPI) Enabled() bool {
+	return b.URL != "" && b.APIKey != ""
 }
 
 type DBStore struct {

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,6 +54,10 @@ services:
       IMS_DMS_USERNAME: "${IMS_DMS_USERNAME:-clubhouseuser}"
       IMS_DMS_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
       IMS_EVENT_DELETION_ENABLED: "true"
+      # Optional. With no key, the Admin Places page's "Set from API" buttons
+      # stay disabled and places must be pasted in by hand.
+      IMS_BM_API_KEY: "${IMS_BM_API_KEY:-}"
+      IMS_BM_API_URL: "${IMS_BM_API_URL:-https://api.burningman.org}"
     ports:
       # Override IMS_HOST_PORT to set the port mapping on the host.
       - "127.0.0.1:${IMS_HOST_PORT:-8080}:8080"

--- a/lib/bmapi/bmapi.go
+++ b/lib/bmapi/bmapi.go
@@ -1,0 +1,147 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Package bmapi is a small client for the public Burning Man API
+// (https://api.burningman.org), which is where IMS gets the camp, art, and
+// mutant vehicle data behind an Event's Places.
+package bmapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Kind is a Burning Man API resource that maps onto an IMS place type. The
+// values are the API's own path segments, e.g. "/api/camp".
+type Kind string
+
+const (
+	KindArt  Kind = "art"
+	KindCamp Kind = "camp"
+	KindMV   Kind = "mv"
+)
+
+// maxResponseBytes caps how much we'll read from the API. A year of camps is
+// on the order of a megabyte, so this leaves a lot of headroom while still
+// keeping a misbehaving upstream from filling our memory.
+const maxResponseBytes = 64 << 20
+
+// requestTimeout bounds a single call to the API. These are large,
+// uncached-looking responses, so it's generous.
+const requestTimeout = 2 * time.Minute
+
+// Record is one camp, art piece, or mutant vehicle. The fields IMS needs are
+// pulled out, and Raw keeps the object exactly as the API sent it, since that
+// whole object is what IMS stores as a Place's external data.
+type Record struct {
+	Name           string
+	LocationString string
+	Raw            json.RawMessage
+}
+
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		baseURL:    strings.TrimSuffix(baseURL, "/"),
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: requestTimeout},
+	}
+}
+
+// Fetch returns every record of the given kind for the given year.
+func (c *Client) Fetch(ctx context.Context, kind Kind, year int32) ([]Record, error) {
+	u := fmt.Sprintf("%v/api/%v?%v", c.baseURL, kind,
+		url.Values{"year": {strconv.FormatInt(int64(year), 10)}}.Encode())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("[NewRequestWithContext]: %w", err)
+	}
+	req.Header.Set("X-API-Key", c.apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("[Do]: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return nil, fmt.Errorf("[ReadAll]: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("burning man API returned %v: %v",
+			resp.Status, summarize(body))
+	}
+
+	var raws []json.RawMessage
+	err = json.Unmarshal(body, &raws)
+	if err != nil {
+		return nil, fmt.Errorf("[Unmarshal]: burning man API returned "+
+			"something other than a JSON array (%v): %w", summarize(body), err)
+	}
+
+	records := make([]Record, 0, len(raws))
+	for _, raw := range raws {
+		var fields struct {
+			Name           string `json:"name"`
+			LocationString string `json:"location_string"`
+		}
+		err = json.Unmarshal(raw, &fields)
+		if err != nil {
+			return nil, fmt.Errorf("[Unmarshal]: %w", err)
+		}
+		records = append(records, Record{
+			Name:           fields.Name,
+			LocationString: fields.LocationString,
+			Raw:            raw,
+		})
+	}
+	return records, nil
+}
+
+// ParseKind maps an IMS place type onto the API resource that provides it.
+func ParseKind(placeType string) (Kind, error) {
+	switch Kind(placeType) {
+	case KindArt, KindCamp, KindMV:
+		return Kind(placeType), nil
+	default:
+		return "", errors.New("no Burning Man API data for place type " + placeType)
+	}
+}
+
+// summarize trims a response body down to something safe to put in an error.
+func summarize(body []byte) string {
+	const limit = 200
+	s := strings.TrimSpace(string(body))
+	if len(s) > limit {
+		s = s[:limit] + "…"
+	}
+	return s
+}

--- a/lib/bmapi/bmapi_test.go
+++ b/lib/bmapi/bmapi_test.go
@@ -1,0 +1,193 @@
+//
+// See the file COPYRIGHT for copyright information.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package bmapi_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/burningmantech/ranger-ims-go/lib/bmapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFetchCamps(t *testing.T) {
+	t.Parallel()
+
+	var gotPath, gotQuery, gotAPIKey string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		gotQuery = req.URL.RawQuery
+		gotAPIKey = req.Header.Get("X-API-Key")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[
+			{"uid": "a1", "name": "Camp Fun Times", "location_string": "4:15 & E", "year": 2025},
+			{"uid": "a2", "name": "Camp Quiet", "location_string": null, "year": 2025}
+		]`))
+	}))
+	defer server.Close()
+
+	records, err := bmapi.NewClient(server.URL, "secret-key").
+		Fetch(t.Context(), bmapi.KindCamp, 2025)
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/camp", gotPath)
+	assert.Equal(t, "year=2025", gotQuery)
+	assert.Equal(t, "secret-key", gotAPIKey)
+
+	require.Len(t, records, 2)
+	assert.Equal(t, "Camp Fun Times", records[0].Name)
+	assert.Equal(t, "4:15 & E", records[0].LocationString)
+	// A null location_string is just an empty one, not an error.
+	assert.Equal(t, "Camp Quiet", records[1].Name)
+	assert.Empty(t, records[1].LocationString)
+
+	// The whole object comes back untouched, since that's what IMS stores as a
+	// Place's external data.
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(records[0].Raw, &raw))
+	assert.Equal(t, map[string]any{
+		"uid": "a1", "name": "Camp Fun Times", "location_string": "4:15 & E", "year": float64(2025),
+	}, raw)
+}
+
+func TestFetchArtAndMV(t *testing.T) {
+	t.Parallel()
+
+	var gotPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotPaths = append(gotPaths, req.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[{"uid": "a1", "name": "Something"}]`))
+	}))
+	defer server.Close()
+
+	client := bmapi.NewClient(server.URL, "secret-key")
+
+	_, err := client.Fetch(t.Context(), bmapi.KindArt, 2025)
+	require.NoError(t, err)
+	// Mutant vehicles have no location of their own.
+	mvs, err := client.Fetch(t.Context(), bmapi.KindMV, 2026)
+	require.NoError(t, err)
+	require.Len(t, mvs, 1)
+	assert.Empty(t, mvs[0].LocationString)
+
+	assert.Equal(t, []string{"/api/art", "/api/mv"}, gotPaths)
+}
+
+func TestFetchEmptyYear(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	// A year the API has nothing for isn't an error here. Deciding what to do
+	// about that is the caller's business.
+	records, err := bmapi.NewClient(server.URL, "secret-key").
+		Fetch(t.Context(), bmapi.KindCamp, 1999)
+	require.NoError(t, err)
+	assert.Empty(t, records)
+}
+
+func TestFetchErrorStatus(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = w.Write([]byte(`{"detail": "year must be greater than 2025"}`))
+	}))
+	defer server.Close()
+
+	_, err := bmapi.NewClient(server.URL, "secret-key").
+		Fetch(t.Context(), bmapi.KindMV, 2020)
+	require.Error(t, err)
+	// The upstream complaint is the useful part of the message.
+	assert.Contains(t, err.Error(), "422")
+	assert.Contains(t, err.Error(), "year must be greater than 2025")
+}
+
+func TestFetchNotAnArray(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html>who knows</html>`))
+	}))
+	defer server.Close()
+
+	_, err := bmapi.NewClient(server.URL, "secret-key").
+		Fetch(t.Context(), bmapi.KindCamp, 2025)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "other than a JSON array")
+}
+
+func TestFetchUnreachable(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	serverURL := server.URL
+	server.Close()
+
+	_, err := bmapi.NewClient(serverURL, "secret-key").
+		Fetch(t.Context(), bmapi.KindCamp, 2025)
+	require.Error(t, err)
+}
+
+func TestParseKind(t *testing.T) {
+	t.Parallel()
+
+	kind, err := bmapi.ParseKind("camp")
+	require.NoError(t, err)
+	assert.Equal(t, bmapi.KindCamp, kind)
+
+	kind, err = bmapi.ParseKind("art")
+	require.NoError(t, err)
+	assert.Equal(t, bmapi.KindArt, kind)
+
+	kind, err = bmapi.ParseKind("mv")
+	require.NoError(t, err)
+	assert.Equal(t, bmapi.KindMV, kind)
+
+	// "Other" places are hand-written in IMS, with no upstream API.
+	_, err = bmapi.ParseKind("other")
+	require.Error(t, err)
+
+	_, err = bmapi.ParseKind("")
+	require.Error(t, err)
+}
+
+func TestTrailingSlashInBaseURL(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		gotPath = req.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	defer server.Close()
+
+	_, err := bmapi.NewClient(server.URL+"/", "secret-key").
+		Fetch(t.Context(), bmapi.KindCamp, 2025)
+	require.NoError(t, err)
+	assert.Equal(t, "/api/camp", gotPath)
+}

--- a/web/template/adminplaces.templ
+++ b/web/template/adminplaces.templ
@@ -42,21 +42,21 @@ templ AdminPlaces(deployment, versionName, versionRef string) {
     <label id="art-data-label" for="art-data" class="form-label">Art JSON Data</label>
     <textarea id="art-data" type="text" class="form-control font-monospace" aria-describedby="art-help" rows="12"></textarea>
     <div id="art-help" class="form-text">Paste in the full API response from the Burning Man v2 art endpoint.</div>
-    <button id="art-save" type="button" class="btn btn-primary mt-2">Save art data</button>
+    @placeButtons("art", "Save art data", "Set art from API")
   </div>
   <h2 class="h5">Camp data</h2>
     <div class="mb-3">
       <label id="camp-data-label" for="camp-data" class="form-label">Camp JSON Data</label>
       <textarea id="camp-data" type="text" class="form-control font-monospace" aria-describedby="camp-help" rows="12"></textarea>
       <div id="camp-help" class="form-text">Paste in the full API response from the Burning Man v2 camp endpoint.</div>
-      <button id="camp-save" type="button" class="btn btn-primary mt-2">Save camp data</button>
+      @placeButtons("camp", "Save camp data", "Set camps from API")
     </div>
   <h2 class="h5">Mutant vehicle data</h2>
     <div class="mb-3">
       <label id="mv-data-label" for="mv-data" class="form-label">Mutant vehicle JSON Data</label>
       <textarea id="mv-data" type="text" class="form-control font-monospace" aria-describedby="mv-help" rows="12"></textarea>
       <div id="mv-help" class="form-text">Paste in the full API response from the Burning Man v2 mv endpoint.</div>
-      <button id="mv-save" type="button" class="btn btn-primary mt-2">Save mutant vehicle data</button>
+      @placeButtons("mv", "Save mutant vehicle data", "Set mutant vehicles from API")
     </div>
   <h2 class="h5">Other data</h2>
     <div class="mb-3">
@@ -73,4 +73,31 @@ templ AdminPlaces(deployment, versionName, versionRef string) {
 </div>
 </body>
 </html>
+}
+
+// placeButtons renders one place section's Save button next to the controls for
+// pulling that place type straight from the Burning Man API. The year is its own
+// input because an IMS event isn't necessarily named for the year whose data it
+// wants. "Other" places have no upstream API, so they don't get this.
+templ placeButtons(placeType, saveText, importText string) {
+<div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+  <button id={ placeType + "-save" } type="button" class="btn btn-primary">{ saveText }</button>
+  // The title lives on the wrapper because a disabled button doesn't fire the
+  // events a tooltip needs.
+  <span id={ placeType + "-api-wrapper" } class="d-inline-flex align-items-center gap-2 ms-auto">
+    <label for={ placeType + "-api-year" } class="form-label mb-0">Year</label>
+    <input
+      id={ placeType + "-api-year" }
+      type="number"
+      class="form-control"
+      style="width: 7em;"
+      inputmode="numeric"
+      min="2000"
+      max="2100"
+      step="1"
+    />
+    <button id={ placeType + "-api-import" } type="button" class="btn btn-secondary">{ importText }</button>
+  </span>
+</div>
+<div id={ placeType + "-api-status" } class="form-text"></div>
 }

--- a/web/typescript/admin_places.ts
+++ b/web/typescript/admin_places.ts
@@ -40,10 +40,42 @@ interface PlaceField {
     dataEl: HTMLTextAreaElement;
     labelEl: HTMLLabelElement;
     saveEl: HTMLButtonElement;
+    // Present for the place types the Burning Man API can provide, i.e. all but
+    // "other".
+    apiImport?: PlaceImport;
     // Converts the pasted external data (e.g. a Burning Man API response) into
     // the Places the IMS API takes.
     parse: (value: string) => ims.Place[];
 }
+
+// The controls for having the server fetch a place type straight from the
+// Burning Man API, rather than an admin pasting the response in by hand.
+interface PlaceImport {
+    // Plural, lowercase, for use in messages, e.g. "camps".
+    noun: string;
+    wrapperEl: HTMLElement;
+    yearEl: HTMLInputElement;
+    buttonEl: HTMLButtonElement;
+    statusEl: HTMLElement;
+}
+
+function placeImport(placeType: ims.PlaceType, noun: string): PlaceImport {
+    return {
+        noun: noun,
+        wrapperEl: ims.typedElement(`${placeType}-api-wrapper`, HTMLElement),
+        yearEl: ims.typedElement(`${placeType}-api-year`, HTMLInputElement),
+        buttonEl: ims.typedElement(`${placeType}-api-import`, HTMLButtonElement),
+        statusEl: ims.typedElement(`${placeType}-api-status`, HTMLElement),
+    };
+}
+
+// Whether this server has a Burning Man API key. Without one, the "Set from
+// API" buttons stay disabled.
+let placesImportAllowed: boolean = false;
+
+// How many places of each type the server last told us it had, used to say what
+// an import is about to destroy.
+const loadedCounts = new Map<ims.PlaceType, number>();
 
 const fields: PlaceField[] = [
     {
@@ -52,6 +84,7 @@ const fields: PlaceField[] = [
         dataEl: ims.typedElement("art-data", HTMLTextAreaElement),
         labelEl: ims.typedElement("art-data-label", HTMLLabelElement),
         saveEl: ims.typedElement("art-save", HTMLButtonElement),
+        apiImport: placeImport("art", "art"),
         parse: (value: string): ims.Place[] =>
             (JSON.parse(value) as ims.BMArt[]).map((ed: ims.BMArt): ims.Place => ({
                 name: ed.name,
@@ -65,6 +98,7 @@ const fields: PlaceField[] = [
         dataEl: ims.typedElement("camp-data", HTMLTextAreaElement),
         labelEl: ims.typedElement("camp-data-label", HTMLLabelElement),
         saveEl: ims.typedElement("camp-save", HTMLButtonElement),
+        apiImport: placeImport("camp", "camps"),
         parse: (value: string): ims.Place[] =>
             (JSON.parse(value) as ims.BMCamp[]).map((ed: ims.BMCamp): ims.Place => ({
                 name: ed.name,
@@ -78,6 +112,7 @@ const fields: PlaceField[] = [
         dataEl: ims.typedElement("mv-data", HTMLTextAreaElement),
         labelEl: ims.typedElement("mv-data-label", HTMLLabelElement),
         saveEl: ims.typedElement("mv-save", HTMLButtonElement),
+        apiImport: placeImport("mv", "mutant vehicles"),
         parse: (value: string): ims.Place[] =>
             (JSON.parse(value) as ims.BMMV[]).map((ed: ims.BMMV): ims.Place => ({
                 name: ed.name,
@@ -108,11 +143,24 @@ async function initAdminPlacesPage(): Promise<void> {
         return;
     }
     window.loadPlaces = loadPlaces;
+    placesImportAllowed = initResult.authInfo.places_import_allowed??false;
     for (const field of fields) {
         field.saveEl.addEventListener("click", async (): Promise<void> => {
             await save(field);
         });
+        const apiImport: PlaceImport|undefined = field.apiImport;
+        if (!apiImport) {
+            continue;
+        }
+        apiImport.buttonEl.disabled = !placesImportAllowed;
+        apiImport.wrapperEl.title = placesImportAllowed
+            ? `Replace this event's ${apiImport.noun} with the Burning Man API's data for this year`
+            : "This IMS server has no Burning Man API key configured";
+        apiImport.buttonEl.addEventListener("click", async (): Promise<void> => {
+            await importFromAPI(field);
+        });
     }
+    setYearInputs(el.eventName.value);
     drawEventNames(await initResult.eventDatas);
 
     // An "event_id" query param (which holds an event name, as elsewhere in IMS)
@@ -198,10 +246,86 @@ async function loadPlaces(): Promise<void> {
     ims.clearErrorMessage();
     const eventName = el.eventName.value;
     setEventURLParam(eventName);
+    setYearInputs(eventName);
+    for (const field of fields) {
+        if (field.apiImport) {
+            field.apiImport.statusEl.textContent = "";
+        }
+    }
     if (!eventName) {
         return;
     }
     await fetchPlaces(fields);
+}
+
+// The Burning Man API year isn't necessarily the IMS event name, but it usually
+// is, so start from any four-digit year in the event name and fall back to the
+// current year. The admin can always type something else.
+function setYearInputs(eventName: string): void {
+    const fromName: RegExpMatchArray|null = eventName.match(/(?:^|\D)(\d{4})(?:\D|$)/);
+    const year: string = fromName?.[1] ?? new Date().getFullYear().toString();
+    for (const field of fields) {
+        if (field.apiImport) {
+            field.apiImport.yearEl.value = year;
+        }
+    }
+}
+
+// Has the server fetch this place type from the Burning Man API and store the
+// result, replacing whatever the event had. The server does the fetching, since
+// that's where the API key lives.
+async function importFromAPI(field: PlaceField): Promise<void> {
+    const apiImport: PlaceImport|undefined = field.apiImport;
+    if (!apiImport || !placesImportAllowed) {
+        return;
+    }
+    ims.clearErrorMessage();
+    apiImport.statusEl.textContent = "";
+    const eventName = el.eventName.value;
+    if (!eventName) {
+        ims.setErrorMessage("Select an event before setting places from the API.");
+        return;
+    }
+    const year: number|null = ims.parseInt10(apiImport.yearEl.value);
+    if (year == null) {
+        ims.setErrorMessage(`Enter the year to fetch ${apiImport.noun} from the API.`);
+        ims.controlHasError(apiImport.yearEl);
+        return;
+    }
+    const existing: number|undefined = loadedCounts.get(field.placeType);
+    const doomed: string = existing == null
+        ? `all ${apiImport.noun} currently stored`
+        : `the ${existing} ${apiImport.noun} currently stored`;
+    if (!confirm(
+        `Set ${apiImport.noun} for event "${eventName}" from the Burning Man API's ${year} data?\n\n` +
+        `This will delete ${doomed} for this event. This cannot be undone.`)) {
+        return;
+    }
+
+    const params: URLSearchParams = new URLSearchParams({
+        place_type: field.placeType,
+        year: year.toString(),
+    });
+    apiImport.buttonEl.disabled = true;
+    apiImport.statusEl.textContent = `Fetching ${apiImport.noun} for ${year}…`;
+    const {json, err} = await ims.fetchNoThrow<ims.ImportPlacesResponse>(
+        `${url_placesImport.replace("<event_id>", eventName)}?${params.toString()}`, {
+            method: "POST",
+        });
+    apiImport.buttonEl.disabled = false;
+    if (err != null || json == null) {
+        apiImport.statusEl.textContent = "";
+        const message = `Failed to set ${apiImport.noun} from the API: ${err}`;
+        console.error(message);
+        ims.setErrorMessage(message);
+        ims.controlHasError(field.dataEl);
+        return;
+    }
+    apiImport.statusEl.textContent =
+        `Saved ${json.count} ${apiImport.noun} from the ${year} Burning Man API data.`;
+    ims.controlHasSuccess(field.dataEl);
+    ims.announce(apiImport.statusEl.textContent);
+    await fetchPlaces([field]);
 }
 
 // Fetches the selected event's places and redraws the given fields from the
@@ -225,5 +349,6 @@ async function fetchPlaces(toDraw: PlaceField[]): Promise<void> {
         );
         field.dataEl.value = JSON.stringify(externalDatas, null, 2);
         field.labelEl.textContent = `${field.labelText} (${externalDatas.length})`;
+        loadedCounts.set(field.placeType, externalDatas.length);
     }
 }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -2148,6 +2148,12 @@ export type Place = {
 
 export type Places = Partial<Record<PlaceType, Place[]|null|undefined>>;
 
+// The response from the places import endpoint, which pulls a place type from
+// the Burning Man API server-side.
+export type ImportPlacesResponse = {
+    count: number;
+}
+
 export type BMArt = {
     name: string;
     location_string: string|null;
@@ -2250,6 +2256,9 @@ export type AuthenticatedAuthInfo = {
     event_access?: Record<string, AuthInfoEventAccess>,
     // Whether this server permits deleting events (an admin-only, config-gated feature).
     event_deletion_allowed?: boolean,
+    // Whether this server has a Burning Man API key, and so can pull an event's
+    // places from that API.
+    places_import_allowed?: boolean,
 }
 
 export type AuthInfo = UnauthenticatedAuthInfo | AuthenticatedAuthInfo;

--- a/web/typescript/urls.ts
+++ b/web/typescript/urls.ts
@@ -65,6 +65,7 @@ const url_visitAttachments = "/ims/api/events/<event_id>/visits/<visit_number>/a
 const url_visitAttachmentNumber = "/ims/api/events/<event_id>/visits/<visit_number>/attachments/<attachment_number>";
 const url_visitRanger = "/ims/api/events/<event_id>/visits/<visit_number>/rangers/<ranger_name>";
 const url_places = "/ims/api/events/<event_id>/places";
+const url_placesImport = "/ims/api/events/<event_id>/places/import";
 const url_eventSource = "/ims/api/eventsource";
 const url_debugBuildInfo = "/ims/api/debug/buildinfo";
 const url_debugRuntimeMetrics = "/ims/api/debug/runtimemetrics";

--- a/web/typescripttest/admin_places.test.ts
+++ b/web/typescripttest/admin_places.test.ts
@@ -23,9 +23,14 @@ import type * as ims from "../typescript/ims.ts";
 import { jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
 
 const placesUrl = url_places.replace("<event_id>", "2025");
+const importUrl = url_placesImport.replace("<event_id>", "2025");
 const adminPlacesPath = "/ims/app/admin/places";
 
 let serverEvents: ims.EventData[];
+let serverAuth: ims.AuthInfo;
+// Requests to the places import endpoint, which carries its arguments in the
+// query string rather than a body.
+let importHandler: (url: string) => Response | undefined;
 
 beforeEach((): void => {
     vi.resetModules();
@@ -37,15 +42,20 @@ beforeEach((): void => {
         { id: 2, name: "2024" },
         { id: 3, name: "Group", is_group: true },
     ];
+    serverAuth = { authenticated: true, user: "Tester", admin: true, places_import_allowed: true };
+    importHandler = (): Response | undefined => jsonResponse({ count: 0 });
 });
 
 async function initAdminPlacesPage(placesHandler: (init?: RequestInit) => Response | undefined = () => undefined) {
     const mock = mockFetch((url, init) => {
         if (url === url_auth && init?.body == null) {
-            return jsonResponse({ authenticated: true, user: "Tester", admin: true });
+            return jsonResponse(serverAuth);
         }
         if (url === url_events && init?.body == null) {
             return jsonResponse(serverEvents);
+        }
+        if (url.startsWith(importUrl)) {
+            return importHandler(url);
         }
         if (url === placesUrl) {
             return placesHandler(init);
@@ -296,6 +306,193 @@ test("an event_id for an event the user can't see errors out and loads nothing",
     // The select falls back to the placeholder rather than showing nothing at all.
     expect((await eventSelect()).value).toBe("");
     expect(mock.mock.calls.some(([url]) => url === url_places.replace("<event_id>", "1999"))).toBe(false);
+});
+
+// The "Set from API" buttons have the server pull a place type straight from
+// the Burning Man API, for a year the admin gives separately (an IMS event
+// isn't necessarily named for the year whose data it wants).
+
+function importButton(placeType: string): HTMLButtonElement {
+    return document.getElementById(`${placeType}-api-import`) as HTMLButtonElement;
+}
+
+function yearInput(placeType: string): HTMLInputElement {
+    return document.getElementById(`${placeType}-api-year`) as HTMLInputElement;
+}
+
+function importUrls(mock: ReturnType<typeof mockFetch>): string[] {
+    return mock.mock.calls.map(([url]) => url).filter(url => url.startsWith(importUrl));
+}
+
+test("the import buttons are disabled when the server has no Burning Man API key", async (): Promise<void> => {
+    serverAuth = { authenticated: true, user: "Tester", admin: true, places_import_allowed: false };
+    const mock = await initAdminPlacesPage(() => jsonResponse({ art: [], camp: [], mv: [], other: [] }));
+
+    await vi.waitFor((): void => {
+        expect(importButton("camp").disabled).toBe(true);
+    });
+    // The explanation goes on the wrapper, since a disabled button doesn't fire
+    // the events a tooltip needs.
+    expect(document.getElementById("camp-api-wrapper")!.title).toContain("no Burning Man API key");
+
+    (await eventSelect()).value = "2025";
+    vi.stubGlobal("confirm", vi.fn((): boolean => true));
+    importButton("camp").click();
+
+    expect(importUrls(mock)).toEqual([]);
+});
+
+test("only art, camp, and mv have import controls; other does not", async (): Promise<void> => {
+    await initAdminPlacesPage();
+
+    await vi.waitFor((): void => {
+        expect(importButton("camp").disabled).toBe(false);
+    });
+    expect(importButton("art")).not.toBeNull();
+    expect(importButton("mv")).not.toBeNull();
+    // "Other" places are hand-written, with no upstream API to pull from.
+    expect(importButton("other")).toBeNull();
+    expect(yearInput("other")).toBeNull();
+});
+
+test("the year inputs are prefilled from the selected event name", async (): Promise<void> => {
+    await initAdminPlacesPage(() => jsonResponse({ art: [], camp: [], mv: [], other: [] }));
+
+    (await eventSelect()).value = "2024";
+    await window.loadPlaces();
+
+    expect(yearInput("camp").value).toBe("2024");
+    expect(yearInput("art").value).toBe("2024");
+    expect(yearInput("mv").value).toBe("2024");
+});
+
+test("an event name with no year in it prefills the current year", async (): Promise<void> => {
+    serverEvents = [{ id: 1, name: "Training" }];
+    await initAdminPlacesPage(() => jsonResponse({ art: [], camp: [], mv: [], other: [] }));
+
+    (await eventSelect()).value = "Training";
+    await window.loadPlaces();
+
+    expect(yearInput("camp").value).toBe(new Date().getFullYear().toString());
+});
+
+test("importing camps posts the place type and year, then reloads just that field", async (): Promise<void> => {
+    importHandler = (): Response => jsonResponse({ count: 2 });
+    const mock = await initAdminPlacesPage(() => jsonResponse({
+        art: [],
+        camp: [
+            { name: "Camp A", location_string: "3:00", external_data: { name: "Camp A", location_string: "3:00" } },
+            { name: "Camp B", location_string: "4:00", external_data: { name: "Camp B", location_string: "4:00" } },
+        ],
+        mv: [],
+        other: [],
+    }));
+
+    (await eventSelect()).value = "2025";
+    await window.loadPlaces();
+    // An unsaved edit in another field must survive the camp import.
+    field("art-data").value = "pending edit";
+    yearInput("camp").value = "2019";
+    vi.stubGlobal("confirm", vi.fn((): boolean => true));
+
+    importButton("camp").click();
+
+    await vi.waitFor((): void => {
+        expect(importUrls(mock)).toHaveLength(1);
+    });
+    const params = new URLSearchParams(importUrls(mock)[0]!.split("?")[1]);
+    expect(params.get("place_type")).toBe("camp");
+    // The year the admin typed, not the event name.
+    expect(params.get("year")).toBe("2019");
+
+    await vi.waitFor((): void => {
+        expect(JSON.parse(field("camp-data").value)).toHaveLength(2);
+    });
+    expect(document.getElementById("camp-data-label")!.textContent).toBe("Camp JSON Data (2)");
+    // The count comes from the server's response, not from the textarea.
+    expect(document.getElementById("camp-api-status")!.textContent).toContain("Saved 2 camps");
+    expect(field("camp-data").classList.contains("is-valid")).toBe(true);
+    expect(field("art-data").value).toBe("pending edit");
+});
+
+test("the import confirmation names what it's about to delete, and declining sends nothing", async (): Promise<void> => {
+    const mock = await initAdminPlacesPage(() => jsonResponse({
+        art: [],
+        camp: [{ name: "Camp A", location_string: "3:00", external_data: { name: "Camp A" } }],
+        mv: [],
+        other: [],
+    }));
+
+    (await eventSelect()).value = "2025";
+    await window.loadPlaces();
+    const confirmMock = vi.fn((_message: string): boolean => false);
+    vi.stubGlobal("confirm", confirmMock);
+
+    importButton("camp").click();
+
+    await vi.waitFor((): void => {
+        expect(confirmMock).toHaveBeenCalledTimes(1);
+    });
+    const prompt: string = confirmMock.mock.calls[0]![0];
+    expect(prompt).toContain("2025");
+    // The count the page last loaded, so the admin knows the size of the loss.
+    expect(prompt).toContain("delete the 1 camps");
+    expect(importUrls(mock)).toEqual([]);
+});
+
+test("importing with no event selected surfaces an error and sends nothing", async (): Promise<void> => {
+    const mock = await initAdminPlacesPage();
+    await eventSelect();
+    vi.stubGlobal("confirm", vi.fn((): boolean => true));
+
+    importButton("camp").click();
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
+    });
+    expect(document.getElementById("error_text")!.textContent).toContain("Select an event");
+    expect(importUrls(mock)).toEqual([]);
+});
+
+test("importing with an empty year surfaces an error and sends nothing", async (): Promise<void> => {
+    const mock = await initAdminPlacesPage(() => jsonResponse({ art: [], camp: [], mv: [], other: [] }));
+
+    (await eventSelect()).value = "2025";
+    await window.loadPlaces();
+    yearInput("camp").value = "";
+    vi.stubGlobal("confirm", vi.fn((): boolean => true));
+
+    importButton("camp").click();
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
+    });
+    expect(document.getElementById("error_text")!.textContent).toContain("year");
+    expect(yearInput("camp").classList.contains("is-invalid")).toBe(true);
+    expect(importUrls(mock)).toEqual([]);
+});
+
+test("a failed import surfaces the server's message and re-enables the button", async (): Promise<void> => {
+    importHandler = (): Response => new Response(
+        JSON.stringify({ detail: "The Burning Man API has no camp data for 1999. Nothing was changed." }),
+        { status: 502, headers: { "content-type": "application/problem+json" } },
+    );
+    await initAdminPlacesPage(() => jsonResponse({ art: [], camp: [], mv: [], other: [] }));
+
+    (await eventSelect()).value = "2025";
+    await window.loadPlaces();
+    yearInput("camp").value = "1999";
+    vi.stubGlobal("confirm", vi.fn((): boolean => true));
+
+    importButton("camp").click();
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
+    });
+    expect(document.getElementById("error_text")!.textContent).toContain("no camp data for 1999");
+    expect(document.getElementById("camp-api-status")!.textContent).toBe("");
+    // The admin can fix the year and try again.
+    expect(importButton("camp").disabled).toBe(false);
 });
 
 test("selecting an event writes the event_id query param", async (): Promise<void> => {


### PR DESCRIPTION
This lets us load the camp/art/mv data directly from BM API into IMS, without needing to run a manual `curl` with the API key. This will be much easier on playa than trying to curl and copy JSON chunks.