### PR TITLE
fix: download the right attachment for a Visit entry on the Incident page

### DIFF
--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -1179,7 +1179,7 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             url = urlReplace(url_visitAttachmentNumber)
                 .replace("<visit_number>", pathIds.visitNumber.toString())
                 .replace("<attachment_number>", entry.id!.toString());
-        } else if (pathIds.incidentNumber != null && entry.frNum == null) {
+        } else if (pathIds.incidentNumber != null && entry.frNum == null && entry.visitNum == null) {
             // incident attachment on incident page
             url = urlReplace(url_incidentAttachmentNumber)
                 .replace("<incident_number>", pathIds.incidentNumber.toString())

--- a/web/typescripttest/field_report.test.ts
+++ b/web/typescripttest/field_report.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
+import { captureLinkClicks, jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -78,6 +78,9 @@ function frRoutes(url: string, init?: RequestInit): Response | undefined {
     }
     if (url === `${frUrl}/7` && !hasBody) {
         return jsonResponse(serverFieldReport, 200);
+    }
+    if (/\/attachments\/\d+$/.test(url) && !hasBody) {
+        return new Response("file contents", { status: 200 });
     }
     if (url.startsWith(`${frUrl}/7`) && hasBody) {
         // Edits and attach/detach.
@@ -156,6 +159,25 @@ test("a viewer without field-report read access sees an authorization error", as
 
     expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
     expect(document.getElementById("error_text")!.textContent).toContain("not currently authorized");
+});
+
+test("an entry's attachment is fetched from the field report's own endpoint", async (): Promise<void> => {
+    serverFieldReport.report_entries![0]!.attachment = { name: "found.jpg", previewable: true };
+    const mock = await initFieldReportPage();
+    const links = captureLinkClicks();
+
+    const entry = document.querySelector<HTMLDivElement>("#report_entries .report_entry")!;
+    const download = [...entry.querySelectorAll("button")]
+        .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes("Download"))!;
+    mock.mockClear();
+    download.click();
+
+    await vi.waitFor((): void => {
+        expect(mock.mock.calls.map(([url]): string => url)).toContain(`${frUrl}/7/attachments/1`);
+        expect(links.length).toBe(1);
+    });
+    expect(links[0]!.download).toBe("found.jpg");
+    expect(document.getElementById("error_text")!.textContent).toBe("");
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {

--- a/web/typescripttest/helpers.ts
+++ b/web/typescripttest/helpers.ts
@@ -63,6 +63,25 @@ export function problemResponse(detail: string, status: number): Response {
     });
 }
 
+// Swallow clicks on <a> elements, returning the array the clicked links are
+// recorded into. The attachment download/preview handlers work by clicking a
+// temporary anchor, and happy-dom honors such a click by navigating away, which
+// would tear down the page the test is inspecting.
+//
+// Call this after the page under test has initialized: loadFixture reopens the
+// document, which drops its event listeners.
+export function captureLinkClicks(): HTMLAnchorElement[] {
+    const clicked: HTMLAnchorElement[] = [];
+    document.addEventListener("click", (e: Event): void => {
+        const link = (e.target as Element | null)?.closest("a");
+        if (link != null) {
+            clicked.push(link as HTMLAnchorElement);
+            e.preventDefault();
+        }
+    });
+    return clicked;
+}
+
 export type FetchHandler = (url: string, init?: RequestInit) => Response | undefined;
 
 // Replace global fetch with a route handler, returning the mock function so

--- a/web/typescripttest/incident.test.ts
+++ b/web/typescripttest/incident.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
+import { captureLinkClicks, jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -181,6 +181,9 @@ function incidentRoutes(url: string, init?: RequestInit): Response | undefined {
     }
     if (url.startsWith(`/ims/api/events/${eventName}/incidents/1/report_entries/`) && hasBody) {
         return new Response(null, { status: 204 });
+    }
+    if (/\/attachments\/\d+$/.test(url) && !hasBody) {
+        return new Response("file contents", { status: 200 });
     }
     if (url === `/ims/api/events/${eventName}/incidents/1/attachments` && hasBody) {
         return new Response(null, { status: 200 });
@@ -360,6 +363,109 @@ test("report entries from the incident, field reports, and visits are merged in 
 
     // History (system entries) is hidden until the checkbox is checked.
     expect(document.getElementById("report_entries")!.classList.contains("hide-history")).toBe(true);
+});
+
+// Attach a file to each of the three entries the incident page merges together:
+// the incident's own, one from an attached field report, and one from an
+// attached visit.
+function attachFilesToEveryEntrySource(): void {
+    serverIncident.report_entries![1]!.attachment = { name: "incident.jpg", previewable: true };
+    serverFieldReports[0]!.report_entries![0]!.attachment = { name: "fr.jpg", previewable: true };
+    serverVisits[0]!.report_entries![0]!.attachment = { name: "visit.jpg", previewable: true };
+}
+
+// Click the Preview or Download button on the report entry with the given text,
+// and return the URL its handler fetched the attachment from, along with the
+// temporary link it then clicked to hand the file to the browser.
+async function useAttachment(
+    mock: ReturnType<typeof mockFetch>,
+    links: HTMLAnchorElement[],
+    entryText: string,
+    label: string,
+): Promise<{ url: string, link: HTMLAnchorElement }> {
+    const entry = [...document.querySelectorAll<HTMLDivElement>("#report_entries .report_entry")]
+        .find((e: HTMLDivElement): boolean => e.querySelector(".report_entry_text")!.textContent === entryText);
+    if (entry == null) {
+        throw new Error(`no report entry reading "${entryText}"`);
+    }
+    const button = [...entry.querySelectorAll("button")]
+        .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes(label));
+    if (button == null) {
+        throw new Error(`no ${label} button on the "${entryText}" entry`);
+    }
+    mock.mockClear();
+    links.length = 0;
+    button.click();
+
+    let fetched = "";
+    await vi.waitFor((): void => {
+        const call = mock.mock.calls.find(([url]): boolean => url.includes("/attachments/"));
+        expect(call, `${label} fetched no attachment`).toBeDefined();
+        fetched = call![0];
+        expect(links.length, `${label} opened no link`).toBe(1);
+    });
+    // A URL naming the wrong record 404s in production; here the fake server has
+    // no route for it, which fetchNoThrow turns into an error banner.
+    expect(document.getElementById("error_text")!.textContent).toBe("");
+    return { url: fetched, link: links[0]! };
+}
+
+// Every entry on the incident page has its attachment stored under the record
+// it came from, which is not necessarily the incident being viewed.
+test("Download fetches each entry's attachment from the record that owns it", async (): Promise<void> => {
+    attachFilesToEveryEntrySource();
+    const mock = await initIncidentPage();
+    const links = captureLinkClicks();
+
+    const incidentEntry = await useAttachment(mock, links, "Dust storm at the Man", "Download");
+    expect(incidentEntry.url).toBe("/ims/api/events/2025/incidents/1/attachments/2");
+    expect(incidentEntry.link.download).toBe("incident.jpg");
+
+    const frEntry = await useAttachment(mock, links, "from the field", "Download");
+    expect(frEntry.url).toBe("/ims/api/events/2025/field_reports/7/attachments/21");
+    expect(frEntry.link.download).toBe("fr.jpg");
+
+    const visitEntry = await useAttachment(mock, links, "visit note", "Download");
+    expect(visitEntry.url).toBe("/ims/api/events/2025/visits/2/attachments/31");
+    expect(visitEntry.link.download).toBe("visit.jpg");
+});
+
+test("Preview fetches each entry's attachment from the record that owns it", async (): Promise<void> => {
+    attachFilesToEveryEntrySource();
+    const mock = await initIncidentPage();
+    const links = captureLinkClicks();
+
+    const incidentEntry = await useAttachment(mock, links, "Dust storm at the Man", "Preview");
+    expect(incidentEntry.url).toBe("/ims/api/events/2025/incidents/1/attachments/2");
+    // Preview opens the file rather than saving it.
+    expect(incidentEntry.link.target).toBe("_blank");
+    expect(incidentEntry.link.download).toBe("");
+
+    expect((await useAttachment(mock, links, "from the field", "Preview")).url)
+        .toBe("/ims/api/events/2025/field_reports/7/attachments/21");
+    expect((await useAttachment(mock, links, "visit note", "Preview")).url)
+        .toBe("/ims/api/events/2025/visits/2/attachments/31");
+});
+
+test("a non-previewable attachment offers Download only", async (): Promise<void> => {
+    attachFilesToEveryEntrySource();
+    serverVisits[0]!.report_entries![0]!.attachment = { name: "visit.bin", previewable: false };
+    await initIncidentPage();
+
+    const visitEntry = [...document.querySelectorAll<HTMLDivElement>("#report_entries .report_entry")]
+        .find((e: HTMLDivElement): boolean => e.querySelector(".report_entry_text")!.textContent === "visit note")!;
+    const labels = [...visitEntry.querySelectorAll("button")]
+        .map((b: HTMLButtonElement): string => b.textContent ?? "");
+    expect(labels.some((t: string): boolean => t.includes("Download"))).toBe(true);
+    expect(labels.some((t: string): boolean => t.includes("Preview"))).toBe(false);
+});
+
+test("an entry with no attachment gets no Preview or Download button", async (): Promise<void> => {
+    await initIncidentPage();
+
+    const buttons = [...document.querySelectorAll<HTMLButtonElement>("#report_entries .report_entry button")]
+        .map((b: HTMLButtonElement): string => b.textContent ?? "");
+    expect(buttons.some((t: string): boolean => t.includes("Download") || t.includes("Preview"))).toBe(false);
 });
 
 test("linked incidents are drawn with links and metadata", async (): Promise<void> => {

--- a/web/typescripttest/sanctuary_visit.test.ts
+++ b/web/typescripttest/sanctuary_visit.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
+import { captureLinkClicks, jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -97,6 +97,9 @@ function visitRoutes(url: string, init?: RequestInit): Response | undefined {
     }
     if (url === `${visitsUrl}/2/attachments` && hasBody) {
         return new Response(null, { status: 200 });
+    }
+    if (/\/attachments\/\d+$/.test(url) && !hasBody) {
+        return new Response("file contents", { status: 200 });
     }
     return undefined;
 }
@@ -220,6 +223,25 @@ test("a viewer without visit read access sees an authorization error", async ():
 
     expect(document.getElementById("error_info")!.classList.contains("hidden")).toBe(false);
     expect(document.getElementById("error_text")!.textContent).toContain("not currently authorized");
+});
+
+test("an entry's attachment is fetched from the visit's own endpoint", async (): Promise<void> => {
+    serverVisit.report_entries![0]!.attachment = { name: "checkin.jpg", previewable: true };
+    const mock = await initVisitPage();
+    const links = captureLinkClicks();
+
+    const entry = document.querySelector<HTMLDivElement>("#report_entries .report_entry")!;
+    const download = [...entry.querySelectorAll("button")]
+        .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes("Download"))!;
+    mock.mockClear();
+    download.click();
+
+    await vi.waitFor((): void => {
+        expect(mock.mock.calls.map(([url]): string => url)).toContain(`${visitsUrl}/2/attachments/1`);
+        expect(links.length).toBe(1);
+    });
+    expect(links[0]!.download).toBe("checkin.jpg");
+    expect(document.getElementById("error_text")!.textContent).toBe("");
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {


### PR DESCRIPTION
The Incident page merges in report entries from attached Field Reports and Visits, and each entry's attachment has to be fetched from the record that owns it. The incident-attachment branch only excluded FR-sourced entries, so a Visit-sourced entry fell into it and Preview/Download went to /incidents/<n>/attachments/<id> — an ID that belongs to the visit, not the incident — which fails.

Tests now cover the whole page x entry-source matrix (incident page with incident/FR/visit entries, plus the FR and Visit pages), since any of those five could break the same way. They click the real buttons and assert the URL fetched; captureLinkClicks in helpers.ts swallows the temporary <a> click the handlers use to hand the file to the browser, which happy-dom would otherwise honor by navigating away mid-test.