### PR TITLE
fix: assorted correctness and robustness fixes

### DIFF
--- a/api/attachment.go
+++ b/api/attachment.go
@@ -427,8 +427,11 @@ func (action AttachToFieldReport) attachToFieldReport(req *http.Request) (int32,
 	if eventPermissions&(authz.EventWriteAllFieldReports|authz.EventWriteOwnFieldReports) == 0 {
 		return 0, herr.Forbidden("The requestor does not have permission to write Field Reports on this Event", nil)
 	}
-	// i.e. the user has EventReadOwnFieldReports, but not EventReadAllFieldReports
-	limitedAccess := eventPermissions&authz.EventReadAllFieldReports == 0
+	// i.e. the user has EventWriteOwnFieldReports, but not EventWriteAllFieldReports.
+	// This gates on the write permission, not the read one: attaching a file adds
+	// a Report Entry, so it's an edit, and it has to be held to what
+	// EditFieldReport allows.
+	limitedAccess := eventPermissions&authz.EventWriteAllFieldReports == 0
 	ctx := req.Context()
 
 	fieldReportNumber, err := conv.ParseInt32(req.PathValue("fieldReportNumber"))
@@ -442,7 +445,7 @@ func (action AttachToFieldReport) attachToFieldReport(req *http.Request) (int32,
 	}
 	if limitedAccess {
 		if !containsAuthor(entries, jwtCtx.Claims.RangerHandle()) {
-			return 0, herr.Forbidden("The requestor does not have permission to read this particular Field Report", nil)
+			return 0, herr.Forbidden("The requestor does not have permission to edit this particular Field Report", nil)
 		}
 	}
 

--- a/api/integration/attachment_test.go
+++ b/api/integration/attachment_test.go
@@ -70,6 +70,56 @@ func newEventWithReporter(t *testing.T, admin ApiHelper) (eventName string) {
 	return eventName
 }
 
+// newEventWithReporterAndReader creates a fresh Event on which Alice is both a
+// Reporter and a Reader, and the admin is a Writer. That combination — may read
+// every Field Report, may write only her own — is what a Ranger ends up with
+// from a blanket "report" rule plus a "read" rule for their position, and it's
+// the case that tells a handler gating on EventWriteAllFieldReports apart from
+// one wrongly gating on EventReadAllFieldReports.
+func newEventWithReporterAndReader(t *testing.T, admin ApiHelper) (eventName string) {
+	t.Helper()
+	ctx := t.Context()
+	eventName = rand.NonCryptoText()
+	_, resp := admin.createEvent(ctx, imsjson.Event{Name: &eventName})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	alice := []imsjson.AccessRule{{Expression: "person:" + userAliceHandle, Validity: "always"}}
+	resp = admin.editAccess(ctx, imsjson.EventsAccess{
+		eventName: imsjson.EventAccess{
+			Readers:   alice,
+			Reporters: alice,
+			Writers:   []imsjson.AccessRule{{Expression: "person:" + userAdminHandle, Validity: "always"}},
+		},
+	})
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+	return eventName
+}
+
+// Attaching a file adds a Report Entry, so it's an edit, and it has to be held
+// to the write permission. A Ranger who may read every Field Report but write
+// only her own must not be able to attach to someone else's.
+func TestAttachToFieldReportDeniedForReaderWhoMayOnlyWriteOwn(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apisAlice := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+
+	eventName := newEventWithReporterAndReader(t, apisAdmin)
+	num := apisAdmin.newFieldReportSuccess(ctx, sampleFieldReport1(eventName))
+
+	_, resp := apisAlice.attachFileToFieldReport(ctx, eventName, num, []byte("Alice was here"))
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+
+	// Alice can read that same Field Report, which is what makes the 403 above
+	// about the write permission rather than the read one.
+	_, resp = apisAlice.getFieldReport(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 // A Reporter may only read Field Reports they authored. Reading an attachment on
 // someone else's Field Report must be refused, even though the Reporter can read
 // Field Reports on this Event in general.

--- a/api/integration/reportentry_test.go
+++ b/api/integration/reportentry_test.go
@@ -228,3 +228,65 @@ func TestEditVisitReportEntry(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, resp.StatusCode)
 	require.NoError(t, resp.Body.Close())
 }
+
+// Striking a Report Entry edits the Field Report it belongs to, so a Reporter,
+// who may only write their own, must not be able to strike an entry on someone
+// else's — not even one they can't read.
+func TestStrikeFieldReportEntryDeniedForNonAuthoringReporter(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apisAlice := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+
+	eventName := newEventWithReporter(t, apisAdmin)
+
+	// The admin authors the Field Report, so Alice authored nothing on it.
+	num := apisAdmin.newFieldReportSuccess(ctx, sampleFieldReport1(eventName))
+	fieldReport, resp := apisAdmin.getFieldReport(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.NotEmpty(t, fieldReport.ReportEntries)
+
+	entry := fieldReport.ReportEntries[0]
+	entry.Stricken = new(true)
+	resp = apisAlice.updateFieldReportReportEntry(ctx, eventName, num, entry)
+	require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	// The entry is untouched, confirming the 403 landed before the write.
+	fieldReport, resp = apisAdmin.getFieldReport(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.False(t, *fieldReport.ReportEntries[0].Stricken)
+
+	// The admin, who may write all Field Reports, can strike it.
+	resp = apisAdmin.updateFieldReportReportEntry(ctx, eventName, num, entry)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+}
+
+// A Reporter striking an entry on their *own* Field Report is allowed. This is
+// the other side of the authorship check above.
+func TestStrikeFieldReportEntryAllowedForAuthoringReporter(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apisAlice := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+
+	eventName := newEventWithReporter(t, apisAdmin)
+	num := apisAlice.newFieldReportSuccess(ctx, sampleFieldReport1(eventName))
+
+	fieldReport, resp := apisAlice.getFieldReport(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.NotEmpty(t, fieldReport.ReportEntries)
+
+	entry := fieldReport.ReportEntries[0]
+	entry.Stricken = new(true)
+	resp = apisAlice.updateFieldReportReportEntry(ctx, eventName, num, entry)
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	require.NoError(t, resp.Body.Close())
+
+	fieldReport, resp = apisAlice.getFieldReport(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.True(t, *fieldReport.ReportEntries[0].Stricken)
+}

--- a/api/integration/visit_test.go
+++ b/api/integration/visit_test.go
@@ -500,8 +500,8 @@ func TestVisitDepartureBeforeStoredArrivalIsRejected(t *testing.T) {
 	requireEqualishTimePtr(t, &sampleDeparture, visit.DepartureTime)
 }
 
-// Both times in one request are applied arrival-first, so an out-of-order pair
-// is caught by the departure check even though neither is being compared
+// A request carrying both times is judged on the pair it asked for, so an
+// out-of-order pair is rejected even though neither time is being compared
 // against a stored value.
 func TestVisitArrivalAndDepartureSentTogetherOutOfOrderIsRejected(t *testing.T) {
 	t.Parallel()
@@ -532,6 +532,69 @@ func TestVisitArrivalAndDepartureSentTogetherOutOfOrderIsRejected(t *testing.T) 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 	requireEqualishTimePtr(t, &sampleArrival, visit.ArrivalTime)
 	requireEqualishTimePtr(t, &sampleDeparture, visit.DepartureTime)
+}
+
+// Moving a whole visit later in one request is allowed, even though the new
+// arrival time lands after the departure time that's currently stored. The pair
+// in the request is in order, which is what matters; checking the new arrival
+// against the stored departure used to reject this.
+func TestVisitArrivalAndDepartureSentTogetherPastStoredDepartureIsAllowed(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apisAlice := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apisAlice.newVisitSuccess(ctx, sampleVisit1(eventName))
+
+	// Both are after the stored departure, and in order relative to each other.
+	newArrival := sampleDeparture.Add(time.Hour)
+	newDeparture := sampleDeparture.Add(2 * time.Hour)
+	resp := apisAlice.updateVisit(ctx, eventName, num, imsjson.Visit{
+		ArrivalTime:   &newArrival,
+		DepartureTime: &newDeparture,
+	})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	visit, resp := apisAlice.getVisit(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	requireEqualishTimePtr(t, &newArrival, visit.ArrivalTime)
+	requireEqualishTimePtr(t, &newDeparture, visit.DepartureTime)
+}
+
+// Clearing a time says so in the change log, rather than reporting the zero time
+// the client sends to clear it.
+func TestVisitClearedArrivalTimeIsNamedInTheChangeLog(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+
+	apisAdmin := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAdmin(ctx, t)}
+	apisAlice := ApiHelper{t: t, serverURL: shared.serverURL, jwt: jwtForAlice(t, ctx)}
+
+	eventName := newEventWithWriter(t, apisAdmin)
+	num := apisAlice.newVisitSuccess(ctx, sampleVisit1(eventName))
+
+	resp := apisAlice.updateVisit(ctx, eventName, num, imsjson.Visit{ArrivalTime: &time.Time{}})
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	visit, resp := apisAlice.getVisit(ctx, eventName, num)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Nil(t, visit.ArrivalTime)
+
+	var systemEntries []string
+	for _, entry := range visit.ReportEntries {
+		if entry.SystemEntry {
+			systemEntries = append(systemEntries, entry.Text)
+		}
+	}
+	changeLog := strings.Join(systemEntries, "\n")
+	require.Contains(t, changeLog, "Changed ArrivalTime: (cleared)")
+	require.NotContains(t, changeLog, "0001-01-01")
 }
 
 // The comparison is strict, so a guest who left the same instant they arrived

--- a/api/reportentry.go
+++ b/api/reportentry.go
@@ -188,6 +188,8 @@ func (action EditFieldReportReportEntry) editFieldReportEntry(req *http.Request)
 	if eventPermissions&(authz.EventWriteAllFieldReports|authz.EventWriteOwnFieldReports) == 0 {
 		return herr.Forbidden("The requestor does not have permission to write Field Reports on this Event", nil)
 	}
+	// i.e. they have EventWriteOwnFieldReports, but not EventWriteAllFieldReports
+	limitedAccess := eventPermissions&authz.EventWriteAllFieldReports == 0
 	ctx := req.Context()
 
 	author := jwtCtx.Claims.RangerHandle()
@@ -206,12 +208,14 @@ func (action EditFieldReportReportEntry) editFieldReportEntry(req *http.Request)
 		return errHTTP.From("[readBodyAs]")
 	}
 
-	_, err = action.imsDBQ.FieldReport(ctx, action.imsDBQ, imsdb.FieldReportParams{
-		Event:  event.ID,
-		Number: fieldReportNumber,
-	})
-	if err != nil {
-		return herr.NotFound("There is no Field Report for the provided ID", err).From("[FieldReport]")
+	_, entries, errHTTP := fetchFieldReport(ctx, action.imsDBQ, event.ID, fieldReportNumber)
+	if errHTTP != nil {
+		return errHTTP.From("[fetchFieldReport]")
+	}
+	// Striking an entry is an edit of the Field Report, so a Ranger who may only
+	// write their own has to be one of its authors, as in EditFieldReport.
+	if limitedAccess && !containsAuthor(entries, author) {
+		return herr.Forbidden("The requestor does not have permission to edit this particular Field Report", nil)
 	}
 
 	if re.Stricken == nil {

--- a/api/visit.go
+++ b/api/visit.go
@@ -453,6 +453,16 @@ func updateVisitAttempt(ctx context.Context, imsDBQ *store.DBQ, es *EventSourcer
 	return false, nil
 }
 
+// visitTimeLogValue renders an arrival or departure time for the change log. A
+// client clears one of these by sending the zero time, which must not reach the
+// log as a date in the year 1.
+func visitTimeLogValue(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return "(cleared)"
+	}
+	return t.In(time.UTC).Format(time.RFC3339)
+}
+
 // buildVisitUpdate merges the client-provided fields of newVisit over the
 // stored Visit, returning the update parameters along with change-log lines
 // describing each modified field. It rejects updates that would put the
@@ -518,10 +528,7 @@ func buildVisitUpdate(stored imsdb.Visit, newVisit imsjson.Visit, normalizeAddre
 
 	if newVisit.ArrivalTime != nil {
 		update.ArrivalTime = conv.TimeToNullFloat(*newVisit.ArrivalTime)
-		if update.ArrivalTime.Valid && update.DepartureTime.Valid && update.DepartureTime.Float64 < update.ArrivalTime.Float64 {
-			return update, nil, herr.BadRequest("Arrival time cannot be after departure time", errors.New("arrival time cannot be after departure time"))
-		}
-		logs = append(logs, fmt.Sprintf("Changed ArrivalTime: %v", newVisit.ArrivalTime.In(time.UTC).Format(time.RFC3339)))
+		logs = append(logs, fmt.Sprintf("Changed ArrivalTime: %v", visitTimeLogValue(newVisit.ArrivalTime)))
 	}
 	applyStringChange(&update.ArrivalMethod, newVisit.ArrivalMethod, "ArrivalMethod", &logs)
 	applyStringChange(&update.ArrivalState, newVisit.ArrivalState, "ArrivalState", &logs)
@@ -530,10 +537,23 @@ func buildVisitUpdate(stored imsdb.Visit, newVisit imsjson.Visit, normalizeAddre
 
 	if newVisit.DepartureTime != nil {
 		update.DepartureTime = conv.TimeToNullFloat(*newVisit.DepartureTime)
-		if update.ArrivalTime.Valid && update.DepartureTime.Valid && update.DepartureTime.Float64 < update.ArrivalTime.Float64 {
-			return update, nil, herr.BadRequest("Departure time cannot be before arrival time", errors.New("departure time cannot be before arrival time"))
+		logs = append(logs, fmt.Sprintf("Changed DepartureTime: %v", visitTimeLogValue(newVisit.DepartureTime)))
+	}
+
+	// Both times are applied before this check, so that a request setting arrival
+	// and departure together is judged on the pair it asked for. Checking each one
+	// as it was applied rejected such a request whenever the new arrival time was
+	// after the *stored* departure time, even when the new departure time it came
+	// with was later still.
+	if update.ArrivalTime.Valid && update.DepartureTime.Valid && update.DepartureTime.Float64 < update.ArrivalTime.Float64 {
+		// Name the end of the visit the request actually moved. When it moved
+		// both, the departure is the one to complain about, since it's the one
+		// that ends up earlier than it may be.
+		msg := "Departure time cannot be before arrival time"
+		if newVisit.DepartureTime == nil {
+			msg = "Arrival time cannot be after departure time"
 		}
-		logs = append(logs, fmt.Sprintf("Changed DepartureTime: %v", newVisit.DepartureTime.In(time.UTC).Format(time.RFC3339)))
+		return update, nil, herr.BadRequest(msg, nil)
 	}
 	applyStringChange(&update.DepartureMethod, newVisit.DepartureMethod, "DepartureMethod", &logs)
 	applyStringChange(&update.DepartureState, newVisit.DepartureState, "DepartureState", &logs)

--- a/directory/clubhousedb.go
+++ b/directory/clubhousedb.go
@@ -26,6 +26,7 @@ import (
 	chqueries "github.com/burningmantech/ranger-ims-go/directory/clubhousedb"
 	"github.com/go-sql-driver/mysql"
 	"log/slog"
+	"time"
 )
 
 //go:embed schema/current.sql
@@ -61,6 +62,10 @@ func MariaDB(ctx context.Context, directoryCfg conf.Directory) (*sql.DB, error) 
 	// Some arbitrary value. We'll get errors from MariaDB if the server
 	// hits the DB with too many parallel requests.
 	db.SetMaxOpenConns(int(chDBCfg.MaxOpenConns))
+	// As in store.openDB: database/sql keeps only two idle connections by
+	// default, so busier moments pay for a connection handshake per query.
+	db.SetMaxIdleConns(int(chDBCfg.MaxOpenConns))
+	db.SetConnMaxLifetime(5 * time.Minute)
 	pingErr := db.PingContext(ctx)
 	if pingErr != nil {
 		return nil, fmt.Errorf("[PingContext]: %w", pingErr)

--- a/store/actionlog/actionlog.go
+++ b/store/actionlog/actionlog.go
@@ -18,10 +18,12 @@ package actionlog
 
 import (
 	"context"
+	"log/slog"
+	"sync/atomic"
+	"time"
+
 	"github.com/burningmantech/ranger-ims-go/store"
 	"github.com/burningmantech/ranger-ims-go/store/imsdb"
-	"log/slog"
-	"time"
 )
 
 const (
@@ -34,6 +36,10 @@ type Logger struct {
 	imsDBQ              *store.DBQ
 	actionLogEnabled    bool
 	synchronousForTests bool
+
+	// dropped counts the rows discarded because the queue was full, for the
+	// worker to report once it's keeping up again.
+	dropped atomic.Int64
 }
 
 func NewLogger(
@@ -52,12 +58,21 @@ func NewLogger(
 	return logger
 }
 
+// Log queues a row to be written by the worker goroutine. This is called from
+// request handlers, so the send must never block: the queue fills up exactly
+// when the database is struggling, and blocking here would stall every request
+// in flight and turn a slow database into a hung server. A dropped audit row is
+// the cheaper loss.
 func (l *Logger) Log(ctx context.Context, record imsdb.AddActionLogParams) {
 	if l.actionLogEnabled {
 		if l.synchronousForTests {
 			l.writeRow(ctx, record)
-		} else {
-			l.work <- record
+			return
+		}
+		select {
+		case l.work <- record:
+		default:
+			l.dropped.Add(1)
 		}
 	}
 }
@@ -67,6 +82,11 @@ func (l *Logger) Close() {}
 func (l *Logger) startWorker(ctx context.Context) {
 	for row := range l.work {
 		l.writeRow(ctx, row)
+		// Report drops from the worker rather than from Log, so that a full
+		// queue produces one line per drained row instead of one per request.
+		if dropped := l.dropped.Swap(0); dropped > 0 {
+			slog.Warn("action log queue was full; rows were dropped", "count", dropped)
+		}
 	}
 	slog.Info("actionlog.Logger worker finished")
 }

--- a/store/errorlog/errorlog.go
+++ b/store/errorlog/errorlog.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"log/slog"
+	"sync/atomic"
 	"time"
 
 	"github.com/burningmantech/ranger-ims-go/lib/conv"
@@ -41,6 +42,10 @@ type Logger struct {
 	imsDBQ              *store.DBQ
 	errorLogEnabled     bool
 	synchronousForTests bool
+
+	// dropped counts the rows discarded because the queue was full, for the
+	// worker to report once it's keeping up again.
+	dropped atomic.Int64
 }
 
 func NewLogger(
@@ -59,6 +64,11 @@ func NewLogger(
 	return logger
 }
 
+// Log queues a row to be written by the worker goroutine. This is called from
+// request handlers, so the send must never block: the queue fills up exactly
+// when the database is struggling — which is also when errors, and so error log
+// rows, come thickest — and blocking here would stall every request in flight
+// and turn a slow database into a hung server.
 func (l *Logger) Log(ctx context.Context, record imsdb.AddErrorLogParams) {
 	if l.errorLogEnabled {
 		record.ResponseMessage = truncate(record.ResponseMessage, maxMessageLength)
@@ -66,8 +76,12 @@ func (l *Logger) Log(ctx context.Context, record imsdb.AddErrorLogParams) {
 		record.StackTrace = truncate(record.StackTrace, maxStackLength)
 		if l.synchronousForTests {
 			l.writeRow(ctx, record)
-		} else {
-			l.work <- record
+			return
+		}
+		select {
+		case l.work <- record:
+		default:
+			l.dropped.Add(1)
 		}
 	}
 }
@@ -77,6 +91,11 @@ func (l *Logger) Close() {}
 func (l *Logger) startWorker(ctx context.Context) {
 	for row := range l.work {
 		l.writeRow(ctx, row)
+		// Report drops from the worker rather than from Log, so that a full
+		// queue produces one line per drained row instead of one per request.
+		if dropped := l.dropped.Swap(0); dropped > 0 {
+			slog.Warn("error log queue was full; rows were dropped", "count", dropped)
+		}
 	}
 	slog.Info("errorlog.Logger worker finished")
 }

--- a/store/store.go
+++ b/store/store.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/burningmantech/ranger-ims-go/lib/noopdb"
 	"github.com/go-sql-driver/mysql"
 	"log/slog"
+	"time"
 )
 
 //go:embed schema/current.sql
@@ -82,6 +83,15 @@ func openDB(ctx context.Context, mariaCfg conf.DBStoreMaria) (*sql.DB, error) {
 		return nil, fmt.Errorf("[sql.Open]: %w", err)
 	}
 	db.SetMaxOpenConns(int(mariaCfg.MaxOpenConns))
+	// database/sql keeps only two idle connections by default, so anything above
+	// two concurrent queries would hand back its connection to be closed and pay
+	// for a fresh TCP and auth handshake on the next query. Let every connection
+	// the pool is allowed to open stay in it.
+	db.SetMaxIdleConns(int(mariaCfg.MaxOpenConns))
+	// Retire connections well before anything between here and the database
+	// (MariaDB's own wait_timeout, a load balancer's idle timeout) can drop one
+	// out from under us and turn it into a failed query.
+	db.SetConnMaxLifetime(5 * time.Minute)
 	pingErr := db.PingContext(ctx)
 	if pingErr != nil {
 		return nil, fmt.Errorf("[db.PingContext]: %w", pingErr)


### PR DESCRIPTION
- Field Report attachment upload was gated on the read permission rather than the write one, so a Ranger who may read every Field Report but write only their own could attach a file to someone else's
- Field Report report-entry strike had no authorship check at all, so any Reporter could strike entries on a Field Report they can't even read
- The action and error log queues blocked the request handler once full, which turned a slow database into a hung server; they now drop rows and report the count instead
- Both database pools kept only Go's default two idle connections, paying for a connection handshake per query beyond that; also retire connections before anything upstream can drop one out from under us
- A Visit edit carrying arrival and departure together checked the new arrival against the *stored* departure, rejecting a valid request that moved the whole visit later
- Clearing a Visit's arrival or departure time logged the zero time in the change log instead of saying it had been cleared