### PR TITLE
fix(attachments): resolve lingering bugs with Preview and Download

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -54,6 +54,9 @@ services:
       IMS_DMS_USERNAME: "${IMS_DMS_USERNAME:-clubhouseuser}"
       IMS_DMS_PASSWORD: "${IMS_DMS_PASSWORD:-clubhousepassword}"
       IMS_EVENT_DELETION_ENABLED: "true"
+      IMS_ATTACHMENTS_STORE: "${IMS_ATTACHMENTS_STORE:-}"
+      IMS_ATTACHMENTS_LOCAL_DIR: "${IMS_ATTACHMENTS_LOCAL_DIR:-}"
+
       # Optional. With no key, the Admin Places page's "Set from API" buttons
       # stay disabled and places must be pasted in by hand.
       IMS_BM_API_KEY: "${IMS_BM_API_KEY:-}"

--- a/web/template/help.templ
+++ b/web/template/help.templ
@@ -190,7 +190,10 @@ templ Help(deployment, versionName, versionRef string) {
   <strong>Attach file</strong> button, so you can add a photo or document (such as a
   picture of a whiteboard or a scanned form) alongside the written entries. An entry with a
   file on it gets a <strong>Download</strong> button, plus a <strong>Preview</strong> button on
-  files a browser can display, such as images and PDFs.
+  files a browser can display, such as images and PDFs. Either button shows how far along the
+  transfer is while it runs. If a slow preview finishes long after you asked for it, the button
+  reads <strong>Preview Ready</strong>; click it again to open the file, which your browser
+  won&#39;t do on its own after that long a wait.
 </p>
 
 <h3 id="incident-linking" class="h5 mt-3">Linking related Incidents</h3>

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -1198,27 +1198,34 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             throw new Error(`Unknown attachment source for entry: ${entry}`);
         }
 
+        const downloadKey: string = `download ${url}`;
         const downloadButt: HTMLButtonElement = createSvgTextButton("#download", "Download");
         downloadButt.onclick = async (e: MouseEvent): Promise<void> => {
             e.preventDefault();
-            const {resp, err} = await fetchNoThrow(url, {});
-            if (err != null || resp == null) {
-                setErrorMessage(`Failed to fetch attachment. ${err}`);
-                return;
-            }
-            const blobUrl: string = window.URL.createObjectURL(await resp.blob());
-            const tmpLink: HTMLAnchorElement = document.createElement("a");
+            const transfer: AttachmentTransfer = startTransfer(downloadKey, downloadButt, "Download");
+            try {
+                const blob: Blob|null = await fetchAttachment(url, transfer);
+                if (blob == null) {
+                    return;
+                }
+                const blobUrl: string = window.URL.createObjectURL(blob);
+                const tmpLink: HTMLAnchorElement = document.createElement("a");
 
-            // Download mode: set a suggested filename.
-            tmpLink.download = entry?.attachment?.name ?? "imsfile";
-            tmpLink.href = blobUrl;
-            document.body.appendChild(tmpLink);
-            tmpLink.click();
-            document.body.removeChild(tmpLink);
-            URL.revokeObjectURL(blobUrl);
+                // Download mode: set a suggested filename.
+                tmpLink.download = entry?.attachment?.name ?? "imsfile";
+                tmpLink.href = blobUrl;
+                document.body.appendChild(tmpLink);
+                tmpLink.click();
+                document.body.removeChild(tmpLink);
+                URL.revokeObjectURL(blobUrl);
+            } finally {
+                attachmentTransfers.delete(downloadKey);
+            }
         };
+        adoptTransfer(downloadKey, downloadButt);
 
         if (entry.attachment?.previewable) {
+            const previewKey: string = `preview ${url}`;
             const previewButt: HTMLButtonElement = createSvgTextButton("#preview", "Preview");
 
             // We need to do a JavaScript fetch of the file, rather than simply
@@ -1226,30 +1233,39 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
             // the Authorization header.
             previewButt.onclick = async (e: MouseEvent): Promise<void> => {
                 e.preventDefault();
-                const {resp, err} = await fetchNoThrow(url, {});
-                if (err != null || resp == null) {
-                    setErrorMessage(`Failed to fetch attachment. ${err}`);
+
+                // Second click on a file that's already in hand. This runs
+                // before any await, so the click still authorizes a new tab.
+                const ready: string|null = attachmentTransfers.get(previewKey)?.readyBlobUrl??null;
+                if (ready != null) {
+                    attachmentTransfers.delete(previewKey);
+                    resetTransferButton(previewButt, "Preview");
+                    openPreviewTab(ready);
                     return;
                 }
-                const blobUrl: string = window.URL.createObjectURL(await resp.blob());
-                const tmpLink: HTMLAnchorElement = document.createElement("a");
 
-                // Preview mode: open a preview in a new window.
-                // We'd use window.open with target _blank, but Safari iOS doesn't support that,
-                // and a lot of Rangers use iPhones.
-                tmpLink.target = "_blank";
-                tmpLink.href = blobUrl;
-                document.body.appendChild(tmpLink);
-                tmpLink.click();
-                document.body.removeChild(tmpLink);
+                const transfer: AttachmentTransfer = startTransfer(previewKey, previewButt, "Preview");
+                const clickedAt: number = Date.now();
+                const blob: Blob|null = await fetchAttachment(url, transfer);
+                if (blob == null) {
+                    attachmentTransfers.delete(previewKey);
+                    return;
+                }
+                const blobUrl: string = window.URL.createObjectURL(blob);
+                if (clickStillOpensTabs(clickedAt)) {
+                    attachmentTransfers.delete(previewKey);
+                    openPreviewTab(blobUrl);
+                    return;
+                }
 
-                // Wait a little while before cleaning up the blob, in case the user opts
-                // to download the file from the preview (that will fail once the object URL
-                // has been revoked).
-                setTimeout(function (): void {
-                    URL.revokeObjectURL(blobUrl);
-                }, 60_000 /* milliseconds */);
+                // The download took long enough that the browser no longer
+                // considers the click to be what's opening the tab, and would
+                // block it as a popup. Hold the file and say so; the next
+                // click opens it immediately.
+                transfer.readyBlobUrl = blobUrl;
+                renderTransfer(transfer);
             };
+            adoptTransfer(previewKey, previewButt);
             entryContainer.append(previewButt);
         }
         entryContainer.append(downloadButt);
@@ -1262,6 +1278,143 @@ function reportEntryElement(entry: ReportEntry): HTMLDivElement {
     entryContainer.append(hr);
 
     return entryContainer;
+}
+
+// Open a fetched attachment in a new tab. Browsers only allow this while the
+// user's click still counts as activation, so callers must either run this
+// promptly after the click or wait for another one.
+function openPreviewTab(blobUrl: string): void {
+    const tmpLink: HTMLAnchorElement = document.createElement("a");
+
+    // We'd use window.open with target _blank, but Safari iOS doesn't support that,
+    // and a lot of Rangers use iPhones.
+    tmpLink.target = "_blank";
+    tmpLink.href = blobUrl;
+    document.body.appendChild(tmpLink);
+    tmpLink.click();
+    document.body.removeChild(tmpLink);
+
+    // Wait a little while before cleaning up the blob, in case the user opts
+    // to download the file from the preview (that will fail once the object URL
+    // has been revoked).
+    setTimeout(function (): void {
+        URL.revokeObjectURL(blobUrl);
+    }, 60_000 /* milliseconds */);
+}
+
+// Whether a click made at clickedAt would still be allowed to open a new tab.
+// Browsers only honor a click for a few seconds, so a slow attachment download
+// can outlive the click that started it, after which opening the preview is
+// blocked as a popup.
+function clickStillOpensTabs(clickedAt: number): boolean {
+    if (navigator.userActivation != null) {
+        return navigator.userActivation.isActive;
+    }
+    // Safari doesn't report activation state, and is stricter than the several
+    // seconds other browsers allow, so only trust a nearly instant download.
+    return Date.now() - clickedAt < 1000 /* milliseconds */;
+}
+
+// An attachment being fetched, or one that's been fetched and is waiting to be
+// opened. This outlives the button that started it: the report entries are
+// redrawn from scratch whenever anything on the page changes (including an
+// update someone else made, which arrives over the event source), and that
+// replaces every attachment button mid-transfer.
+interface AttachmentTransfer {
+    // The button currently standing in for this transfer, swapped out for the
+    // newly drawn one each time the entries are redrawn.
+    butt: HTMLButtonElement;
+    // The button's usual label, e.g. "Download".
+    name: string;
+    // How far along the fetch is, e.g. "42%", or null when nothing's moving.
+    progress: string|null;
+    // A file that's been fetched but not yet opened, because the download
+    // outlived the click that asked for it. It waits here for the next click.
+    readyBlobUrl: string|null;
+}
+
+const attachmentTransfers: Map<string, AttachmentTransfer> = new Map();
+
+function startTransfer(key: string, butt: HTMLButtonElement, name: string): AttachmentTransfer {
+    const transfer: AttachmentTransfer = {butt: butt, name: name, progress: null, readyBlobUrl: null};
+    attachmentTransfers.set(key, transfer);
+    return transfer;
+}
+
+// Hand a freshly drawn button whatever its predecessor was in the middle of, so
+// that a redraw doesn't strand a download in progress or a file waiting to be
+// opened.
+function adoptTransfer(key: string, butt: HTMLButtonElement): void {
+    const transfer: AttachmentTransfer|undefined = attachmentTransfers.get(key);
+    if (transfer == null) {
+        return;
+    }
+    transfer.butt = butt;
+    renderTransfer(transfer);
+}
+
+function renderTransfer(transfer: AttachmentTransfer): void {
+    const label: HTMLSpanElement = transfer.butt.querySelector("span")!;
+    if (transfer.progress != null) {
+        transfer.butt.disabled = true;
+        transfer.butt.title = "";
+        label.textContent = `${transfer.name} ${transfer.progress}`;
+    } else if (transfer.readyBlobUrl != null) {
+        transfer.butt.disabled = false;
+        transfer.butt.title = `Click again to open the ${transfer.name.toLowerCase()}`;
+        label.textContent = `${transfer.name} Ready`;
+    } else {
+        resetTransferButton(transfer.butt, transfer.name);
+    }
+}
+
+function resetTransferButton(butt: HTMLButtonElement, name: string): void {
+    butt.disabled = false;
+    butt.title = "";
+    butt.querySelector("span")!.textContent = name;
+}
+
+// Fetch an attachment, using the transfer's button as the progress indicator,
+// since a large file on a slow connection can take a long while with nothing
+// else to show for it. Returns null if the fetch failed, having already shown
+// the user an error.
+async function fetchAttachment(url: string, transfer: AttachmentTransfer): Promise<Blob|null> {
+    transfer.progress = "…";
+    renderTransfer(transfer);
+    try {
+        const {resp, err} = await fetchNoThrow(url, {});
+        if (err != null || resp == null) {
+            setErrorMessage(`Failed to fetch attachment. ${err}`);
+            return null;
+        }
+        if (resp.body == null) {
+            return await resp.blob();
+        }
+        // The server sends Content-Length for attachments, but fall back to
+        // counting bytes if some proxy in between drops it.
+        const total: number = parseInt10(resp.headers.get("Content-Length"))??0;
+        // The lib types allow chunks backed by a SharedArrayBuffer, which Blob
+        // won't accept, but fetch never produces those.
+        const reader = resp.body.getReader() as ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>;
+        const chunks: Uint8Array<ArrayBuffer>[] = [];
+        let loaded = 0;
+        for (;;) {
+            const {done, value} = await reader.read();
+            if (done) {
+                break;
+            }
+            chunks.push(value);
+            loaded += value.length;
+            transfer.progress = total > 0
+                ? `${Math.min(100, Math.floor(100 * loaded / total))}%`
+                : `${(loaded / 1e6).toFixed(1)} MB`;
+            renderTransfer(transfer);
+        }
+        return new Blob(chunks, {type: resp.headers.get("Content-Type")??""});
+    } finally {
+        transfer.progress = null;
+        renderTransfer(transfer);
+    }
 }
 
 // Create a button that'll show an SVG icon and some text as its content.

--- a/web/typescripttest/field_report.test.ts
+++ b/web/typescripttest/field_report.test.ts
@@ -17,7 +17,7 @@
 // Tests for field_report.ts against the real templ-rendered field report page
 // (field_report.templ).
 
-import { beforeEach, expect, test, vi } from "vitest";
+import { beforeEach, expect, onTestFinished, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
 import { captureLinkClicks, jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
 
@@ -178,6 +178,192 @@ test("an entry's attachment is fetched from the field report's own endpoint", as
     });
     expect(links[0]!.download).toBe("found.jpg");
     expect(document.getElementById("error_text")!.textContent).toBe("");
+});
+
+test("downloading an attachment shows progress on the button, then restores it", async (): Promise<void> => {
+    serverFieldReport.report_entries![0]!.attachment = { name: "found.jpg", previewable: true };
+
+    // A body the test feeds by hand, so the button can be inspected mid-download.
+    let push: (chunk: Uint8Array) => void = (): void => {};
+    let finish: () => void = (): void => {};
+    const body = new ReadableStream<Uint8Array>({
+        start(controller): void {
+            push = (chunk: Uint8Array): void => controller.enqueue(chunk);
+            finish = (): void => controller.close();
+        },
+    });
+    await initFieldReportPage((url, init) => {
+        if (/\/attachments\/\d+$/.test(url) && init?.body == null) {
+            return new Response(body, { status: 200, headers: { "Content-Length": "10" } });
+        }
+        return frRoutes(url, init);
+    });
+    const links = captureLinkClicks();
+    const blobs: Blob[] = [];
+    vi.spyOn(window.URL, "createObjectURL").mockImplementation((blob: Blob|MediaSource): string => {
+        blobs.push(blob as Blob);
+        return "blob:fake";
+    });
+
+    const entry = document.querySelector<HTMLDivElement>("#report_entries .report_entry")!;
+    const download = [...entry.querySelectorAll("button")]
+        .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes("Download"))!;
+    download.click();
+
+    // Halfway through, the button is unusable and reports how far along it is.
+    push(new Uint8Array([1, 2, 3, 4, 5]));
+    await vi.waitFor((): void => {
+        expect(download.textContent).toContain("50%");
+    });
+    expect(download.disabled).toBe(true);
+
+    push(new Uint8Array([6, 7, 8, 9, 10]));
+    finish();
+
+    await vi.waitFor((): void => {
+        expect(links.length).toBe(1);
+    });
+    // The whole file made it through the streamed read.
+    expect(await blobs[0]!.arrayBuffer()).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]).buffer);
+    // The button goes back to being a Download button.
+    expect(download.disabled).toBe(false);
+    expect(download.textContent).toContain("Download");
+    expect(download.textContent).not.toContain("%");
+});
+
+// A slow preview download outlives the click that started it, and the browser
+// would block the new tab as a popup, so the file waits for a second click.
+test("a preview whose download outlives its click waits to be opened", async (): Promise<void> => {
+    serverFieldReport.report_entries![0]!.attachment = { name: "found.jpg", previewable: true };
+    // The click no longer counts as user activation, as after a long download.
+    Object.defineProperty(navigator, "userActivation", {
+        configurable: true,
+        value: { isActive: false, hasBeenActive: true },
+    });
+    onTestFinished((): void => {
+        Reflect.deleteProperty(navigator, "userActivation");
+    });
+
+    await initFieldReportPage();
+    const links = captureLinkClicks();
+    vi.spyOn(window.URL, "createObjectURL").mockReturnValue("blob:fake");
+
+    const entry = document.querySelector<HTMLDivElement>("#report_entries .report_entry")!;
+    const preview = [...entry.querySelectorAll("button")]
+        .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes("Preview"))!;
+    preview.click();
+
+    // The file arrived, but opening it now would be blocked, so the button says
+    // it's holding one rather than opening a tab.
+    await vi.waitFor((): void => {
+        expect(preview.textContent).toContain("Preview Ready");
+    });
+    expect(links.length).toBe(0);
+    expect(preview.disabled).toBe(false);
+
+    // The second click opens the file it already has, without re-fetching.
+    preview.click();
+    expect(links.length).toBe(1);
+    expect(links[0]!.target).toBe("_blank");
+    expect(links[0]!.href).toContain("blob:fake");
+    expect(preview.textContent).toContain("Preview");
+    expect(preview.textContent).not.toContain("Ready");
+});
+
+// The report entries are rebuilt from scratch on every update, including ones
+// that arrive from other users, which replaces the button a transfer is running
+// on. The replacement has to pick up where its predecessor left off.
+test("a redraw mid-download hands the progress to the newly drawn button", async (): Promise<void> => {
+    serverFieldReport.report_entries![0]!.attachment = { name: "found.jpg", previewable: true };
+
+    let push: (chunk: Uint8Array) => void = (): void => {};
+    let finish: () => void = (): void => {};
+    const body = new ReadableStream<Uint8Array>({
+        start(controller): void {
+            push = (chunk: Uint8Array): void => controller.enqueue(chunk);
+            finish = (): void => controller.close();
+        },
+    });
+    await initFieldReportPage((url, init) => {
+        if (/\/attachments\/\d+$/.test(url) && init?.body == null) {
+            return new Response(body, { status: 200, headers: { "Content-Length": "10" } });
+        }
+        return frRoutes(url, init);
+    });
+    const links = captureLinkClicks();
+    vi.spyOn(window.URL, "createObjectURL").mockReturnValue("blob:fake");
+    const ims = await import("../typescript/ims.ts");
+
+    const downloadButton = (): HTMLButtonElement =>
+        [...document.querySelectorAll<HTMLDivElement>("#report_entries .report_entry")[0]!.querySelectorAll("button")]
+            .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes("Download"))!;
+
+    const firstButt = downloadButton();
+    firstButt.click();
+    push(new Uint8Array([1, 2, 3, 4, 5]));
+    await vi.waitFor((): void => {
+        expect(firstButt.textContent).toContain("50%");
+    });
+
+    // Someone else's update redraws every entry, discarding the button that was
+    // showing the progress.
+    ims.drawReportEntries(serverFieldReport.report_entries!);
+    const redrawnButt = downloadButton();
+    expect(redrawnButt).not.toBe(firstButt);
+    expect(redrawnButt.textContent).toContain("50%");
+    expect(redrawnButt.disabled).toBe(true);
+
+    push(new Uint8Array([6, 7, 8, 9, 10]));
+    finish();
+
+    // The download still completes, and it's the new button that gets cleaned up.
+    await vi.waitFor((): void => {
+        expect(links.length).toBe(1);
+    });
+    expect(redrawnButt.disabled).toBe(false);
+    expect(redrawnButt.textContent).toContain("Download");
+    expect(redrawnButt.textContent).not.toContain("%");
+});
+
+// A file parked for a second click has to survive a redraw too, or the only
+// reference to it is lost and the user has to download it all over again.
+test("a redraw keeps a preview that's waiting to be opened", async (): Promise<void> => {
+    serverFieldReport.report_entries![0]!.attachment = { name: "found.jpg", previewable: true };
+    Object.defineProperty(navigator, "userActivation", {
+        configurable: true,
+        value: { isActive: false, hasBeenActive: true },
+    });
+    onTestFinished((): void => {
+        Reflect.deleteProperty(navigator, "userActivation");
+    });
+
+    const mock = await initFieldReportPage();
+    const links = captureLinkClicks();
+    vi.spyOn(window.URL, "createObjectURL").mockReturnValue("blob:fake");
+    const ims = await import("../typescript/ims.ts");
+
+    const previewButton = (): HTMLButtonElement =>
+        [...document.querySelectorAll<HTMLDivElement>("#report_entries .report_entry")[0]!.querySelectorAll("button")]
+            .find((b: HTMLButtonElement): boolean => (b.textContent ?? "").includes("Preview"))!;
+
+    previewButton().click();
+    await vi.waitFor((): void => {
+        expect(previewButton().textContent).toContain("Preview Ready");
+    });
+
+    ims.drawReportEntries(serverFieldReport.report_entries!);
+    const redrawnButt = previewButton();
+    expect(redrawnButt.textContent).toContain("Preview Ready");
+
+    // The redrawn button opens the file its predecessor fetched, without going
+    // back to the server for it.
+    mock.mockClear();
+    redrawnButt.click();
+    expect(links.length).toBe(1);
+    expect(links[0]!.href).toContain("blob:fake");
+    expect(mock.mock.calls.some(([url]): boolean => url.includes("/attachments/"))).toBe(false);
+    expect(redrawnButt.textContent).toContain("Preview");
+    expect(redrawnButt.textContent).not.toContain("Ready");
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {


### PR DESCRIPTION
The main problem was that on a slow connection, preview would not work in most browsers, because they require a short time period between a user action and the new window opening. This fixes that by letting the user click again to preview the loaded file. This also adds percentage downloaded numbers to the buttons, to make it clearer what's happening.