### PR TITLE
fix(search): add logging to aid debugging

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -27,7 +27,9 @@ tmp_dir = "air_tmp"
 
   #  ]
   exclude_regex = ["_test.go"]
-  exclude_unchanged = false
+  # Only rebuild when a watched file's contents actually differ, so a spurious
+  # event (Docker Desktop's file sharing emits plenty) doesn't restart the server.
+  exclude_unchanged = true
   follow_symlink = false
   full_bin = ""
   include_dir = []

--- a/api/search.go
+++ b/api/search.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"log/slog"
 	"net/http"
 	"regexp"
 	"slices"
@@ -54,6 +55,7 @@ const (
 	searchDefaultLimit   = 100
 	searchMaxLimit       = 1000
 	searchQueryTimeout   = 20 * time.Second
+	searchSlowThreshold  = 2 * time.Second
 	searchSnippetPrefix  = 40
 	searchSnippetMaxLen  = 200
 	searchSnippetMarker  = "…"
@@ -192,15 +194,25 @@ func (action GetSearch) getSearch(req *http.Request) (imsjson.SearchResults, *he
 		return searchSnippet(text, matchAt)
 	}
 
+	// Logged however this ends, so that a search that fails or times out is
+	// still accounted for.
+	searchStarted := time.Now()
+	var incidentStat, fieldReportStat, visitStat searchQueryStat
+	defer func() {
+		action.logSearch(ctx, query, regex, limit, time.Since(searchStarted), incidentStat, fieldReportStat, visitStat)
+	}()
+
 	if searchIncidents && len(incidentEventIDs) > 0 {
+		started := time.Now()
 		rows, err := action.imsDBQ.SearchIncidents(ctx, action.imsDBQ, imsdb.SearchIncidentsParams{
 			TextLike:   textLike,
 			TextRegexp: textRegexp,
 			EventIds:   incidentEventIDs,
 			Limit:      limit,
 		})
+		incidentStat = searchQueryStat{ran: true, elapsed: time.Since(started), rows: len(rows), err: err}
 		if err != nil {
-			return resp, searchQueryError("Incidents", err).From("[SearchIncidents]")
+			return resp, searchQueryError(ctx, "Incidents", err).From("[SearchIncidents]")
 		}
 		for _, row := range rows {
 			resp.Hits = append(resp.Hits, imsjson.SearchResult{
@@ -217,14 +229,16 @@ func (action GetSearch) getSearch(req *http.Request) (imsjson.SearchResults, *he
 	}
 
 	if searchFieldReports && len(fieldReportEventIDs) > 0 {
+		started := time.Now()
 		rows, err := action.imsDBQ.SearchFieldReports(ctx, action.imsDBQ, imsdb.SearchFieldReportsParams{
 			TextLike:   textLike,
 			TextRegexp: textRegexp,
 			EventIds:   fieldReportEventIDs,
 			Limit:      limit,
 		})
+		fieldReportStat = searchQueryStat{ran: true, elapsed: time.Since(started), rows: len(rows), err: err}
 		if err != nil {
-			return resp, searchQueryError("Field Reports", err).From("[SearchFieldReports]")
+			return resp, searchQueryError(ctx, "Field Reports", err).From("[SearchFieldReports]")
 		}
 		for _, row := range rows {
 			resp.Hits = append(resp.Hits, imsjson.SearchResult{
@@ -242,14 +256,16 @@ func (action GetSearch) getSearch(req *http.Request) (imsjson.SearchResults, *he
 	}
 
 	if searchVisits && len(visitEventIDs) > 0 {
+		started := time.Now()
 		rows, err := action.imsDBQ.SearchVisits(ctx, action.imsDBQ, imsdb.SearchVisitsParams{
 			TextLike:   textLike,
 			TextRegexp: textRegexp,
 			EventIds:   visitEventIDs,
 			Limit:      limit,
 		})
+		visitStat = searchQueryStat{ran: true, elapsed: time.Since(started), rows: len(rows), err: err}
 		if err != nil {
-			return resp, searchQueryError("Visits", err).From("[SearchVisits]")
+			return resp, searchQueryError(ctx, "Visits", err).From("[SearchVisits]")
 		}
 		for _, row := range rows {
 			summary := row.GuestPreferredName.String
@@ -270,11 +286,84 @@ func (action GetSearch) getSearch(req *http.Request) (imsjson.SearchResults, *he
 		resp.Truncated = resp.Truncated || len(rows) == int(limit)
 	}
 
-	slices.SortFunc(resp.Hits, func(a, b imsjson.SearchResult) int {
+	slices.SortStableFunc(resp.Hits, func(a, b imsjson.SearchResult) int {
 		return b.Created.Compare(a.Created)
 	})
 
 	return resp, nil
+}
+
+// searchQueryStat is what one of the three searches leaves behind for the
+// diagnostic log line, whether it succeeded or not.
+type searchQueryStat struct {
+	ran     bool
+	elapsed time.Duration
+	rows    int
+	err     error
+}
+
+func (s searchQueryStat) logAttrs(prefix string) []any {
+	if !s.ran {
+		return nil
+	}
+	attrs := []any{
+		prefix + "Millis", s.elapsed.Milliseconds(),
+		prefix + "Rows", s.rows,
+	}
+	if s.err != nil {
+		attrs = append(attrs, prefix+"Err", s.err.Error())
+	}
+	return attrs
+}
+
+// logSearch emits one line accounting for a search's time in the database.
+// A search that times out in production is otherwise near-impossible to
+// explain after the fact: this says which of the three searches was slow, how
+// much of the corpus it was allowed to scan, whether it hit the row limit
+// (i.e. the query was broad enough to match a large fraction of the corpus,
+// which is what makes these queries expensive), and what the connection pool
+// looked like — pool wait counts against the same deadline as the query
+// itself, so a saturated pool and a slow database look identical from the
+// client side.
+func (action GetSearch) logSearch(
+	ctx context.Context,
+	query string, regex bool, limit int32,
+	total time.Duration,
+	incidents, fieldReports, visits searchQueryStat,
+) {
+	level := slog.LevelDebug
+	if total >= searchSlowThreshold {
+		level = slog.LevelWarn
+	}
+	for _, stat := range []searchQueryStat{incidents, fieldReports, visits} {
+		if stat.err != nil {
+			level = slog.LevelWarn
+		}
+	}
+	if !slog.Default().Enabled(ctx, level) {
+		return
+	}
+
+	pool := action.imsDBQ.Stats()
+	attrs := []any{
+		"q", query,
+		"regex", regex,
+		"limit", limit,
+		"totalMillis", total.Milliseconds(),
+	}
+	attrs = append(attrs, incidents.logAttrs("incident")...)
+	attrs = append(attrs, fieldReports.logAttrs("fieldReport")...)
+	attrs = append(attrs, visits.logAttrs("visit")...)
+	attrs = append(attrs,
+		"poolInUse", pool.InUse,
+		"poolIdle", pool.Idle,
+		"poolMaxOpen", pool.MaxOpenConnections,
+		// Cumulative over the process's lifetime, so read these as a rate
+		// across successive log lines rather than as this request's own wait.
+		"poolWaitsSinceStart", pool.WaitCount,
+		"poolWaitMillisSinceStart", pool.WaitDuration.Milliseconds(),
+	)
+	slog.Log(ctx, level, "Served a cross-event search", attrs...)
 }
 
 // escapeLikePattern escapes the characters that have special meaning inside
@@ -302,13 +391,17 @@ func textColumn(v any) string {
 // HTTP error. A pattern that Go's regexp compiler accepted but the database's
 // PCRE engine rejected (MariaDB error 1139) is the client's fault, not ours,
 // and hitting the search deadline deserves better advice than a plain 500.
-func searchQueryError(what string, err error) *herr.HTTPError {
+func searchQueryError(ctx context.Context, what string, err error) *herr.HTTPError {
 	const mySQLErRegexpError = 1139
 	mysqlErr, ok := errors.AsType[*mysql.MySQLError](err)
 	if ok && mysqlErr.Number == mySQLErRegexpError {
 		return herr.BadRequest("Invalid regular expression", err)
 	}
-	if errors.Is(err, context.DeadlineExceeded) {
+	// The deadline doesn't always come back as context.DeadlineExceeded: when
+	// the driver notices the cancellation first, it tears the connection down
+	// and reports its own error (e.g. "invalid connection") instead. Ask the
+	// context rather than trusting the error to say so.
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 		return herr.New(http.StatusServiceUnavailable, "Search took too long — try a more specific query", err)
 	}
 	return herr.InternalServerError("Failed to search "+what, err)

--- a/api/search_test.go
+++ b/api/search_test.go
@@ -24,6 +24,7 @@ import (
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/stretchr/testify/assert"
@@ -47,18 +48,35 @@ func TestIndexFold(t *testing.T) {
 func TestSearchQueryError(t *testing.T) {
 	t.Parallel()
 
+	ctx := t.Context()
+
 	// A database-side regexp error means the client sent a bad pattern.
 	regexpErr := &mysql.MySQLError{Number: 1139, Message: "Regex error 'missing closing parenthesis'"}
-	httpErr := searchQueryError("Incidents", regexpErr)
+	httpErr := searchQueryError(ctx, "Incidents", regexpErr)
 	assert.Equal(t, http.StatusBadRequest, httpErr.Code)
 
 	// Hitting the search deadline is reported as unavailability, not a 500.
 	deadlineErr := fmt.Errorf("query: %w", context.DeadlineExceeded)
-	httpErr = searchQueryError("Incidents", deadlineErr)
+	httpErr = searchQueryError(ctx, "Incidents", deadlineErr)
 	assert.Equal(t, http.StatusServiceUnavailable, httpErr.Code)
 
+	// The driver often notices the cancellation first and reports its own
+	// error instead, so an expired context alone is enough to call it a
+	// timeout.
+	expired, cancel := context.WithDeadline(ctx, time.Now().Add(-time.Second))
+	defer cancel()
+	httpErr = searchQueryError(expired, "Incidents", errors.New("invalid connection"))
+	assert.Equal(t, http.StatusServiceUnavailable, httpErr.Code)
+
+	// A cancelled — as opposed to timed-out — context is not the search
+	// taking too long; that's the client hanging up.
+	cancelled, cancel2 := context.WithCancel(ctx)
+	cancel2()
+	httpErr = searchQueryError(cancelled, "Incidents", context.Canceled)
+	assert.Equal(t, http.StatusInternalServerError, httpErr.Code)
+
 	// Anything else is an internal error.
-	httpErr = searchQueryError("Incidents", errors.New("connection lost"))
+	httpErr = searchQueryError(ctx, "Incidents", errors.New("connection lost"))
 	assert.Equal(t, http.StatusInternalServerError, httpErr.Code)
 }
 

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import { defineConfig, devices } from '@playwright/test';
+import os from 'os';
+import path from 'path';
 
 /**
  * Read environment variables from file.
@@ -21,6 +23,13 @@ import { defineConfig, devices } from '@playwright/test';
 // import dotenv from 'dotenv';
 // import path from 'path';
 // dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/* Artifacts live outside the repo on purpose. The dev stack bind-mounts the
+ * repo into the container, and Docker Desktop reports host writes under the
+ * mount as a nameless event on the mount root, which makes air re-walk and
+ * re-watch the whole tree mid-run. Writing test-results and the HTML report
+ * elsewhere keeps that churn out of the mount. */
+const artifactsDir = path.join(os.tmpdir(), 'ims-playwright');
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -39,8 +48,13 @@ export default defineConfig({
   /* List gives live per-test terminal output; the html report only pops open on failure. */
   reporter: [
     ['list'],
-    ['html', { open: process.env.CI ? 'never' : 'on-failure' }],
+    ['html', {
+      outputFolder: path.join(artifactsDir, 'report'),
+      open: process.env.CI ? 'never' : 'on-failure',
+    }],
   ],
+  /* Traces, screenshots and other per-test output. */
+  outputDir: path.join(artifactsDir, 'test-results'),
   /* Possibly wait upto this long for expectations. IMS can be slow. */
   expect: { timeout: 15_000 },
   /* With a 15s expect timeout, the default 30s per-test budget leaves room

--- a/playwright/tests/a11y.spec.ts
+++ b/playwright/tests/a11y.spec.ts
@@ -51,6 +51,11 @@ async function login(page: Page): Promise<void> {
   await expect(page.getByRole("button", {name: /^Log (In|Out)$/})).toBeVisible();
   if (await page.getByRole("button", {name: "Log In"}).isVisible()) {
     await page.getByRole("button", {name: "Log In"}).click();
+    // The login page's inputs are usable before its JavaScript has finished
+    // initializing, and submitting that early does a native form POST to a
+    // GET-only route (a 405). Page init ends by focusing the username input,
+    // so that's the signal that the form is ready to submit.
+    await expect(page.getByPlaceholder("name@example.com")).toBeFocused();
     await page.getByPlaceholder("name@example.com").fill(username);
     await page.getByPlaceholder("Password").fill(username);
     await page.getByPlaceholder("Password").press("Enter");

--- a/playwright/tests/ims.spec.ts
+++ b/playwright/tests/ims.spec.ts
@@ -26,6 +26,11 @@ async function login(page: Page): Promise<void> {
   await expect(page.getByRole("button", { name: /^Log (In|Out)$/ })).toBeVisible();
   if (await page.getByRole("button", { name: "Log In" }).isVisible()) {
     await page.getByRole("button", { name: "Log In" }).click();
+    // The login page's inputs are usable before its JavaScript has finished
+    // initializing, and submitting that early does a native form POST to a
+    // GET-only route (a 405). Page init ends by focusing the username input,
+    // so that's the signal that the form is ready to submit.
+    await expect(page.getByPlaceholder("name@example.com")).toBeFocused();
     await page.getByPlaceholder("name@example.com").click();
     await page.getByPlaceholder("name@example.com").fill(username);
     await page.getByPlaceholder("Password").fill(username);

--- a/web/typescript/login.ts
+++ b/web/typescript/login.ts
@@ -39,15 +39,19 @@ const el = {
 initLoginPage();
 
 async function initLoginPage(): Promise<void> {
-    await ims.commonPageInit();
-
     window.login = login;
     window.toggleShowPassword = toggleShowPassword;
 
+    // Attach this before awaiting anything. The form's inputs are usable as
+    // soon as the HTML parses, and a submit that isn't intercepted here falls
+    // through to a native POST to this page's URL, which is a GET-only route.
     el.loginForm.addEventListener("submit", (e: SubmitEvent): void => {
         e.preventDefault();
         login();
     });
+
+    await ims.commonPageInit();
+
     el.usernameInput.focus();
 }
 


### PR DESCRIPTION
I'm trying to debug timeouts I've seen on the new Search Anywhere page in prod. Sometimes one of these searches will take over 20 seconds, the overall timeout on the API endpoint. I can't get this to happen consistently though. I bet there's something cold we're hitting on Aurora in AWS. I need better visibility in here.

also tweak login page load order to avoid test flakiness