### PR TITLE
fix(attachments): make uploads work better on slow connections

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -141,7 +141,7 @@ func mustStartServer(ctx context.Context, unvalidatedCfg *conf.IMSConfig, printC
 
 	s := &http.Server{
 		Handler:     mux,
-		ReadTimeout: 1 * time.Minute,
+		ReadTimeout: 5 * time.Minute,
 		// This needs to be long to support long-lived EventSource calls.
 		// After this duration, a client will be disconnected and forced
 		// to reconnect.

--- a/playwright/tests/ims.spec.ts
+++ b/playwright/tests/ims.spec.ts
@@ -542,6 +542,57 @@ test("incidents", async ({ page, browser }) => {
 })
 
 
+// Attaching a file is the one flow that goes out over XMLHttpRequest rather
+// than fetch (only XHR reports upload progress), so the Vitest suite's mocked
+// fetch can't cover it. A few bytes are plenty: this checks the round trip, not
+// throughput.
+test("attachments", async ({ page }) => {
+  await login(page);
+  const eventName: string = randomName("event");
+  await addEvent(page, eventName);
+  await addWriter(page, eventName, "person:" + username);
+
+  await page.goto(`http://localhost:8080/ims/app/events/${eventName}/incidents`);
+  await page.getByRole("link", {name: "New"}).click();
+  await page.getByLabel("Summary").fill(randomName("summary"));
+  await page.getByLabel("Summary").press("Tab");
+  await expect(page.getByLabel("IMS #", {exact: true})).toHaveValue(/^\d+$/);
+
+  // The Attach file button only appears when the server has an attachments
+  // store configured (IMS_ATTACHMENTS_STORE), which a dev stack needn't.
+  const attachButt = page.locator("#attach_file");
+  if (!await attachButt.isVisible()) {
+    test.skip(true, "server has no attachments store configured");
+  }
+
+  const contents = `attached by playwright ${crypto.randomUUID()}`;
+  await page.locator("#attach_file_input").setInputFiles({
+    name: "note.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from(contents),
+  });
+
+  // The upload lands as a report entry offering the file back, and the button
+  // returns to its resting label rather than sticking on a progress percentage.
+  const downloadButt = page.getByRole("button", {name: "Download"});
+  await expect(downloadButt).toBeVisible();
+  await expect(attachButt).toHaveValue("Attach file");
+
+  // Downloading gives back the bytes that went up, so the multipart body the
+  // XHR sent really did arrive intact.
+  const download = await Promise.all([
+    page.waitForEvent("download"),
+    downloadButt.click(),
+  ]).then(([d]) => d);
+  expect(download.suggestedFilename()).toBe("note.txt");
+  const stream = await download.createReadStream();
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.from(chunk));
+  }
+  expect(Buffer.concat(chunks).toString()).toBe(contents);
+});
+
 test("field_reports", async ({ page, browser }) => {
   test.slow();
 

--- a/web/typescript/field_report.ts
+++ b/web/typescript/field_report.ts
@@ -504,10 +504,10 @@ async function attachFile(): Promise<void> {
         .replace("<field_report_number>", (ims.pathIds.fieldReportNumber??"").toString());
 
     el.attachFile.disabled = true;
-    el.attachFile.value = "Uploading...";
+    el.attachFile.value = "Uploading …";
     try {
-        const {err} = await ims.fetchNoThrow(attachURL, {
-            body: formData,
+        const {err} = await ims.uploadNoThrow(attachURL, formData, (progress: string): void => {
+            el.attachFile.value = `Uploading ${progress}`;
         });
         if (err != null) {
             const message = `Failed to attach file: ${err}`;
@@ -516,7 +516,6 @@ async function attachFile(): Promise<void> {
             return;
         }
         ims.clearErrorMessage();
-        el.attachFileInput.value = "";
         await loadAndDisplayFieldReport();
 
         // Brief confirmation, then revert.
@@ -526,6 +525,10 @@ async function attachFile(): Promise<void> {
             attachFileRevertTimeout = null;
         }, 2000);
     } finally {
+        // Clear the picked file even when the upload failed. A change event on
+        // the file input is what starts an upload, so leaving the value set
+        // would make picking the same file again do nothing at all.
+        el.attachFileInput.value = "";
         el.attachFile.disabled = false;
     }
 }

--- a/web/typescript/ims.ts
+++ b/web/typescript/ims.ts
@@ -173,24 +173,15 @@ export async function fetchNoThrow<T>(url: string, init: RequestInit|null): Prom
     if (init.body != null) {
         init.method = init.method || "POST";
 
-        if (init.body.constructor.name === "FormData") {
-            let size = 0;
-            const fd = init.body as FormData;
-            for(const [k,v] of fd.entries()) {
-                size += k.length;
-                if (v instanceof Blob) {
-                    size += v.size;
-                } else {
-                    size += v.length;
-                }
-            }
-            // don't JSONify, don't set a Content-Type (fetch does it automatically for FormData)
-        } else {
-            // otherwise assume body is supposed to be json
-            init.headers.set("Content-Type", "application/json");
-            if (typeof init.body !== "string") {
-                init.body = JSON.stringify(init.body);
-            }
+        // A FormData would otherwise be JSONified into "{}" below, silently
+        // sending an empty request instead of the file.
+        if (init.body instanceof FormData) {
+            throw new Error("fetchNoThrow can't send FormData; use uploadNoThrow");
+        }
+        // assume body is supposed to be json
+        init.headers.set("Content-Type", "application/json");
+        if (typeof init.body !== "string") {
+            init.body = JSON.stringify(init.body);
         }
     }
     let response: Response;
@@ -215,6 +206,56 @@ export async function fetchNoThrow<T>(url: string, init: RequestInit|null): Prom
         json = await response.json();
     }
     return {resp: response, json: json, err: err};
+}
+
+// Upload FormData, reporting how much of the request body has gone out. This
+// uses XMLHttpRequest rather than fetch, because only XHR reports the progress
+// of a request. onProgress gets a label like "42%", or a byte count when the
+// total size isn't known.
+export async function uploadNoThrow(
+    url: string, body: FormData, onProgress: (progress: string) => void,
+): Promise<{err: string|null}> {
+    await maybeRefreshAuth();
+    return new Promise((resolve): void => {
+        const xhr = new XMLHttpRequest();
+        xhr.open("POST", url);
+        xhr.setRequestHeader("Accept", "application/json");
+        const tok = getAccessToken();
+        if (tok) {
+            xhr.setRequestHeader("Authorization", "Bearer " + tok);
+        }
+        // Don't set a Content-Type: XHR derives it, with the multipart
+        // boundary, from the FormData body, just as fetch does.
+        xhr.upload.onprogress = (e: ProgressEvent): void => {
+            onProgress(e.lengthComputable
+                ? `${Math.min(100, Math.floor(100 * e.loaded / e.total))}%`
+                : `${(e.loaded / 1e6).toFixed(1)} MB`);
+        };
+        // The bytes are out, but the server still has to store the file, so
+        // stop showing a percentage while that finishes.
+        xhr.upload.onload = (): void => {
+            onProgress("…");
+        };
+        xhr.onload = (): void => {
+            resolve({err: xhr.status < 400 ? null : uploadError(xhr)});
+        };
+        xhr.onerror = (): void => {
+            resolve({err: "Upload failed"});
+        };
+        xhr.send(body);
+    });
+}
+
+function uploadError(xhr: XMLHttpRequest): string {
+    if (xhr.getResponseHeader("content-type") === "application/problem+json") {
+        try {
+            const problem: Problem = JSON.parse(xhr.responseText);
+            return `${problem.detail??""} (HTTP ${xhr.status})`;
+        } catch {
+            // Fall through to the bare status.
+        }
+    }
+    return `${xhr.statusText} (${xhr.status})`;
 }
 
 //

--- a/web/typescript/incident.ts
+++ b/web/typescript/incident.ts
@@ -1777,10 +1777,10 @@ async function attachFile(): Promise<void> {
         .replace("<incident_number>", (ims.pathIds.incidentNumber??"").toString());
 
     el.attachFile.disabled = true;
-    el.attachFile.value = "Uploading...";
+    el.attachFile.value = "Uploading …";
     try {
-        const {err} = await ims.fetchNoThrow(attachURL, {
-            body: formData,
+        const {err} = await ims.uploadNoThrow(attachURL, formData, (progress: string): void => {
+            el.attachFile.value = `Uploading ${progress}`;
         });
         if (err != null) {
             const message = `Failed to attach file: ${err}`;
@@ -1789,7 +1789,6 @@ async function attachFile(): Promise<void> {
             return;
         }
         ims.clearErrorMessage();
-        el.attachFileInput.value = "";
         await loadAndDisplayIncident();
 
         // Brief confirmation, then revert.
@@ -1799,6 +1798,10 @@ async function attachFile(): Promise<void> {
             attachFileRevertTimeout = null;
         }, 2000);
     } finally {
+        // Clear the picked file even when the upload failed. A change event on
+        // the file input is what starts an upload, so leaving the value set
+        // would make picking the same file again do nothing at all.
+        el.attachFileInput.value = "";
         el.attachFile.disabled = false;
     }
 }

--- a/web/typescript/sanctuary_visit.ts
+++ b/web/typescript/sanctuary_visit.ts
@@ -676,10 +676,10 @@ async function attachFile(): Promise<void> {
         .replace("<visit_number>", (ims.pathIds.visitNumber??"").toString());
 
     el.attachFile.disabled = true;
-    el.attachFile.value = "Uploading...";
+    el.attachFile.value = "Uploading …";
     try {
-        const {err} = await ims.fetchNoThrow(attachURL, {
-            body: formData,
+        const {err} = await ims.uploadNoThrow(attachURL, formData, (progress: string): void => {
+            el.attachFile.value = `Uploading ${progress}`;
         });
         if (err != null) {
             const message = `Failed to attach file: ${err}`;
@@ -688,7 +688,6 @@ async function attachFile(): Promise<void> {
             return;
         }
         ims.clearErrorMessage();
-        el.attachFileInput.value = "";
         await loadAndDisplayVisit();
 
         // Brief confirmation, then revert.
@@ -698,6 +697,10 @@ async function attachFile(): Promise<void> {
             attachFileRevertTimeout = null;
         }, 2000);
     } finally {
+        // Clear the picked file even when the upload failed. A change event on
+        // the file input is what starts an upload, so leaving the value set
+        // would make picking the same file again do nothing at all.
+        el.attachFileInput.value = "";
         el.attachFile.disabled = false;
     }
 }

--- a/web/typescripttest/fetch.test.ts
+++ b/web/typescripttest/fetch.test.ts
@@ -16,7 +16,7 @@
 
 import { expect, test } from "vitest";
 import * as ims from "../typescript/ims.ts";
-import { jsonResponse, mockFetch, problemResponse } from "./helpers.ts";
+import { jsonResponse, mockFetch, mockXHR, problemResponse } from "./helpers.ts";
 
 function requestHeaders(init?: RequestInit): Headers {
     return new Headers(init?.headers);
@@ -122,4 +122,94 @@ test("fetchNoThrow clears stored credentials when the token refresh fails", asyn
     // The real request goes out unauthenticated.
     const headers = requestHeaders(mock.mock.calls[1]![1]);
     expect(headers.get("Authorization")).toBeNull();
+});
+
+test("fetchNoThrow refuses a FormData body rather than JSONifying it", async (): Promise<void> => {
+    mockFetch(() => jsonResponse({}));
+
+    await expect(ims.fetchNoThrow(url_ping, { body: new FormData() })).rejects.toThrow(/uploadNoThrow/);
+});
+
+test("uploadNoThrow posts the form data with a Bearer token and no Content-Type", async (): Promise<void> => {
+    ims.setAccessToken("token123");
+    ims.setRefreshTokenBy(Date.now() + 60_000);
+    const uploads = mockXHR(() => new Response(null, { status: 204 }));
+    const body = new FormData();
+    body.append("imsAttachment", new Blob(["file contents"]), "photo.jpg");
+
+    const { err } = await ims.uploadNoThrow(url_ping, body, (): void => {});
+    expect(err).toBeNull();
+
+    expect(uploads.length).toBe(1);
+    expect(uploads[0]!.method).toBe("POST");
+    expect(uploads[0]!.url).toBe(url_ping);
+    expect(uploads[0]!.body).toBe(body);
+    expect(uploads[0]!.headers["Accept"]).toBe("application/json");
+    expect(uploads[0]!.headers["Authorization"]).toBe("Bearer token123");
+    // XHR sets the multipart Content-Type, with its boundary, itself.
+    expect(uploads[0]!.headers["Content-Type"]).toBeUndefined();
+});
+
+test("uploadNoThrow reports progress as a percentage, then as pending once the body is sent", async (): Promise<void> => {
+    mockXHR(() => new Response(null, { status: 204 }), { progress: [0, 0.5, 0.999, 1] });
+    const progress: string[] = [];
+
+    const { err } = await ims.uploadNoThrow(url_ping, new FormData(), (p: string): void => {
+        progress.push(p);
+    });
+    expect(err).toBeNull();
+    expect(progress).toEqual(["0%", "50%", "99%", "100%", "…"]);
+});
+
+test("uploadNoThrow reports a byte count when the upload size is unknown", async (): Promise<void> => {
+    mockXHR(
+        () => new Response(null, { status: 204 }),
+        { progress: [0.5], lengthComputable: false },
+    );
+    const progress: string[] = [];
+
+    await ims.uploadNoThrow(url_ping, new FormData(), (p: string): void => {
+        progress.push(p);
+    });
+    // Half of the fake's 1000 byte total.
+    expect(progress).toEqual(["0.0 MB", "…"]);
+});
+
+test("uploadNoThrow extracts the detail from an application/problem+json error", async (): Promise<void> => {
+    mockXHR(() => problemResponse("attachment too large", 413));
+
+    const { err } = await ims.uploadNoThrow(url_ping, new FormData(), (): void => {});
+    expect(err).toBe("attachment too large (HTTP 413)");
+});
+
+test("uploadNoThrow falls back to the bare status for a non-problem error", async (): Promise<void> => {
+    mockXHR(() => new Response("nope", { status: 500, statusText: "Internal Server Error" }));
+
+    const { err } = await ims.uploadNoThrow(url_ping, new FormData(), (): void => {});
+    expect(err).toBe("Internal Server Error (500)");
+});
+
+test("uploadNoThrow reports a failed request rather than throwing", async (): Promise<void> => {
+    mockXHR(() => undefined);
+
+    const { err } = await ims.uploadNoThrow(url_ping, new FormData(), (): void => {});
+    expect(err).toBe("Upload failed");
+});
+
+test("uploadNoThrow refreshes a stale access token before uploading", async (): Promise<void> => {
+    ims.setAccessToken("staleToken");
+    ims.setRefreshTokenBy(Date.now() - 1);
+    const mock = mockFetch((url, _init) => {
+        if (url === url_authRefresh) {
+            return jsonResponse({ token: "freshToken", expires_unix_ms: Date.now() + 60_000 });
+        }
+        return undefined;
+    });
+    const uploads = mockXHR(() => new Response(null, { status: 204 }));
+
+    const { err } = await ims.uploadNoThrow(url_ping, new FormData(), (): void => {});
+    expect(err).toBeNull();
+
+    expect(mock.mock.calls[0]![0]).toBe(url_authRefresh);
+    expect(uploads[0]!.headers["Authorization"]).toBe("Bearer freshToken");
 });

--- a/web/typescripttest/field_report.test.ts
+++ b/web/typescripttest/field_report.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, onTestFinished, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { captureLinkClicks, jsonResponse, loadFixture, mockFetch } from "./helpers.ts";
+import { captureLinkClicks, jsonResponse, loadFixture, mockFetch, mockXHR } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -367,23 +367,33 @@ test("a redraw keeps a preview that's waiting to be opened", async (): Promise<v
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {
-    const mock = await initFieldReportPage();
+    await initFieldReportPage();
     const button = document.getElementById("attach_file") as HTMLInputElement;
     expect(button.value).toBe("Attach file");
+
+    const labels: string[] = [];
+    const uploads = mockXHR(
+        (url) => url === `${frUrl}/7/attachments` ? new Response(null, { status: 204 }) : undefined,
+        { progress: [0.25, 1], onProgress: (): void => { labels.push(button.value); } },
+    );
 
     vi.useFakeTimers();
     try {
         // The synchronous prefix of attachFile disables the button and relabels
-        // it before the upload fetch is awaited.
+        // it before the upload is awaited.
         const pending = window.attachFile();
         expect(button.disabled).toBe(true);
-        expect(button.value).toBe("Uploading...");
+        expect(button.value).toBe("Uploading …");
 
         await pending;
 
         // The file form data went to the attachments endpoint.
-        expect(mock.mock.calls.some(([url, init]) =>
-            url === `${frUrl}/7/attachments` && init?.body instanceof FormData)).toBe(true);
+        expect(uploads.length).toBe(1);
+        expect(uploads[0]!.url).toBe(`${frUrl}/7/attachments`);
+        expect(uploads[0]!.body).toBeInstanceOf(FormData);
+
+        // The button tracked the upload, then waited on the server to store it.
+        expect(labels).toEqual(["Uploading 25%", "Uploading 100%", "Uploading …"]);
 
         // On success the button re-enables and briefly confirms.
         expect(button.disabled).toBe(false);
@@ -398,13 +408,19 @@ test("attachFile shows an uploading state, posts the file, then confirms and rev
 });
 
 test("a failed attachment re-enables the button and surfaces the error", async (): Promise<void> => {
-    await initFieldReportPage((url, init) => {
-        if (url === `${frUrl}/7/attachments` && init?.body != null) {
-            return undefined;
-        }
-        return frRoutes(url, init);
-    });
+    await initFieldReportPage();
+    mockXHR(() => undefined);
     const button = document.getElementById("attach_file") as HTMLInputElement;
+
+    // A failure has to clear the file input too, or picking the same file again
+    // fires no change event and the retry does nothing. Neither happy-dom nor a
+    // browser lets a test assign a file input's value, so watch the assignment.
+    const cleared = vi.fn();
+    Object.defineProperty(document.getElementById("attach_file_input")!, "value", {
+        configurable: true,
+        get: (): string => "",
+        set: cleared,
+    });
 
     await window.attachFile();
 
@@ -413,4 +429,5 @@ test("a failed attachment re-enables the button and surfaces the error", async (
     expect(button.disabled).toBe(false);
     expect(button.value).toBe("Attach file");
     expect(document.getElementById("error_text")!.textContent).toContain("Failed to attach file");
+    expect(cleared).toHaveBeenCalledWith("");
 });

--- a/web/typescripttest/helpers.ts
+++ b/web/typescripttest/helpers.ts
@@ -99,6 +99,102 @@ export function mockFetch(handler: FetchHandler) {
     return mock;
 }
 
+export interface XHRCall {
+    method: string;
+    url: string;
+    headers: Record<string, string>;
+    body: FormData | null;
+}
+
+export type XHRHandler = (url: string, body: FormData | null) => Response | undefined;
+
+export interface MockXHROptions {
+    // Fractions of the upload (0 through 1) to report progress at before the
+    // request completes.
+    progress?: number[];
+    // Whether the progress events know the upload's total size. Defaults to
+    // true; turn it off to exercise the byte-count fallback.
+    lengthComputable?: boolean;
+    // Called after each upload event has been delivered — every progress
+    // fraction, then the one marking the body fully sent — so that a test can
+    // record how the page looked mid-upload.
+    onProgress?: () => void;
+}
+
+// Replace global XMLHttpRequest with a fake that routes requests through a
+// handler, returning the array of calls it records. Attachment uploads go
+// through ims.uploadNoThrow, which uses XHR rather than fetch (only XHR reports
+// request progress), so mockFetch doesn't see them.
+//
+// The fake completes a request as soon as it's sent, having first delivered the
+// progress events the options ask for. Returning undefined from the handler
+// fails the request, as a network error would.
+export function mockXHR(handler: XHRHandler, options: MockXHROptions = {}): XHRCall[] {
+    const calls: XHRCall[] = [];
+    // Progress is reported against an arbitrary total, since happy-dom won't
+    // tell us how large a FormData body is. Only the fractions matter.
+    const total = 1000;
+
+    class FakeXHR {
+        upload = {
+            onprogress: null as ((e: ProgressEvent) => void) | null,
+            onload: null as (() => void) | null,
+        };
+        onload: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        status = 0;
+        statusText = "";
+        responseText = "";
+        private method = "";
+        private url = "";
+        private headers: Record<string, string> = {};
+        private responseHeaders = new Headers();
+
+        open(method: string, url: string): void {
+            this.method = method;
+            this.url = url;
+        }
+
+        setRequestHeader(name: string, value: string): void {
+            this.headers[name] = value;
+        }
+
+        getResponseHeader(name: string): string | null {
+            return this.responseHeaders.get(name);
+        }
+
+        send(body: FormData | null): void {
+            calls.push({ method: this.method, url: this.url, headers: this.headers, body: body });
+
+            for (const fraction of options.progress ?? []) {
+                this.upload.onprogress?.(new ProgressEvent("progress", {
+                    lengthComputable: options.lengthComputable ?? true,
+                    loaded: Math.round(fraction * total),
+                    total: total,
+                }));
+                options.onProgress?.();
+            }
+            this.upload.onload?.();
+            options.onProgress?.();
+
+            const response = handler(this.url, body);
+            if (response == null) {
+                this.onerror?.();
+                return;
+            }
+            void response.text().then((text: string): void => {
+                this.status = response.status;
+                this.statusText = response.statusText;
+                this.responseHeaders = response.headers;
+                this.responseText = text;
+                this.onload?.();
+            });
+        }
+    }
+    vi.stubGlobal("XMLHttpRequest", FakeXHR);
+    return calls;
+}
+
 type FlatpickrHook = (selectedDates: Date[], dateStr: string, instance: MockFlatpickr) => void;
 
 interface FlatpickrOptionsLike {

--- a/web/typescripttest/incident.test.ts
+++ b/web/typescripttest/incident.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { captureLinkClicks, jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
+import { captureLinkClicks, jsonResponse, loadFixture, MockFlatpickr, mockFetch, mockXHR } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -948,34 +948,35 @@ test("printing swaps in a filesystem-safe document title", async (): Promise<voi
     expect(document.title).toBe("#1 Dust storm | 2025");
 });
 
-test("attachFile posts the file form data to the attachments endpoint", async (): Promise<void> => {
-    const mock = await initIncidentPage();
-
-    await window.attachFile();
-    const attach = mock.mock.calls.find(
-        ([url, init]): boolean =>
-            url === "/ims/api/events/2025/incidents/1/attachments" && init?.body instanceof FormData);
-    expect(attach).toBeDefined();
-});
-
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {
-    const mock = await initIncidentPage();
+    await initIncidentPage();
+    const attachUrl = `/ims/api/events/${eventName}/incidents/1/attachments`;
     const button = document.getElementById("attach_file") as HTMLInputElement;
     expect(button.value).toBe("Attach file");
+
+    const labels: string[] = [];
+    const uploads = mockXHR(
+        (url) => url === attachUrl ? new Response(null, { status: 204 }) : undefined,
+        { progress: [0.25, 1], onProgress: (): void => { labels.push(button.value); } },
+    );
 
     vi.useFakeTimers();
     try {
         // The synchronous prefix of attachFile disables the button and relabels
-        // it before the upload fetch is awaited.
+        // it before the upload is awaited.
         const pending = window.attachFile();
         expect(button.disabled).toBe(true);
-        expect(button.value).toBe("Uploading...");
+        expect(button.value).toBe("Uploading …");
 
         await pending;
 
         // The file form data went to the attachments endpoint.
-        expect(mock.mock.calls.some(([url, init]) =>
-            url === `/ims/api/events/${eventName}/incidents/1/attachments` && init?.body instanceof FormData)).toBe(true);
+        expect(uploads.length).toBe(1);
+        expect(uploads[0]!.url).toBe(attachUrl);
+        expect(uploads[0]!.body).toBeInstanceOf(FormData);
+
+        // The button tracked the upload, then waited on the server to store it.
+        expect(labels).toEqual(["Uploading 25%", "Uploading 100%", "Uploading …"]);
 
         // On success the button re-enables and briefly confirms.
         expect(button.disabled).toBe(false);
@@ -990,12 +991,8 @@ test("attachFile shows an uploading state, posts the file, then confirms and rev
 });
 
 test("a failed attachment re-enables the button and surfaces the error", async (): Promise<void> => {
-    await initIncidentPage((url, init) => {
-        if (url === `/ims/api/events/${eventName}/incidents/1/attachments` && init?.body != null) {
-            return undefined;
-        }
-        return incidentRoutes(url, init);
-    });
+    await initIncidentPage();
+    mockXHR(() => undefined);
     const button = document.getElementById("attach_file") as HTMLInputElement;
 
     await window.attachFile();

--- a/web/typescripttest/sanctuary_visit.test.ts
+++ b/web/typescripttest/sanctuary_visit.test.ts
@@ -19,7 +19,7 @@
 
 import { beforeEach, expect, test, vi } from "vitest";
 import type * as ims from "../typescript/ims.ts";
-import { captureLinkClicks, jsonResponse, loadFixture, MockFlatpickr, mockFetch } from "./helpers.ts";
+import { captureLinkClicks, jsonResponse, loadFixture, MockFlatpickr, mockFetch, mockXHR } from "./helpers.ts";
 
 const eventName = "2025";
 const eventId = 1;
@@ -245,23 +245,33 @@ test("an entry's attachment is fetched from the visit's own endpoint", async ():
 });
 
 test("attachFile shows an uploading state, posts the file, then confirms and reverts", async (): Promise<void> => {
-    const mock = await initVisitPage();
+    await initVisitPage();
     const button = document.getElementById("attach_file") as HTMLInputElement;
     expect(button.value).toBe("Attach file");
+
+    const labels: string[] = [];
+    const uploads = mockXHR(
+        (url) => url === `${visitsUrl}/2/attachments` ? new Response(null, { status: 204 }) : undefined,
+        { progress: [0.25, 1], onProgress: (): void => { labels.push(button.value); } },
+    );
 
     vi.useFakeTimers();
     try {
         // The synchronous prefix of attachFile disables the button and relabels
-        // it before the upload fetch is awaited.
+        // it before the upload is awaited.
         const pending = window.attachFile();
         expect(button.disabled).toBe(true);
-        expect(button.value).toBe("Uploading...");
+        expect(button.value).toBe("Uploading …");
 
         await pending;
 
         // The file form data went to the attachments endpoint.
-        expect(mock.mock.calls.some(([url, init]) =>
-            url === `${visitsUrl}/2/attachments` && init?.body instanceof FormData)).toBe(true);
+        expect(uploads.length).toBe(1);
+        expect(uploads[0]!.url).toBe(`${visitsUrl}/2/attachments`);
+        expect(uploads[0]!.body).toBeInstanceOf(FormData);
+
+        // The button tracked the upload, then waited on the server to store it.
+        expect(labels).toEqual(["Uploading 25%", "Uploading 100%", "Uploading …"]);
 
         // On success the button re-enables and briefly confirms.
         expect(button.disabled).toBe(false);
@@ -276,12 +286,8 @@ test("attachFile shows an uploading state, posts the file, then confirms and rev
 });
 
 test("a failed attachment re-enables the button and surfaces the error", async (): Promise<void> => {
-    await initVisitPage((url, init) => {
-        if (url === `${visitsUrl}/2/attachments` && init?.body != null) {
-            return undefined;
-        }
-        return visitRoutes(url, init);
-    });
+    await initVisitPage();
+    mockXHR(() => undefined);
     const button = document.getElementById("attach_file") as HTMLInputElement;
 
     await window.attachFile();


### PR DESCRIPTION
I finally got around to testing attachments with throttled connectivity (as many people have on the playa), and I learned we quickly needed some improvements. This bumps up the maximum allowable upload time to 5 minutes (from 1) which can be necessary for people on really lousy connections.

This also adds an upload progress bar (requiring XMLHttpRequest rather than fetch) and it adds vitest and playwright tests for attachments as well.