### PR TITLE
fix(places): make a place's detail modal linkable by URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ https://github.com/burningmantech/ranger-ims-go/commit/f5409ac
 - Added server-side error logging, surfaced on a new Error Logs admin page. This makes it much easier to spot problems during the event. https://github.com/burningmantech/ranger-ims-go/pull/737
 - Added "Set from API" buttons to the Admin Places page for camps, art, and mutant vehicles, so that an admin can have the server pull that data from the Burning Man API for a given year rather than pasting the response in by hand. This needs a Burning Man API key in the server's config (`IMS_BM_API_KEY`); without one, the buttons stay disabled.
 - Added normalization of Black Rock City addresses, so that an Incident location or a Sanctuary Visit guest camp address typed as "7+e" is saved as "7:00 & E". It's opt-in per event, toggled from the Admin Events page, so it can be turned on or off without a server restart. https://github.com/burningmantech/ranger-ims-go/pull/736
+- Made a Place's detail popup on the Places page linkable: opening one adds a short code for that Place to the page's URL, and following such a link opens the same Place's popup straight away. The code is derived from the Place's Burning Man ID (or from its name and type, for a Place that has no such ID), so a link keeps working across the wholesale deletion and reimport of an event's places.
 
 ### Fixed
 
@@ -89,7 +90,6 @@ https://github.com/burningmantech/ranger-ims-go/commit/f5409ac
 ### Added
 
 - Showed an "uploading" indicator while a file attachment is in progress. https://github.com/burningmantech/ranger-ims-go/pull/661
-
 - Added a "not before" access mode and renamed the old "expired" concept to "not after". Together these let admins specify both when an event permission becomes active and when it lapses. https://github.com/burningmantech/ranger-ims-go/pull/648
 - Started using flatpickr for selecting the "not before" and "not after" permission times. https://github.com/burningmantech/ranger-ims-go/pull/649
 - Added an optional map link for each event, which surfaces as a "Map" link (e.g. on the Incident page) pointing to the official PDF map of public camps. https://github.com/burningmantech/ranger-ims-go/pull/652 https://github.com/burningmantech/ranger-ims-go/pull/653

--- a/web/typescript/places.ts
+++ b/web/typescript/places.ts
@@ -36,6 +36,12 @@ const destDefaultRows = "25";
 let _destShowType: string|null = null;
 const destDefaultType = "all";
 
+// The key of the place whose modal is currently open (or which a shared link
+// asked for), as it appears in the URL fragment.
+let _destShowPlace: string|null = null;
+
+let placeInfoModal: ReturnType<typeof ims.bsModal>|null = null;
+
 //
 // Initialize UI
 //
@@ -164,6 +170,16 @@ function renderEmbargoNotice(events: ims.EventData[]|null, isAdmin: boolean): vo
 //
 
 function initPlacesTable() {
+    placeInfoModal = ims.bsModal(el.placeInfoModal);
+
+    // A shared link names the place to open. Read it before anything can rewrite
+    // the fragment, and drop it again once the reader closes the modal.
+    _destShowPlace = ims.windowFragmentParams().get("place");
+    el.placeInfoModal.addEventListener("hidden.bs.modal", function(): void {
+        _destShowPlace = null;
+        destReplaceWindowState();
+    });
+
     destInitDataTables();
     destInitTableButtons();
     destInitSearchField();
@@ -182,8 +198,6 @@ declare let DataTable: any;
 //
 
 function destInitDataTables() {
-    const placeInfoModal = ims.bsModal(el.placeInfoModal);
-
     DataTable.ext.errMode = "none";
     placesTable = new DataTable("#places_table", {
         // Save table state to SessionStorage (-1). This tells DataTables to save state
@@ -244,6 +258,7 @@ function destInitDataTables() {
                     places.push(other);
                 }
                 callback({data: places});
+                openLinkedPlace(places);
             }
             doAjax();
         },
@@ -277,15 +292,71 @@ function destInitDataTables() {
 
         "createdRow": function (row: HTMLElement, place: ims.Place, _index: number) {
             const openLink = function(_e: MouseEvent): void {
-                el.placeInfoModalLabel.textContent = place.name??"(unnamed place)";
-                el.placeBody.replaceChildren(placeToHTML(place));
-                placeInfoModal.toggle();
+                showPlace(place);
             }
             row.addEventListener("click", openLink);
             row.addEventListener("auxclick", openLink);
         },
     });
 }
+
+
+function showPlace(place: ims.Place): void {
+    el.placeInfoModalLabel.textContent = place.name??"(unnamed place)";
+    el.placeBody.replaceChildren(placeToHTML(place));
+    _destShowPlace = placeKey(place);
+    destReplaceWindowState();
+    placeInfoModal!.show();
+}
+
+
+// Open the place named by a shared link, once the table data has arrived.
+function openLinkedPlace(places: ims.Place[]): void {
+    if (_destShowPlace == null) {
+        return;
+    }
+    const place = places.find((p: ims.Place): boolean => placeKey(p) === _destShowPlace);
+    if (place == null) {
+        ims.setErrorMessage(
+            `The linked place isn't in Event "${ims.pathIds.eventName}" anymore.`
+        );
+        _destShowPlace = null;
+        destReplaceWindowState();
+        return;
+    }
+    showPlace(place);
+}
+
+
+// The URL-shareable name for a place. Our own Place IDs churn, since places get
+// deleted and reimported wholesale, so key off the Burning Man Salesforce UID
+// where there is one and off the type and name where there isn't. Both are too
+// long and too ugly to paste into a URL, so carry a hash of them instead: 8
+// base36 digits is ~41 bits, which leaves collisions well below one in 100,000
+// across an event's few thousand places.
+function placeKey(place: ims.Place): string {
+    const uid = (place.external_data as {uid?: string|null}|null)?.uid;
+    const identity = uid || `${place.type}/${(place.name??"").trim().toLowerCase()}`;
+    return hash53(identity).toString(36).padStart(11, "0").slice(-8);
+}
+
+
+// cyrb53, a small non-cryptographic 53-bit string hash. Deliberately not
+// crypto.subtle.digest, which is both async and unavailable outside secure
+// contexts, and we need neither property here.
+function hash53(str: string): number {
+    let h1 = 0xdeadbeef;
+    let h2 = 0x41c6ce57;
+    for (let i = 0; i < str.length; i++) {
+        const ch = str.charCodeAt(i);
+        h1 = Math.imul(h1 ^ ch, 2654435761);
+        h2 = Math.imul(h2 ^ ch, 1597334677);
+    }
+    h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507) ^ Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+    h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507) ^ Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+    return 4294967296 * (2097151 & h2) + (h1 >>> 0);
+}
+
 
 function placeToHTML(place: ims.Place): Node {
     function setImageDetails(imageDd: HTMLElement, imageURL?: string|null) {
@@ -587,6 +658,9 @@ function destReplaceWindowState(): void {
     }
     if (_destShowType != null && _destShowType !== destDefaultType) {
         newParams.push(["type", _destShowType]);
+    }
+    if (_destShowPlace != null) {
+        newParams.push(["place", _destShowPlace]);
     }
     const newURL = `${ims.urlReplace(url_viewPlaces)}#${new URLSearchParams(newParams).toString()}`;
     window.history.replaceState(null, "", newURL);

--- a/web/typescripttest/places.test.ts
+++ b/web/typescripttest/places.test.ts
@@ -235,6 +235,119 @@ test("clicking an 'other' place with missing details shows 'None provided' fallb
     expect(body.querySelector("#image_dd")!.textContent).toContain("None provided");
 });
 
+// The place key in the URL fragment, if any.
+function placeParam(): string|null {
+    return new URLSearchParams(window.location.hash.substring(1)).get("place");
+}
+
+test("opening a place puts a short, opaque key for it in the URL hash", async (): Promise<void> => {
+    await initPlacesPage();
+    const camp: ims.Place = {
+        name: "Camp Friendly", type: "camp",
+        external_data: { name: "Camp Friendly", uid: "a1XVI000009jNPY2A2" } as ims.BMCamp,
+    };
+    openPlace(camp);
+
+    const key = placeParam();
+    expect(key).toMatch(/^[0-9a-z]{8}$/);
+    // The key gives away neither the UID nor the name.
+    expect(camp.external_data!.name!.toLowerCase()).not.toContain(key!);
+    expect("a1XVI000009jNPY2A2".toLowerCase()).not.toContain(key!);
+});
+
+test("the place key follows the Salesforce UID, not our own row order or the name", async (): Promise<void> => {
+    await initPlacesPage();
+    openPlace({ name: "Camp Friendly", type: "camp", external_data: { uid: "sf-1" } as ims.BMCamp });
+    const first = placeParam();
+
+    // Same place, renamed and re-imported into a different table position.
+    openPlace({ name: "Camp Friendlier", type: "camp", external_data: { uid: "sf-1" } as ims.BMCamp });
+    expect(placeParam()).toBe(first);
+
+    // A different place with the same name is a different key.
+    openPlace({ name: "Camp Friendly", type: "camp", external_data: { uid: "sf-2" } as ims.BMCamp });
+    expect(placeParam()).not.toBe(first);
+});
+
+test("a place with no UID keys off its type and name", async (): Promise<void> => {
+    await initPlacesPage();
+    openPlace({ name: "First Camp", type: "other", external_data: { name: "First Camp" } as ims.OtherDest });
+    const first = placeParam();
+    expect(first).toMatch(/^[0-9a-z]{8}$/);
+
+    // Whitespace and case in the name don't change the key.
+    openPlace({ name: "  first camp ", type: "other", external_data: {} as ims.OtherDest });
+    expect(placeParam()).toBe(first);
+
+    // The same name under another type is a different place.
+    openPlace({ name: "First Camp", type: "camp", external_data: {} as ims.BMCamp });
+    expect(placeParam()).not.toBe(first);
+});
+
+test("closing the modal drops the place from the URL hash but keeps the other state", async (): Promise<void> => {
+    await initPlacesPage();
+    window.destShowType("camp", true);
+    openPlace({ name: "Camp Friendly", type: "camp", external_data: { uid: "sf-1" } as ims.BMCamp });
+    expect(placeParam()).not.toBeNull();
+
+    document.getElementById("placeInfoModal")!.dispatchEvent(new Event("hidden.bs.modal"));
+
+    expect(placeParam()).toBeNull();
+    expect(window.location.hash).toContain("type=camp");
+});
+
+// The keys the page derives for the two seeded places below. Pinned literally,
+// so that a change to the key encoding — which would break every link Rangers
+// have already shared — has to be a deliberate edit here.
+const campKey = "mwx4f1r0";  // uid "sf-camp"
+const otherKey = "in9dy0c5"; // no uid: type "other", name "First Camp"
+
+test("the derived key for a place is stable across releases", async (): Promise<void> => {
+    await initPlacesPage();
+
+    openPlace({ name: "Camp Friendly", type: "camp", external_data: { uid: "sf-camp" } as ims.BMCamp });
+    expect(placeParam()).toBe(campKey);
+
+    openPlace({ name: "First Camp", type: "other", external_data: {} as ims.OtherDest });
+    expect(placeParam()).toBe(otherKey);
+});
+
+test("a place fragment opens that place's modal on load", async (): Promise<void> => {
+    serverPlaces.camp![0]!.external_data = {
+        name: "Camp Friendly", description: "Friendly folks", uid: "sf-camp",
+    } as ims.BMCamp;
+    window.history.replaceState(null, "", `/ims/app/events/${eventName}/places#place=${campKey}`);
+    await initPlacesPage();
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("placeInfoModalLabel")!.textContent).toBe("Camp Friendly");
+    });
+    expect(document.getElementById("placeBody")!.querySelector("#description")!.textContent)
+        .toBe("Friendly folks");
+    // The link stays shareable after it's followed.
+    expect(placeParam()).toBe(campKey);
+});
+
+test("a place fragment resolves a place that has no Salesforce UID", async (): Promise<void> => {
+    window.history.replaceState(null, "", `/ims/app/events/${eventName}/places#place=${otherKey}`);
+    await initPlacesPage();
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("placeInfoModalLabel")!.textContent).toBe("First Camp");
+    });
+});
+
+test("a place fragment naming a place that's no longer there reports it and clears the link", async (): Promise<void> => {
+    window.history.replaceState(null, "", `/ims/app/events/${eventName}/places#place=deadbeef`);
+    await initPlacesPage();
+
+    await vi.waitFor((): void => {
+        expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
+    });
+    expect(document.getElementById("error_text")!.textContent).toContain("linked place");
+    expect(placeParam()).toBeNull();
+});
+
 test("destShowRows updates the dropdown label, page length, and URL hash", async (): Promise<void> => {
     await initPlacesPage();
 


### PR DESCRIPTION
The key in the URL is a short hash of the Burning Man Salesforce UID, or of the type and name where there is none, since our own Place IDs churn whenever an event's places are deleted and reimported.